### PR TITLE
Change profile page URL pattern

### DIFF
--- a/_protected/app/configs/routes/en.xml
+++ b/_protected/app/configs/routes/en.xml
@@ -7,7 +7,7 @@
     <!-- BEGIN SYSTEM MODULES -->
 
     <!-- User -->
-      <route url="([a-zA-Z0-9_-]+)[$page_ext]" path="system/modules" module="user" controller="profile" action="index" vars="username" />
+      <route url="@([a-zA-Z0-9_-]+)" path="system/modules" module="user" controller="profile" action="index" vars="username" />
       <route url="signup" path="system/modules" module="user" controller="signup" action="step1" />
       <route url="login" path="system/modules" module="user" controller="main" action="login" />
       <route url="resend-activation" path="system/modules" module="user" controller="main" action="resendactivation" />

--- a/_protected/app/system/core/classes/UserCore.php
+++ b/_protected/app/system/core/classes/UserCore.php
@@ -316,9 +316,9 @@ class UserCore
     public function getProfileLink($sUsername)
     {
         $sUsername = (new Str)->lower($sUsername);
-        //return (strlen($sUsername) >1) ? PH7_URL_ROOT . $sUsername . PH7_PAGE_EXT : '#';
+        //return (strlen($sUsername) > 1) ? PH7_URL_ROOT . '@' . $sUsername : '#';
 
-        return PH7_URL_ROOT . $sUsername . PH7_PAGE_EXT;
+        return PH7_URL_ROOT . '@' . $sUsername;
     }
 
     /**

--- a/_protected/app/system/core/classes/UserCore.php
+++ b/_protected/app/system/core/classes/UserCore.php
@@ -34,6 +34,9 @@ use stdClass;
 // Abstract Class
 class UserCore
 {
+    /** The prefix of the profile page URI path (eg https://mysite.com/@<USERNAME>) */
+    const PROFILE_PAGE_PREFIX = '@';
+
     const MAX_WIDTH_AVATAR = 600;
     const MAX_HEIGHT_AVATAR = 800;
 
@@ -318,7 +321,7 @@ class UserCore
         $sUsername = (new Str)->lower($sUsername);
         //return (strlen($sUsername) > 1) ? PH7_URL_ROOT . '@' . $sUsername : '#';
 
