### PR TITLE
pH7Tpl minor syntax changes + Improvement 

### DIFF
--- a/_protected/app/system/modules/affiliate/views/base/tpl/home/resendactivation.tpl
+++ b/_protected/app/system/modules/affiliate/views/base/tpl/home/resendactivation.tpl
@@ -13,5 +13,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/blog/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/blog/views/base/tpl/main/index.tpl
@@ -55,7 +55,7 @@
                 </div>
 
                 {* Don't check the post with \PH7\Framework\Security\Ban\Ban::filterWord() since this blog is only allowed for administrators *}
-                {% escape($this->str->extract($post->content,0,400), true) %}
+                {% escape($str->extract($post->content,0,400), true) %}
                 <p><a href="{{ $design->url('blog','main','read',$post->postId) }}" data-load="ajax">{lang 'See more'}</a></p>
 
                 {if AdminCore::auth()}

--- a/_protected/app/system/modules/blog/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/blog/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/comment/views/base/tpl/comment/add.tpl
+++ b/_protected/app/system/modules/comment/views/base/tpl/comment/add.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/comment/views/base/tpl/comment/edit.tpl
+++ b/_protected/app/system/modules/comment/views/base/tpl/comment/edit.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/comment/views/base/tpl/comment/read.tpl
+++ b/_protected/app/system/modules/comment/views/base/tpl/comment/read.tpl
@@ -9,7 +9,7 @@
                 {{ $comment = nl2br(
                     Framework\Parse\User::atUsernameToLink(
                         Framework\Parse\Emoticon::init(
-                            escape($this->str->extract(Framework\Security\Ban\Ban::filterWord($com->comment)), true)
+                            escape($str->extract(Framework\Security\Ban\Ban::filterWord($com->comment)), true)
                         )
                     )
                 ) }}

--- a/_protected/app/system/modules/connect/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/connect/views/base/tpl/main/index.tpl
@@ -1,17 +1,17 @@
 <div class="center">
-    {if $this->config->values['module.api']['facebook.enabled']}
+    {if $config->values['module.api']['facebook.enabled']}
         <a href="{{ $design->url('connect','main','login','fb') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}facebook.svg" alt="Facebook Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['google.enabled']}
+    {if $config->values['module.api']['google.enabled']}
         <a href="{{ $design->url('connect','main','login','google') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}google.svg" alt="Google Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['twitter.enabled']}
+    {if $config->values['module.api']['twitter.enabled']}
         <a href="{{ $design->url('connect','main','login','twitter') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}twitter.svg" alt="Twitter Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['microsoft.enabled']}
+    {if $config->values['module.api']['microsoft.enabled']}
         <a href="{{ $design->url('connect','main','login','microsoft') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}microsoft.svg" alt="Microsoft" /></a>
     {/if}
 </div>

--- a/_protected/app/system/modules/contact/views/base/tpl/contact/index.tpl
+++ b/_protected/app/system/modules/contact/views/base/tpl/contact/index.tpl
@@ -4,5 +4,5 @@
 </div>
 
 <div role="banner" class="right col-md-2 col-md-offset-2 ad_160_600">
-    {{ $designModel->ad(160, 600) }}
+    {designModel.ad(160, 600)}
 </div>

--- a/_protected/app/system/modules/cool-profile-page/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/cool-profile-page/views/base/tpl/main/index.tpl
@@ -206,7 +206,7 @@
         </div>
 
         <div class="ad_160_600">
-            {{ $designModel->ad(160, 600) }}
+            {designModel.ad(160, 600)}
         </div>
 
         {{ CommentDesignCore::link($id, 'profile') }}

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/addtopic.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/addtopic.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/editmessage.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/editmessage.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/edittopic.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/edittopic.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/reply.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/reply.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/search.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/friend/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/friend/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/game/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/game/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336, 280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/invite/views/base/tpl/home/invitation.tpl
+++ b/_protected/app/system/modules/invite/views/base/tpl/home/invitation.tpl
@@ -8,6 +8,6 @@
 <div class="right col-md-4">
     {{ $design->littleLikeApi() }}
     <div role="banner" class="ad_336_280">
-        {{ $designModel->ad(336,280) }}
+        {designModel.ad(336, 280)}
     </div>
 </div>

--- a/_protected/app/system/modules/lost-password/views/base/tpl/main/forgot.tpl
+++ b/_protected/app/system/modules/lost-password/views/base/tpl/main/forgot.tpl
@@ -4,5 +4,5 @@
 </div>
 
 <div class="col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/mail/views/base/tpl/main/compose.tpl
+++ b/_protected/app/system/modules/mail/views/base/tpl/main/compose.tpl
@@ -2,4 +2,6 @@
     {{ MailForm::display() }}
 </div>
 
-<div class="col-md-4 ad_336_280">{designModel.ad(336, 280)}</div>
+<div class="col-md-4 ad_336_280">
+    {designModel.ad(336, 280)}
+</div>

--- a/_protected/app/system/modules/mail/views/base/tpl/main/compose.tpl
+++ b/_protected/app/system/modules/mail/views/base/tpl/main/compose.tpl
@@ -2,4 +2,4 @@
     {{ MailForm::display() }}
 </div>
 
-<div class="col-md-4 ad_336_280">{{ $designModel->ad(336,280) }}</div>
+<div class="col-md-4 ad_336_280">{designModel.ad(336, 280)}</div>

--- a/_protected/app/system/modules/mail/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/mail/views/base/tpl/main/search.tpl
@@ -2,4 +2,4 @@
     {{ SearchMailForm::display() }}
 </div>
 
-<div class="col-md-4 ad_336_280">{{ $designModel->ad(336,280) }}</div>
+<div class="col-md-4 ad_336_280">{designModel.ad(336, 280)}</div>

--- a/_protected/app/system/modules/newsletter/views/base/tpl/home/subscription.tpl
+++ b/_protected/app/system/modules/newsletter/views/base/tpl/home/subscription.tpl
@@ -6,5 +6,5 @@
 </div>
 
 <div role="banner" class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/note/views/base/tpl/home.inc.tpl
+++ b/_protected/app/system/modules/note/views/base/tpl/home.inc.tpl
@@ -59,7 +59,7 @@
             <p>{error}</p>
         {else}
             {each $post in $posts}
-                {{ $content = escape($this->str->extract(Framework\Security\Ban\Ban::filterWord($post->content),0,400), true) }}
+                {{ $content = escape($str->extract(Framework\Security\Ban\Ban::filterWord($post->content),0,400), true) }}
 
                 <h1>
                     <a href="{{ $design->url('note','main','read',"$post->username,$post->postId") }}" title="{% $post->title %}" data-load="ajax">

--- a/_protected/app/system/modules/note/views/base/tpl/main/add.tpl
+++ b/_protected/app/system/modules/note/views/base/tpl/main/add.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/note/views/base/tpl/main/edit.tpl
+++ b/_protected/app/system/modules/note/views/base/tpl/main/edit.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/note/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/note/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/payment/views/base/tpl/admin/membershiplist.tpl
+++ b/_protected/app/system/modules/payment/views/base/tpl/admin/membershiplist.tpl
@@ -2,7 +2,7 @@
     <tr>
         <th>{lang 'Group ID#'}</th>
         <th>{lang 'Name'}</th>
-        <th>{lang 'Price (%0%)', $this->config->values['module.setting']['currency']}</th>
+        <th>{lang 'Price (%0%)', $config->values['module.setting']['currency']}</th>
         <th>{lang 'Expiration Days'}</th>
         <th>{lang 'Active'}</th>
         <th>{lang 'Action'}</th>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/addalbum.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/addalbum.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/addphoto.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/addphoto.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/editalbum.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/editalbum.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/editphoto.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/editphoto.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/report/views/base/tpl/main/abuse.tpl
+++ b/_protected/app/system/modules/report/views/base/tpl/main/abuse.tpl
@@ -5,5 +5,5 @@
 </div>
 
 <div role="banner" class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/main/login.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/login.tpl
@@ -15,5 +15,5 @@
 </div>
 
 <div class="col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/main/resendactivation.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/resendactivation.tpl
@@ -10,5 +10,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/main/soon.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/soon.tpl
@@ -4,5 +4,5 @@
 </p>
 
 <div role="banner" class="center ad_728_90">
-    {{ $designModel->ad(728,90) }}
+    {designModel.ad(728, 90)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
@@ -297,7 +297,7 @@
                 <p class="bold">{lang 'Description:'}</p>
                 <div class="quote italic">{description}</div>
                 <div class="ad_336_280">
-                    {{ $designModel->ad(336, 280) }}
+                    {designModel.ad(336, 280)}
                 </div>
             </div>
         {/if}

--- a/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/profile/index.tpl
@@ -413,7 +413,7 @@
 
     {* Signup Popup *}
     {if !$is_logged AND !AdminCore::auth()}
-        {{ $design->staticFiles('js', PH7_LAYOUT . PH7_SYS . PH7_MOD . $this->registry->module . PH7_SH . PH7_TPL . PH7_TPL_MOD_NAME . PH7_SH . PH7_JS, 'signup_popup.js') }}
+        {{ $design->staticFiles('js', PH7_LAYOUT . PH7_SYS . PH7_MOD . $registry->module . PH7_SH . PH7_TPL . PH7_TPL_MOD_NAME . PH7_SH . PH7_JS, 'signup_popup.js') }}
     {/if}
 {else}
     <p class="center">{error}</p>

--- a/_protected/app/system/modules/user/views/base/tpl/search/advanced.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/search/advanced.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-2 col-md-offset-2 ad_160_600">
-    {{ $designModel->ad(160,600) }}
+    {designModel.ad(160, 600)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/search/quick.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/search/quick.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-2 col-md-offset-2 ad_160_600">
-    {{ $designModel->ad(160,600) }}
+    {designModel.ad(160, 600)}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/signup/step2.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/signup/step2.tpl
@@ -1,4 +1,4 @@
 <div class="col-md-8">
-  {include 'progressbar.inc.tpl'}
-  {{ JoinForm::step2() }}
+    {include 'progressbar.inc.tpl'}
+    {{ JoinForm::step2() }}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/signup/step4.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/signup/step4.tpl
@@ -3,4 +3,6 @@
     {{ JoinForm::step4() }}
 </div>
 
-<div class="right col-md-4 ad_336_280">{designModel.ad(336, 280)}</div>
+<div class="right col-md-4 ad_336_280">
+    {designModel.ad(336, 280)}
+</div>

--- a/_protected/app/system/modules/user/views/base/tpl/signup/step4.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/signup/step4.tpl
@@ -3,4 +3,4 @@
     {{ JoinForm::step4() }}
 </div>
 
-<div class="right col-md-4 ad_336_280">{{ $designModel->ad(336,280) }}</div>
+<div class="right col-md-4 ad_336_280">{designModel.ad(336, 280)}</div>

--- a/_protected/app/system/modules/user/views/base/tpl/visitor/search.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/visitor/search.tpl
@@ -2,4 +2,6 @@
     {{ SearchVisitorForm::display() }}
 </div>
 
-<div class="right col-md-4 ad_336_280">{{ $designModel->ad(336,280) }}</div>
+<div class="right col-md-4 ad_336_280">
+    {designModel.ad(336,280)}
+</div>

--- a/_protected/app/system/modules/video/views/base/tpl/main/addalbum.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/addalbum.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/video/views/base/tpl/main/addvideo.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/addvideo.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/video/views/base/tpl/main/editalbum.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/editalbum.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/video/views/base/tpl/main/editvideo.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/editvideo.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/app/system/modules/video/views/base/tpl/main/search.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/search.tpl
@@ -3,5 +3,5 @@
 </div>
 
 <div class="right col-md-4 ad_336_280">
-    {{ $designModel->ad(336,280) }}
+    {designModel.ad(336, 280)}
 </div>

--- a/_protected/framework/Layout/Html/Design.class.php
+++ b/_protected/framework/Layout/Html/Design.class.php
@@ -984,6 +984,7 @@ class Design
     public function externalCssFile($sFile, $sCssMedia = null)
     {
         $sCssMedia = $sCssMedia !== null ? ' media="' . $sCssMedia . '"' : '';
+
         echo '<link rel="stylesheet" href="', $sFile, '"', $sCssMedia, ' />';
     }
 

--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/PH7Tpl.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/PH7Tpl.class.php
@@ -717,8 +717,18 @@ Template Engine: ' . self::NAME . ' version ' . self::VERSION . ' by ' . self::A
     {
         /***** Object shortcuts *****/
         $this->sCode = str_replace(
-            ['$browser->', '$designModel->'],
-            ['$this->browser->', '$this->designModel->'],
+            [
+                '$browser->',
+                '$registry->',
+                '$str->',
+                '$config->'
+            ],
+            [
+                '$this->browser->',
+                '$this->registry->',
+                '$this->str->',
+                '$this->config->'
+            ],
             $this->sCode
         );
 

--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Curly.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Curly.class.php
@@ -105,6 +105,13 @@ class Curly extends Syntax
         /***** endif | endfor | endwhile | endforeach *****/
         $this->sCode = str_replace(['{/if}', '{/for}', '{/while}', '{/each}'], '<?php } ?>', $this->sCode);
 
+        /***** {designModel.[a-z0-9_]+()} *****/
+        $this->sCode = preg_replace(
+            '#{designModel\.([a-z0-9_]+)\((.*)\)}#i',
+            '<?php $this->designModel->$1($2) ?>',
+            $this->sCode
+        );
+
         /***** Escape (htmlspecialchars) *****/
         $this->sCode = preg_replace(
             '#{escape ([^\{\}]+)}#',

--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Tal.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Tal.class.php
@@ -157,6 +157,13 @@ class Tal extends Syntax
             $this->sCode
         );
 
+        /***** <ph:designmodel value=[a-z0-9_]+()" /> *****/
+        $this->sCode = preg_replace(
+            '#<ph:designmodel value=(?:"|\')([a-z0-9_]+)\((.*)\)(?:"|\') ?/?>#i',
+            '<?php $this->designModel->$1($2) ?>',
+            $this->sCode
+        );
+
         /***** Escape (htmlspecialchars) *****/
         $this->sCode = preg_replace(
             '#<ph:escape value=([^\<\>/\n]+) ?/?>#',

--- a/_protected/framework/Mvc/Controller/Controller.class.php
+++ b/_protected/framework/Mvc/Controller/Controller.class.php
@@ -172,7 +172,10 @@ abstract class Controller extends Core
      */
     private function assignGlobalTplVars()
     {
-        // Set config and design objects to the template
+        /**
+         * Set design object to the template.
+         * @internal Warning: This one won't work if directly used as shortcut in pH7Tpl parser.
+         */
         $this->view->design = $this->design;
 
         $bIsMobApp = MobApp::is($this->httpRequest, $this->session);

--- a/_protected/framework/Mvc/Controller/Controller.class.php
+++ b/_protected/framework/Mvc/Controller/Controller.class.php
@@ -173,7 +173,6 @@ abstract class Controller extends Core
     private function assignGlobalTplVars()
     {
         // Set config and design objects to the template
-        $this->view->config = $this->config;
         $this->view->design = $this->design;
 
         $bIsMobApp = MobApp::is($this->httpRequest, $this->session);

--- a/_repository/upgrade/12.9.7-12.9.8/data/file/protected/app/system/modules/connect/views/base/tpl/main/index.tpl
+++ b/_repository/upgrade/12.9.7-12.9.8/data/file/protected/app/system/modules/connect/views/base/tpl/main/index.tpl
@@ -1,17 +1,17 @@
 <div class="center">
-    {if $this->config->values['module.api']['facebook.enabled']}
+    {if $config->values['module.api']['facebook.enabled']}
         <a href="{{ $design->url('connect','main','login','fb') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}facebook.svg" alt="Facebook Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['google.enabled']}
+    {if $config->values['module.api']['google.enabled']}
         <a href="{{ $design->url('connect','main','login','google') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}google.svg" alt="Google Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['twitter.enabled']}
+    {if $config->values['module.api']['twitter.enabled']}
         <a href="{{ $design->url('connect','main','login','twitter') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}twitter.svg" alt="Twitter Connect" /></a>  &nbsp; &nbsp;
     {/if}
 
-    {if $this->config->values['module.api']['microsoft.enabled']}
+    {if $config->values['module.api']['microsoft.enabled']}
         <a href="{{ $design->url('connect','main','login','microsoft') }}" rel="nofollow" target="_blank"><img src="{url_tpl_mod_img}microsoft.svg" alt="Microsoft" /></a>
     {/if}
 </div>

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/CurlyTest.php
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/CurlyTest.php
@@ -116,6 +116,11 @@ class CurlyTest extends SyntaxTestCase
         $this->assertFile('each', $this->oCurlySyntax);
     }
 
+    public function testDesignModelObject()
+    {
+        $this->assertFile('design-model', $this->oCurlySyntax);
+    }
+
     public function testEscapeFunction()
     {
         $this->assertFile('escape', $this->oCurlySyntax);

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/TalTest.php
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/TalTest.php
@@ -131,6 +131,11 @@ class TalTest extends SyntaxTestCase
         $this->assertFile('each', $this->oTalSyntax);
     }
 
+    public function testDesignModelObject()
+    {
+        $this->assertFile('design-model', $this->oTalSyntax);
+    }
+
     public function testEscapeFunction()
     {
         $this->assertFile('escape', $this->oTalSyntax);

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/curly/design-model.curly.tpl
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/curly/design-model.curly.tpl
@@ -1,0 +1,8 @@
+{designModel.langList()}
+{designModel.ad(160, 600)}
+{designModel.ad(160, 600, false)}
+{designModel.analyticsApi()}
+{designModel.analyticsApi(true, false)}
+{designModel.customCode('js')}
+{designModel.file('css')}
+{designModel.file('css', false)}

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/tal/design-model.tal.tpl
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/tal/design-model.tal.tpl
@@ -1,0 +1,8 @@
+<ph:designmodel value="langList()" />
+<ph:designmodel value="ad(160, 600)" />
+<ph:designmodel value="ad(160, 600, false)" />
+<ph:designmodel value="analyticsApi()" />
+<ph:designmodel value="analyticsApi(true, false)" />
+<ph:designmodel value="customCode('js')" />
+<ph:designmodel value="file('css')" />
+<ph:designmodel value="file('css', false)" />

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/curly/design-model.curly.output
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/curly/design-model.curly.output
@@ -1,0 +1,8 @@
+<?php $this->designModel->langList() ?>
+<?php $this->designModel->ad(160, 600) ?>
+<?php $this->designModel->ad(160, 600, false) ?>
+<?php $this->designModel->analyticsApi() ?>
+<?php $this->designModel->analyticsApi(true, false) ?>
+<?php $this->designModel->customCode('js') ?>
+<?php $this->designModel->file('css') ?>
+<?php $this->designModel->file('css', false) ?>

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/tal/design-model.tal.output
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/tal/design-model.tal.output
@@ -1,0 +1,8 @@
+<?php $this->designModel->langList() ?>
+<?php $this->designModel->ad(160, 600) ?>
+<?php $this->designModel->ad(160, 600, false) ?>
+<?php $this->designModel->analyticsApi() ?>
+<?php $this->designModel->analyticsApi(true, false) ?>
+<?php $this->designModel->customCode('js') ?>
+<?php $this->designModel->file('css') ?>
+<?php $this->designModel->file('css', false) ?>

--- a/templates/themes/base/tpl/browse_user.inc.tpl
+++ b/templates/themes/base/tpl/browse_user.inc.tpl
@@ -29,8 +29,8 @@
 
                 {{ $avatarDesign->get($user->username, $user->firstName, $user->sex, 64, true) }}
                 <p class="cy_ico">
-                    <a href="{% (new UserCore)->getProfileLink($user->username) %}" title="{lang 'Name: %0%', $user->firstName}<br> {lang 'Gender: %0% %1%', t($user->sex), $sex_ico}<br> {lang 'Seeking: %0%', t($user->matchSex)}<br> {lang 'Age: %0%', $age}<br> {lang 'From: %0%', $country_name}<br> {lang 'City: %0%', $this->str->upperFirst($user->city)}<br> {lang 'State: %0%', $this->str->upperFirst($user->state)}">
-                        <strong>{% $this->str->extract($user->username, 0, PH7_MAX_USERNAME_LENGTH_SHOWN, PH7_ELLIPSIS) %}</strong>
+                    <a href="{% (new UserCore)->getProfileLink($user->username) %}" title="{lang 'Name: %0%', $user->firstName}<br> {lang 'Gender: %0% %1%', t($user->sex), $sex_ico}<br> {lang 'Seeking: %0%', t($user->matchSex)}<br> {lang 'Age: %0%', $age}<br> {lang 'From: %0%', $country_name}<br> {lang 'City: %0%', $str->upperFirst($user->city)}<br> {lang 'State: %0%', $str->upperFirst($user->state)}">
+                        <strong>{% $str->extract($user->username, 0, PH7_MAX_USERNAME_LENGTH_SHOWN, PH7_ELLIPSIS) %}</strong>
                     </a> <img src="{{ $design->getSmallFlagIcon($user->country) }}" alt="{country_name}" title="{lang 'From %0%', $country_name}" />
                 </p>
 

--- a/templates/themes/base/tpl/layout.tpl
+++ b/templates/themes/base/tpl/layout.tpl
@@ -48,7 +48,7 @@
 
     <!-- Other sheet CSS for modules etc. -->
     {{ $design->css() }}
-    {{ $designModel->files('css') }}
+    {designModel.files('css')}
     <!-- End CSS -->
 
     <!-- Begin Header JavaScript -->
@@ -67,7 +67,7 @@
     {{ XmlDesignCore::sitemapHeaderLink() }}
     {{ XmlDesignCore::rssHeaderLinks() }}
 
-    {{ $designModel->analyticsApi() }}
+    {designModel.analyticsApi()}
   </head>
   <body>
 
@@ -112,7 +112,7 @@
       {* Don't display the top middle banner on the the splash page *}
       {if !$is_guest_homepage}
           <div role="banner" class="center ad_468_60">
-              {{ $designModel->ad(468, 60) }}
+              {designModel.ad(468, 60)}
           </div>
       {/if}
 
@@ -152,14 +152,14 @@
       </div>
     </div>
     <div role="banner" class="center ad_468_60">
-        {{ $designModel->ad(468, 60) }}
+        {designModel.ad(468, 60)}
     </div>
     <!-- End Content -->
 
     <!-- Begin Footer -->
     <footer>
       <div role="banner" class="center ad_728_90">
-          {{ $designModel->ad(728, 90) }}
+          {designModel.ad(728, 90)}
       </div>
 
       {* To avoid scammers *}
@@ -227,7 +227,7 @@
 
     <!-- Other JavaScript files for modules etc. -->
     {{ $design->js() }}
-    {{ $designModel->files('js') }}
+    {designModel.files('js')}
 
     {if $is_user_auth}
       {main_include 'favicon_alert.inc.tpl'}

--- a/templates/themes/base/tpl/layout.tpl
+++ b/templates/themes/base/tpl/layout.tpl
@@ -6,9 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     <!-- Begin Title and Meta info -->
-    <title>{if $page_title}{% $this->str->escape($this->str->upperFirst($page_title), true) %} - {site_name}{else}{site_name} - {slogan}{/if}</title>
-    <meta name="description" content="{% $this->str->escape($this->str->upperFirst($meta_description), true) %}" />
-    <meta name="keywords" content="{% $this->str->escape($meta_keywords, true) %}" />
+    <title>{if $page_title}{% $str->escape($str->upperFirst($page_title), true) %} - {site_name}{else}{site_name} - {slogan}{/if}</title>
+    <meta name="description" content="{% $str->escape($str->upperFirst($meta_description), true) %}" />
+    <meta name="keywords" content="{% $str->escape($meta_keywords, true) %}" />
     <meta name="robots" content="{meta_robots}" />
     <link rel="icon" href="{url_relative}favicon.ico" />
     <link rel="canonical" href="{current_url}" />


### PR DESCRIPTION
* Cleanup a bit pH7Tpl syntaxes
* Add `designModel` object  natively as variable prefix. e.g. `{designModel.funcName()}`
* Add new shortcuts for `$config`, `$browser`, `$str` and remove all `$this->` that points to PH7Tpl class to make template code more readable and line length shorter.
* Better template indentation 