### PR TITLE
Compatibility with Apache 2.4 and higher

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -42,19 +42,43 @@ ServerSignature Off
 
 # Deny access to all CGI, Perl, Python, Bash, SQL, Template, INI configuration, cache, log, temporary and text files
 <FilesMatch "\.(cgi|pl|py|sh|bash|sql|tpl|ini|cache|log|tmp|txt)">
-    Deny from all
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Deny from all
+    </IfModule>
 </FilesMatch>
 
 # Leave open the humans.txt and robots.txt file
 <FilesMatch "humans\.txt|robots\.txt">
-    Allow from all
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Allow from all
+    </IfModule>
 </FilesMatch>
 
 # Prevent downloading files .htaccess (Default configuration of Apache)
 <Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
-    Satisfy all
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+        Satisfy all
+    </IfModule>
+
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </Files>
 
 # block bots spam
@@ -567,14 +591,32 @@ ServerSignature Off
     SetEnvIfNoCase User-Agent "^zerxbot" bad_bot
     SetEnvIfNoCase User-Agent "^Zeus" bad_bot
     SetEnvIfNoCase User-Agent "^ZyBorg" bad_bot
-    Order deny,allow
-    Deny from env=bad_bot
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from env=bad_bot
+    </IfModule>
+
+    # Apache >= 2.4
+    <IfModule mod_authz_core.c>
+        Require not env bad_bot
+    </IfModule>
 </IfModule>
 
 <Limit GET POST PUT DELETE HEAD>
-    Order allow,deny
-    Allow from all
-    Deny from env=bad_bot
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+        Deny from env=bad_bot
+    </IfModule>
+
+    # Apache >= 2.4
+    <IfModule mod_authz_core.c>
+        Require all granted
+        Require not env bad_bot
+    </IfModule>
 </Limit>
 
 ErrorDocument 400 /error/http/index?code=400

--- a/.htaccess
+++ b/.htaccess
@@ -68,16 +68,16 @@ ServerSignature Off
 
 # Prevent .htaccess/.htpasswd from being downloaded
 <Files ~ "^\.ht">
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny
         Deny from all
         Satisfy all
-    </IfModule>
-
-    # Apache 2.4+
-    <IfModule mod_authz_core.c>
-        Require all denied
     </IfModule>
 </Files>
 
@@ -592,34 +592,34 @@ ServerSignature Off
     SetEnvIfNoCase User-Agent "^Zeus" bad_bot
     SetEnvIfNoCase User-Agent "^ZyBorg" bad_bot
 
-    # Apache <= 2.2
-    <IfModule !mod_authz_core.c>
-        Order deny,allow
-        Deny from env=bad_bot
-    </IfModule>
-
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
         <RequireAll>
             Require not env bad_bot
         </RequireAll>
     </IfModule>
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from env=bad_bot
+    </IfModule>
 </IfModule>
 
 <Limit GET POST PUT DELETE HEAD>
-    # Apache <= 2.2
-    <IfModule !mod_authz_core.c>
-        Order allow,deny
-        Allow from all
-        Deny from env=bad_bot
-    </IfModule>
-
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
         <RequireAll>
             Require all granted
             Require not env bad_bot
         </RequireAll>
+    </IfModule>
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+        Deny from env=bad_bot
     </IfModule>
 </Limit>
 

--- a/.htaccess
+++ b/.htaccess
@@ -600,7 +600,9 @@ ServerSignature Off
 
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
-        Require not env bad_bot
+        <RequireAll>
+            Require not env bad_bot
+        </RequireAll>
     </IfModule>
 </IfModule>
 
@@ -614,8 +616,10 @@ ServerSignature Off
 
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
-        Require all granted
-        Require not env bad_bot
+        <RequireAll>
+            Require all granted
+            Require not env bad_bot
+        </RequireAll>
     </IfModule>
 </Limit>
 

--- a/.htaccess
+++ b/.htaccess
@@ -66,7 +66,7 @@ ServerSignature Off
     </IfModule>
 </FilesMatch>
 
-# Prevent downloading files .htaccess (Default configuration of Apache)
+# Prevent .htaccess/.htpasswd from being downloaded
 <Files ~ "^\.ht">
     # Apache 2.2
     <IfModule !mod_authz_core.c>

--- a/_protected/.htaccess
+++ b/_protected/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/_repository/.htaccess
+++ b/_repository/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/_repository/module/fake-admin-panel/inc/.htaccess
+++ b/_repository/module/fake-admin-panel/inc/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,7 +1,20 @@
 # Deny all other file extensions to prevent any compromised files to be executed
 
-Deny from all
-<FilesMatch "\.(jpe?g|png|gif|webp|mp4|webm|swf)$">
-    Order deny,allow
-    Allow from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>
+
+<FilesMatch "\.(jpe?g|png|gif|webp|mp3|mp4|flv|webm|swf)$">
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Allow from all
+    </IfModule>
 </FilesMatch>