-        return PH7_URL_ROOT . '@' . $sUsername;
+        return PH7_URL_ROOT . self::PROFILE_PAGE_PREFIX . $sUsername;
     }
 
     /**

--- a/_protected/app/system/modules/user/forms/JoinForm.php
+++ b/_protected/app/system/modules/user/forms/JoinForm.php
@@ -44,7 +44,7 @@ class JoinForm
         $oForm->addElement(new \PFBC\Element\Textbox(t('Your First Name'), 'first_name', ['placeholder' => t('First Name'), 'id' => 'name_first', 'onblur' => 'CValid(this.value,this.id)', 'required' => 1, 'validation' => new \PFBC\Validation\Name]));
         $oForm->addElement(new \PFBC\Element\HTMLExternal('<span class="input_error name_first"></span>'));
 
-        $oForm->addElement(new \PFBC\Element\Username(t('Your Nickname'), 'username', ['placeholder' => t('Nickname'), 'description' => PH7_URL_ROOT . '<strong><span class="your-user-name">' . t('your-user-name') . '</span><span class="username"></span></strong>' . PH7_PAGE_EXT, 'id' => 'username', 'required' => 1, 'validation' => new \PFBC\Validation\Username]));
+        $oForm->addElement(new \PFBC\Element\Username(t('Your Nickname'), 'username', ['placeholder' => t('Nickname'), 'description' => PH7_URL_ROOT . '@<strong><span class="your-user-name">' . t('your-user-name') . '</span><span class="username"></span></strong>', 'id' => 'username', 'required' => 1, 'validation' => new \PFBC\Validation\Username]));
 
         $oForm->addElement(new \PFBC\Element\Email(t('Your Email'), 'mail', ['placeholder' => t('Email'), 'id' => 'email', 'onblur' => 'CValid(this.value, this.id,\'guest\')', 'required' => 1, 'validation' => new \PFBC\Validation\CEmail('guest')]));
         $oForm->addElement(new \PFBC\Element\HTMLExternal('<span class="input_error email"></span>'));

--- a/_protected/app/system/modules/user/forms/JoinForm.php
+++ b/_protected/app/system/modules/user/forms/JoinForm.php
@@ -44,7 +44,7 @@ class JoinForm
         $oForm->addElement(new \PFBC\Element\Textbox(t('Your First Name'), 'first_name', ['placeholder' => t('First Name'), 'id' => 'name_first', 'onblur' => 'CValid(this.value,this.id)', 'required' => 1, 'validation' => new \PFBC\Validation\Name]));
         $oForm->addElement(new \PFBC\Element\HTMLExternal('<span class="input_error name_first"></span>'));
 
-        $oForm->addElement(new \PFBC\Element\Username(t('Your Nickname'), 'username', ['placeholder' => t('Nickname'), 'description' => PH7_URL_ROOT . '@<strong><span class="your-user-name">' . t('your-user-name') . '</span><span class="username"></span></strong>', 'id' => 'username', 'required' => 1, 'validation' => new \PFBC\Validation\Username]));
+        $oForm->addElement(new \PFBC\Element\Username(t('Your Nickname'), 'username', ['placeholder' => t('Nickname'), 'description' => PH7_URL_ROOT . UserCore::PROFILE_PAGE_PREFIX . '<strong><span class="your-user-name">' . t('your-user-name') . '</span><span class="username"></span></strong>', 'id' => 'username', 'required' => 1, 'validation' => new \PFBC\Validation\Username]));
 
         $oForm->addElement(new \PFBC\Element\Email(t('Your Email'), 'mail', ['placeholder' => t('Email'), 'id' => 'email', 'onblur' => 'CValid(this.value, this.id,\'guest\')', 'required' => 1, 'validation' => new \PFBC\Validation\CEmail('guest')]));
         $oForm->addElement(new \PFBC\Element\HTMLExternal('<span class="input_error email"></span>'));

--- a/_protected/framework/Mvc/Router/Uri.class.php
+++ b/_protected/framework/Mvc/Router/Uri.class.php
@@ -181,13 +181,6 @@ class Uri
     private static function parseVariable($sContents)
     {
         /**
-         * Replace the "[$page_ext]" variable by the "PH7_PAGE_EXT" constant.
-         *
-         * @internal We add a slash for RegEx ignores the dot (e.g., '.'html), (in RegEx, the dot means "any single character").
-         */
-        $sContents = str_replace('[$page_ext]', '\\' . PH7_PAGE_EXT, $sContents);
-
-        /**
          * Replace the "[$admin_mod]" variable by the "PH7_ADMIN_MOD" constant.
          */
         $sContents = str_replace('[$admin_mod]', PH7_ADMIN_MOD, $sContents);

--- a/_protected/framework/Navigation/Page.class.php
+++ b/_protected/framework/Navigation/Page.class.php
@@ -144,6 +144,6 @@ class Page
      */
     private static function getUrlSlug($sCurrentUrl)
     {
-        return strpos($sCurrentUrl, '&amp;') !== false ? strrchr($sCurrentUrl, '?') : strrchr($sCurrentUrl, '?');
+        return strpos($sCurrentUrl, '&amp;') !== false ? strrchr($sCurrentUrl, '?') !== false : strrchr($sCurrentUrl, '?');
     }
 }

