### PR TITLE
Fix bug that displayed weight in height units

### DIFF
--- a/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
@@ -83,7 +83,7 @@
           <p><span class="bold">{lang 'Height:'}</span> <span class="italic"><a href="{{ $design->url('user','browse','index', '?country='.$country_code.'&height='.$val) }}">{{ (new Framework\Math\Measure\Height($val))->display(true) }}</a></span></p>
 
         {elseif $key == 'weight'}
-          <p><span class="bold">{lang 'Weight:'}</span> <span class="italic"><a href="{{ $design->url('user','browse','index', '?country='.$country_code.'&weight='.$val) }}">{{ (new Framework\Math\Measure\Height($val))->display(true) }}</a></span></p>
+          <p><span class="bold">{lang 'Weight:'}</span> <span class="italic"><a href="{{ $design->url('user','browse','index', '?country='.$country_code.'&weight='.$val) }}">{{ (new Framework\Math\Measure\Weight($val))->display(true) }}</a></span></p>
 
         {elseif $key == 'country'}
           <p><span class="bold">{lang 'Country:'}</span> <span class="italic"><a href="{{ $design->url('user','browse','index', '?country='.$country_code) }}">{country}</a></span>&nbsp;&nbsp;<img src="{{ $design->getSmallFlagIcon($country_code) }}" title="{country}" alt="{country}" /></p>


### PR DESCRIPTION
When using a ph7 dating site I saw that in the profile page the weight
was displayed in height units. Did not create a bug report, but searched for the bug in the code and
fixed it hopefully. Have not checked for correctness yet. Would be good if somebody looked at it to see if the bug is reproducible and if the fix works, I have not checked it yet. However, the bug seems trivial when you look at the diff.
![bildschirmfoto_2016-04-02_22-54-54](https://cloud.githubusercontent.com/assets/5121824/14228938/5a36f892-f926-11e5-9c1a-90cf188c8c58.png)