--- a/sample.htaccess
+++ b/sample.htaccess
@@ -42,19 +42,43 @@ ServerSignature Off
 
 # Deny access to all CGI, Perl, Python, Bash, SQL, Template, INI configuration, cache, log, temporary and text files
 <FilesMatch "\.(cgi|pl|py|sh|bash|sql|tpl|ini|cache|log|tmp|txt)">
-    Deny from all
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Deny from all
+    </IfModule>
 </FilesMatch>
 
 # Leave open the humans.txt and robots.txt file
 <FilesMatch "humans\.txt|robots\.txt">
-    Allow from all
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Allow from all
+    </IfModule>
 </FilesMatch>
 
 # Prevent downloading files .htaccess (Default configuration of Apache)
 <Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
-    Satisfy all
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+        Satisfy all
+    </IfModule>
+
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </Files>
 
 # block bots spam
@@ -567,14 +591,32 @@ ServerSignature Off
     SetEnvIfNoCase User-Agent "^zerxbot" bad_bot
     SetEnvIfNoCase User-Agent "^Zeus" bad_bot
     SetEnvIfNoCase User-Agent "^ZyBorg" bad_bot
-    Order deny,allow
-    Deny from env=bad_bot
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from env=bad_bot
+    </IfModule>
+
+    # Apache >= 2.4
+    <IfModule mod_authz_core.c>
+        Require not env bad_bot
+    </IfModule>
 </IfModule>
 
 <Limit GET POST PUT DELETE HEAD>
-    Order allow,deny
-    Allow from all
-    Deny from env=bad_bot
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+        Deny from env=bad_bot
+    </IfModule>
+
+    # Apache >= 2.4
+    <IfModule mod_authz_core.c>
+        Require all granted
+        Require not env bad_bot
+    </IfModule>
 </Limit>
 
 ErrorDocument 400 /error/http/index?code=400

--- a/sample.htaccess
+++ b/sample.htaccess
@@ -68,16 +68,16 @@ ServerSignature Off
 
 # Prevent .htaccess/.htpasswd from being downloaded
 <Files ~ "^\.ht">
+    # Apache 2.4+
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order allow,deny
         Deny from all
         Satisfy all
-    </IfModule>
-
-    # Apache 2.4+
-    <IfModule mod_authz_core.c>
-        Require all denied
     </IfModule>
 </Files>
 
@@ -592,34 +592,34 @@ ServerSignature Off
     SetEnvIfNoCase User-Agent "^Zeus" bad_bot
     SetEnvIfNoCase User-Agent "^ZyBorg" bad_bot
 
-    # Apache <= 2.2
-    <IfModule !mod_authz_core.c>
-        Order deny,allow
-        Deny from env=bad_bot
-    </IfModule>
-
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
         <RequireAll>
             Require not env bad_bot
         </RequireAll>
     </IfModule>
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from env=bad_bot
+    </IfModule>
 </IfModule>
 
 <Limit GET POST PUT DELETE HEAD>
-    # Apache <= 2.2
-    <IfModule !mod_authz_core.c>
-        Order allow,deny
-        Allow from all
-        Deny from env=bad_bot
-    </IfModule>
-
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
         <RequireAll>
             Require all granted
             Require not env bad_bot
         </RequireAll>
+    </IfModule>
+
+    # Apache <= 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+        Deny from env=bad_bot
     </IfModule>
 </Limit>
 

--- a/sample.htaccess
+++ b/sample.htaccess
@@ -600,7 +600,9 @@ ServerSignature Off
 
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
-        Require not env bad_bot
+        <RequireAll>
+            Require not env bad_bot
+        </RequireAll>
     </IfModule>
 </IfModule>
 
@@ -614,8 +616,10 @@ ServerSignature Off
 
     # Apache >= 2.4
     <IfModule mod_authz_core.c>
-        Require all granted
-        Require not env bad_bot
+        <RequireAll>
+            Require all granted
+            Require not env bad_bot
+        </RequireAll>
     </IfModule>
 </Limit>
 

--- a/sample.htaccess
+++ b/sample.htaccess
@@ -66,7 +66,7 @@ ServerSignature Off
     </IfModule>
 </FilesMatch>
 
-# Prevent downloading files .htaccess (Default configuration of Apache)
+# Prevent .htaccess/.htpasswd from being downloaded
 <Files ~ "^\.ht">
     # Apache 2.2
     <IfModule !mod_authz_core.c>

--- a/templates/themes/base/config/.htaccess
+++ b/templates/themes/base/config/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/templates/themes/cartoon/config/.htaccess
+++ b/templates/themes/cartoon/config/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/templates/themes/datelove/config/.htaccess
+++ b/templates/themes/datelove/config/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/templates/themes/zendate/config/.htaccess
+++ b/templates/themes/zendate/config/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
Make the .htaccess files compatible with Apache 2.4+ when `mod_access_compat` isn't enabled (and keep compatibility with Apache 2.2).

In Apache 2.4, `Order`, `Allow`, `Deny`, and `Satisfy` directives are replaced by the `Require` directive. 