--- a/_protected/framework/Parse/User.class.php
+++ b/_protected/framework/Parse/User.class.php
@@ -30,7 +30,7 @@ class User
      */
     public static function atUsernameToLink($sContents)
     {
-        foreach (static::getAtUsernames($sContents) as $sUsername) {
+        foreach (self::getAtUsernames($sContents) as $sUsername) {
             $sUsernameLink = (new UserCore)->getProfileLink($sUsername);
 
             $sContents = str_replace(
@@ -52,7 +52,7 @@ class User
      */
     private static function getAtUsernames($sContents)
     {
-        if (preg_match_all('#' . static::AT . '(' . PH7_USERNAME_PATTERN . '{' . DbConfig::getSetting('minUsernameLength') . ',' . DbConfig::getSetting('maxUsernameLength') . '})#u', $sContents, $aMatches, PREG_PATTERN_ORDER)) {
+        if (self::areProfileFound($sContents, $aMatches)) {
             $aMatches[1] = array_unique($aMatches[1]); // Delete duplicate usernames.
             foreach ($aMatches[1] as $sUsername) {
                 if ((new ExistsCoreModel)->username($sUsername)) {
@@ -60,5 +60,21 @@ class User
                 }
             }
         }
+    }
+
+    /**
+     * @param string $sContents
+     * @param array $aMatches
+     *
+     * @return false|int
+     */
+    private static function areProfileFound($sContents, array &$aMatches)
+    {
+        return preg_match_all(
+            '#' . static::AT . '(' . PH7_USERNAME_PATTERN . '{' . DbConfig::getSetting('minUsernameLength') . ',' . DbConfig::getSetting('maxUsernameLength') . '})#u',
+            $sContents,
+            $aMatches,
+            PREG_PATTERN_ORDER
+        );
     }
 }

--- a/_protected/framework/Parse/User.class.php
+++ b/_protected/framework/Parse/User.class.php
@@ -68,7 +68,7 @@ class User
      *
      * @return false|int
      */
-    private static function areProfileFound($sContents, array &$aMatches)
+    private static function areProfileFound($sContents, &$aMatches)
     {
         return preg_match_all(
             '#' . static::AT . '(' . PH7_USERNAME_PATTERN . '{' . DbConfig::getSetting('minUsernameLength') . ',' . DbConfig::getSetting('maxUsernameLength') . '})#u',

--- a/_protected/framework/Security/Validate/Validate.class.php
+++ b/_protected/framework/Security/Validate/Validate.class.php
@@ -224,7 +224,7 @@ class Validate
 
         return (
             preg_match('#^' . PH7_USERNAME_PATTERN . '{' . $iMin . ',' . $iMax . '}$#', $sUsername) &&
-            !file_exists(PH7_PATH_ROOT . $sUsername . PH7_PAGE_EXT) && !Ban::isUsername($sUsername) &&
+            !file_exists(PH7_PATH_ROOT . '@' . $sUsername) && !Ban::isUsername($sUsername) &&
             !(new ExistsCoreModel)->username($sUsername, $sTable)
         );
     }

--- a/_protected/framework/Security/Validate/Validate.class.php
+++ b/_protected/framework/Security/Validate/Validate.class.php
@@ -22,6 +22,7 @@ use PH7\Framework\Error\CException\PH7InvalidArgumentException;
 use PH7\Framework\Math\Measure\Year as YearMeasure;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Str\Str;
+use PH7\UserCore;
 
 class Validate
 {
@@ -224,7 +225,7 @@ class Validate
 
         return (
             preg_match('#^' . PH7_USERNAME_PATTERN . '{' . $iMin . ',' . $iMax . '}$#', $sUsername) &&
-            !file_exists(PH7_PATH_ROOT . '@' . $sUsername) && !Ban::isUsername($sUsername) &&
+            !file_exists(PH7_PATH_ROOT . UserCore::PROFILE_PAGE_PREFIX . $sUsername) && !Ban::isUsername($sUsername) &&
             !(new ExistsCoreModel)->username($sUsername, $sTable)
         );
     }

--- a/_protected/framework/Security/Validate/Validate.class.php
+++ b/_protected/framework/Security/Validate/Validate.class.php
@@ -225,7 +225,8 @@ class Validate
 
         return (
             preg_match('#^' . PH7_USERNAME_PATTERN . '{' . $iMin . ',' . $iMax . '}$#', $sUsername) &&
-            !file_exists(PH7_PATH_ROOT . UserCore::PROFILE_PAGE_PREFIX . $sUsername) && !Ban::isUsername($sUsername) &&
+            !file_exists(PH7_PATH_ROOT . UserCore::PROFILE_PAGE_PREFIX . $sUsername) &&
+            !Ban::isUsername($sUsername) &&
             !(new ExistsCoreModel)->username($sUsername, $sTable)
         );
     }


### PR DESCRIPTION
To modernize the profile page URLs (and make the profile page URLs more consistent with the others), remove the `.html` suffix, and use the `@` prefix for the profile pages.

## Profile Page URL Before
my-website.com/**&lt;USERNAME&gt;.html**

## Profile Page URL NOW
my-website.com/**@&lt;USERNAME&gt;**