### PR TITLE
Bump copyright year

### DIFF
--- a/_protected/app/includes/classes/LoginableForm.php
+++ b/_protected/app/includes/classes/LoginableForm.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / App / Include / Class
  */

--- a/_protected/app/system/core/classes/SearchQueryCore.php
+++ b/_protected/app/system/core/classes/SearchQueryCore.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author         Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright      (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license        GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package        PH7 / App / System / Core / Class
  */

--- a/_protected/app/system/modules/friend/config/Permission.php
+++ b/_protected/app/system/modules/friend/config/Permission.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author         Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright      (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license        GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package        PH7 / App / System / Module / Friend / Config
  */

--- a/_protected/app/system/modules/payment/inc/class/Braintree.php
+++ b/_protected/app/system/modules/payment/inc/class/Braintree.php
@@ -3,7 +3,7 @@
  * @title          Braintree
  *
  * @author         Pierre-Henry Soria <hi@ph7.me>
- * @copyright      (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license        GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package        PH7 / App / System / Module / Payment / Inc / Class
  */

--- a/_protected/app/system/modules/related-profile/controllers/MainController.php
+++ b/_protected/app/system/modules/related-profile/controllers/MainController.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author         Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright      (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license        GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package        PH7 / App / System / Module / Related Profile / Controller
  */

--- a/_protected/framework/Cache/Storage/MissingExtensionException.class.php
+++ b/_protected/framework/Cache/Storage/MissingExtensionException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Cache / Storage
  */

--- a/_protected/framework/Cache/Storage/Redis.class.php
+++ b/_protected/framework/Cache/Storage/Redis.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Cache / Storage
  */

--- a/_protected/framework/Core/License.class.php
+++ b/_protected/framework/Core/License.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author         Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright      (c) 2012-2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2012-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license        CC-BY License - http://creativecommons.org/licenses/by/3.0/
  * @package        PH7 / Framework / Core
  */

--- a/_protected/framework/File/MissingProgramException.class.php
+++ b/_protected/framework/File/MissingProgramException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / File
  */

--- a/_protected/framework/File/TooLargeException.class.php
+++ b/_protected/framework/File/TooLargeException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / File
  */

--- a/_protected/framework/File/Transfer/MissingExtensionException.class.php
+++ b/_protected/framework/File/Transfer/MissingExtensionException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / File / Transfer
  */

--- a/_protected/framework/File/Transfer/PermissionException.class.php
+++ b/_protected/framework/File/Transfer/PermissionException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / File / Transfer
  */

--- a/_protected/framework/File/Transfer/UploadingFileException.class.php
+++ b/_protected/framework/File/Transfer/UploadingFileException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / File / Transfer
  */

--- a/_protected/framework/Payment/Gateway/Api/Braintree.class.php
+++ b/_protected/framework/Payment/Gateway/Api/Braintree.class.php
@@ -3,7 +3,7 @@
  * @title            Braintree Class
  *
  * @author           Pierre-Henry Soria <hi@ph7.me>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Payment / Gateway / Api
  */

--- a/_protected/framework/Service/SearchImage/Google.class.php
+++ b/_protected/framework/Service/SearchImage/Google.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Service / SearchImage
  */

--- a/_protected/framework/Service/SearchImage/Imageable.interface.php
+++ b/_protected/framework/Service/SearchImage/Imageable.interface.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Service / SearchImage
  */

--- a/_protected/framework/Service/SearchImage/InvalidUrlException.class.php
+++ b/_protected/framework/Service/SearchImage/InvalidUrlException.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Service / SearchImage
  */

--- a/_protected/framework/Service/SearchImage/Url.class.php
+++ b/_protected/framework/Service/SearchImage/Url.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Framework / Service / SearchImage
  */

--- a/_repository/upgrade/6.0.13-7.1.3/data/sql/MySQL/upgrade.sql
+++ b/_repository/upgrade/6.0.13-7.1.3/data/sql/MySQL/upgrade.sql
@@ -1,6 +1,6 @@
 --
 -- Author:        Pierre-Henry Soria <hello@ph7cms.com>
--- Copyright:     (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+-- Copyright:     (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
 -- License:       GNU General Public License; https://www.gnu.org/licenses/gpl-3.0.en.html
 --
 

--- a/_repository/upgrade/7.1.3-8.0.6/data/sql/MySQL/upgrade.sql
+++ b/_repository/upgrade/7.1.3-8.0.6/data/sql/MySQL/upgrade.sql
@@ -1,6 +1,6 @@
 --
 -- Author:        Pierre-Henry Soria <hello@ph7cms.com>
--- Copyright:     (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+-- Copyright:     (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
 -- License:       GNU General Public License; https://www.gnu.org/licenses/gpl-3.0.en.html
 --
 

--- a/_repository/upgrade/8.0.2-10.0.8/data/sql/MySQL/upgrade.sql
+++ b/_repository/upgrade/8.0.2-10.0.8/data/sql/MySQL/upgrade.sql
@@ -1,6 +1,6 @@
 --
 -- Author:        Pierre-Henry Soria <hi@ph7.me>
--- Copyright:     (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+-- Copyright:     (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
 -- License:       GNU General Public License
 --
 

--- a/_tests/Unit/Framework/Ajax/AjaxTest.php
+++ b/_tests/Unit/Framework/Ajax/AjaxTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Ajax
  */

--- a/_tests/Unit/Framework/Config/ConfigTest.php
+++ b/_tests/Unit/Framework/Config/ConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Config
  */

--- a/_tests/Unit/Framework/Geo/Map/ApiTest.php
+++ b/_tests/Unit/Framework/Geo/Map/ApiTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Geo / Map
  */

--- a/_tests/Unit/Framework/Ip/IpTest.php
+++ b/_tests/Unit/Framework/Ip/IpTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Ip
  */

--- a/_tests/Unit/Framework/Layout/Html/DesignTest.php
+++ b/_tests/Unit/Framework/Layout/Html/DesignTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Layout / Html
  */

--- a/_tests/Unit/Framework/Parse/UrlTest.php
+++ b/_tests/Unit/Framework/Parse/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Config
  */

--- a/_tests/Unit/Framework/Security/SecurityTest.php
+++ b/_tests/Unit/Framework/Security/SecurityTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Security
  */

--- a/_tests/Unit/Framework/Service/SearchImage/GoogleTest.php
+++ b/_tests/Unit/Framework/Service/SearchImage/GoogleTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Service / SearchImage
  */

--- a/_tests/Unit/Framework/Service/SearchImage/UrlTest.php
+++ b/_tests/Unit/Framework/Service/SearchImage/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Service / SearchImage
  */

--- a/_tests/Unit/Framework/Str/StrTest.php
+++ b/_tests/Unit/Framework/Str/StrTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Str
  */

--- a/_tests/Unit/Framework/Translate/LangTest.php
+++ b/_tests/Unit/Framework/Translate/LangTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Util
  */

--- a/_tests/Unit/Framework/Url/UrlTest.php
+++ b/_tests/Unit/Framework/Url/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Config
  */

--- a/_tests/Unit/Framework/Util/VariousTest.php
+++ b/_tests/Unit/Framework/Util/VariousTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Util
  */

--- a/_tests/Unit/Framework/Video/Api/YoutubeTest.php
+++ b/_tests/Unit/Framework/Video/Api/YoutubeTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit / Framework / Video / Api
  */

--- a/_tests/Unit/bootstrap.php
+++ b/_tests/Unit/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author           Pierre-Henry Soria <hello@ph7cms.com>
- * @copyright        (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * @license          GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  * @package          PH7 / Test / Unit
  */

--- a/templates/themes/cartoon/css/_inc/common.custom.css
+++ b/templates/themes/cartoon/css/_inc/common.custom.css
@@ -1,6 +1,6 @@
 /*
  * Author:        Pierre-Henry Soria <ph7software@gmail.com>
- * Copyright:     (c) 2017, Pierre-Henry Soria. All Rights Reserved.
+ * Copyright:     (c) 2017-2018, Pierre-Henry Soria. All Rights Reserved.
  * License:       GNU General Public License; See PH7.LICENSE.txt and PH7.COPYRIGHT.txt in the root directory.
  */
 


### PR DESCRIPTION
"(c) 2017" was forgotten in the previous branch.