### PR TITLE
Refactor pH7Tpl Predefined Func

### DIFF
--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Predefined/Func.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Predefined/Func.class.php
@@ -1,14 +1,13 @@
 <?php
 /***************************************************************************
  * @title            PH7 Template Engine
- * @desc             We define functions (and helpers).
- *                   Predefined functions can save considerable resources and speeds up the code with respect to functions in variables assigned by through the object's template engine (PH7Tpl).
+ * @desc             Define functions (and helpers).
+ *                   Predefined functions can save considerable resources and speeds up the code with respect to functions in variables assigned through the object's template engine (PH7Tpl).
  *
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
  * @category         PH7 Template Engine
  * @package          PH7 / Framework / Layout / Tpl / Engine / PH7Tpl / Predefined
  * @copyright        (c) 2012-2018, Pierre-Henry Soria. All Rights Reserved.
- * @version          1.0.2
  * @license          CC-BY License - http://creativecommons.org/licenses/by/3.0/
  ***************************************************************************/
 

--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Predefined/Func.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Predefined/Func.class.php
@@ -22,8 +22,13 @@ class Func extends Predefined
      */
     public function assign()
     {
-        $this->addFunc('<ph:date value="(\w+)" ?/?>', 'date(\'$1\')');
+        $this->dataFunction();
 
         return $this;
+    }
+
+    private function dataFunction()
+    {
+        $this->addFunc('<ph:date value="(\w+)" ?/?>', 'date(\'$1\')');
     }
 }


### PR DESCRIPTION
Split code from located in Predefined/Func.class.php into a describable method name (instead of ugly comments) for better readability.