### PR TITLE
Cleanup XML indentation in XML view files

### DIFF
--- a/_protected/app/system/modules/xml/views/base/tpl/blog.rss.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/blog.rss.xml.tpl
@@ -2,21 +2,23 @@
 {{ XmlDesign::rssHeader() }}
 
 <channel>
-   <title>{lang 'Latest Blog Posts'}</title>
-   <link>{{ $design->url('blog','main','index') }}</link>
-   <description>{lang 'Latest Blog Posts %site_name%'}</description>
+  <title>{lang 'Latest Blog Posts'}</title>
+  <link>{{ $design->url('blog','main','index') }}</link>
+  <description>{lang 'Latest Blog Posts %site_name%'}</description>
 
-   {each $post in $blogs}
-     <item>
-       <title>{% escape($post->pageTitle) %}</title>
-       <link>{{ $design->url('blog','main','read',$post->postId) }}</link>
-       <pubDate>{% DateFormat::getRss($post->createdDate) %}</pubDate>
-       {if !empty($post->updatedDate)}<lastBuildDate>{% DateFormat::getRss($post->updatedDate) %}</lastBuildDate>{/if}
-       <description><![CDATA[{% $post->content %}]]></description>
-       <language>{% $post->langId %}</language>
-       <copyright>{% $post->metaCopyright %} </copyright>
-     </item>
-   {/each}
-
+  {each $post in $blogs}
+    <item>
+      <title>{% escape($post->pageTitle) %}</title>
+      <link>{{ $design->url('blog','main','read',$post->postId) }}</link>
+      <pubDate>{% DateFormat::getRss($post->createdDate) %}</pubDate>
+      {if !empty($post->updatedDate)}
+        <lastBuildDate>{% DateFormat::getRss($post->updatedDate) %}</lastBuildDate>
+      {/if}
+      <description><![CDATA[{% $post->content %}]]></description>
+      <language>{% $post->langId %}</language>
+      <copyright>{% $post->metaCopyright %}</copyright>
+    </item>
+  {/each}
 </channel>
+
 {{ XmlDesign::rssFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/blog.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/blog.sitemap.xml.tpl
@@ -2,12 +2,12 @@
 {{ XmlDesign::xslHeader() }}
 
 {each $post in $blogs}
-    <url>
-        <loc>{{ $design->url('blog','main','read',$post->postId) }}</loc>
-        <lastmod>{% DateFormat::getSitemap((!empty($post->updatedDate) ? $post->updatedDate : $post->createdDate)) %}</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.6</priority>
-    </url>
+  <url>
+    <loc>{{ $design->url('blog','main','read',$post->postId) }}</loc>
+    <lastmod>{% DateFormat::getSitemap((!empty($post->updatedDate) ? $post->updatedDate : $post->createdDate)) %}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 {/each}
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/comment.inc.rss.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/comment.inc.rss.xml.tpl
@@ -11,10 +11,12 @@
       <title>{lang "%0%'s comments", $com->username}</title>
       <link>{{ $design->url('comment','comment','post',"$table,$com->commentId") }}</link>
       <pubDate>{% DateFormat::getRss($com->createdDate) %}</pubDate>
-      {if !empty($com->updatedDate)}<lastBuildDate>{% DateFormat::getRss($com->updatedDate) %}</lastBuildDate>{/if}
+      {if !empty($com->updatedDate)}
+        <lastBuildDate>{% DateFormat::getRss($com->updatedDate) %}</lastBuildDate>
+      {/if}
       <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($com->comment, false) %}]]></description>
     </item>
   {/each}
-
 </channel>
+
 {{ XmlDesign::rssFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/comment.inc.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/comment.inc.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $com in $comments}
   <url>
     <loc>{{ $design->url('comment','comment','read',"$table,$com->recipient") }}</loc>
@@ -10,6 +9,5 @@
     <priority>0.5</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/comment.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/comment.sitemap.xml.tpl
@@ -8,39 +8,49 @@
   <priority>0.5</priority>
 </url>
 
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-blog') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_blog_enabled}
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-blog') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-note') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_note_enabled}
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-note') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-picture') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_picture_enabled}
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-picture') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-video') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_video_enabled}
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-video') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-game') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_game_enabled}
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-game') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/comment.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/comment.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 <url>
   <loc>{{ $design->url('xml','sitemap','xmlrouter','comment-profile') }}</loc>
   <lastmod>{current_date}</lastmod>
@@ -43,6 +42,5 @@
   <changefreq>weekly</changefreq>
   <priority>0.5</priority>
 </url>
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/forum-post.rss.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/forum-post.rss.xml.tpl
@@ -2,19 +2,23 @@
 {{ XmlDesign::rssHeader() }}
 
 <channel>
-    <title>{lang 'Latest Forum Topic Posts'}</title>
-    <link>{current_url}</link>
-    <description>{lang 'Latest Forum Topic Posts of %site_name%'}</description>
-    {each $msg in $forums_messages}
-        <item>
-            <title>{% escape(Framework\Security\Ban\Ban::filterWord($msg->title, false)) %}</title>
-            <link>
-                {{ $design->url('forum', 'forum', 'post', escape("$msg->name,$msg->forumId,$msg->title,$msg->topicId") ) }}#{% $msg->messageId %}
-            </link>
-            <pubDate>{% DateFormat::getRss($msg->createdDate) %}</pubDate>
-            {if !empty($com->updatedDate)}<lastBuildDate>{% DateFormat::getRss($msg->updatedDate) %}</lastBuildDate>{/if}
-            <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($msg->message, false) %}]]></description>
-        </item>
-    {/each}
+  <title>{lang 'Latest Forum Topic Posts'}</title>
+  <link>{current_url}</link>
+  <description>{lang 'Latest Forum Topic Posts of %site_name%'}</description>
+
+  {each $msg in $forums_messages}
+    <item>
+      <title>{% escape(Framework\Security\Ban\Ban::filterWord($msg->title, false)) %}</title>
+      <link>
+        {{ $design->url('forum', 'forum', 'post', escape("$msg->name,$msg->forumId,$msg->title,$msg->topicId") ) }}#{% $msg->messageId %}
+      </link>
+      <pubDate>{% DateFormat::getRss($msg->createdDate) %}</pubDate>
+      {if !empty($com->updatedDate)}
+        <lastBuildDate>{% DateFormat::getRss($msg->updatedDate) %}</lastBuildDate>
+      {/if}
+      <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($msg->message, false) %}]]></description>
+    </item>
+  {/each}
 </channel>
+
 {{ XmlDesign::rssFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/forum-topic.rss.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/forum-topic.rss.xml.tpl
@@ -11,10 +11,12 @@
       <title>{% escape(Framework\Security\Ban\Ban::filterWord($topic->title, false)) %}</title>
       <link>{{ $design->url('forum','forum','post', escape("$topic->name,$topic->forumId,$topic->title,$topic->topicId") ) }}</link>
       <pubDate>{% DateFormat::getRss($topic->createdDate) %}</pubDate>
-      {if !empty($com->updatedDate)}<lastBuildDate>{% DateFormat::getRss($topic->updatedDate) %}</lastBuildDate>{/if}
+      {if !empty($com->updatedDate)}
+        <lastBuildDate>{% DateFormat::getRss($topic->updatedDate) %}</lastBuildDate>
+      {/if}
       <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($topic->message, false) %}]]></description>
     </item>
   {/each}
-
 </channel>
+
 {{ XmlDesign::rssFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/forum-topic.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/forum-topic.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $topic in $forums_topics}
   <url>
     <loc>{{ $design->url('forum','forum','post', escape("$topic->name,$topic->forumId,$topic->title,$topic->topicId") ) }}</loc>
@@ -10,6 +9,5 @@
     <priority>0.6</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/game.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/game.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $game in $games}
   <url>
     <loc>{{ $design->url('game','main','game',"$game->title,$game->gameId") }}</loc>
@@ -10,6 +9,5 @@
     <priority>0.7</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/home.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/home.sitemap.xml.tpl
@@ -1,9 +1,7 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {* General Link *}
-
 <url>
   <loc>{{ $design->url('xml','sitemap','xmlrouter','main') }}</loc>
   <lastmod>{current_date}</lastmod>
@@ -11,9 +9,7 @@
   <priority>1.0</priority>
 </url>
 
-
-{* Mod *}
-
+{* Mods *}
 <url>
   <loc>{{ $design->url('xml','sitemap','xmlrouter','user') }}</loc>
   <lastmod>{current_date}</lastmod>
@@ -22,30 +18,30 @@
 </url>
 
 {if $is_blog_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','blog') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.9</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','blog') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 {/if}
 
 {if $is_note_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','note') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.8</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','note') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 {/if}
 
 {if $is_forum_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','forums') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.8</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','forums') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 {/if}
 
 <url>
@@ -56,30 +52,30 @@
 </url>
 
 {if $is_picture_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','picture') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.6</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','picture') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
 {/if}
 
 {if $is_video_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','video') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.8</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','video') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 {/if}
 
 {if $is_game_enabled}
-<url>
-  <loc>{{ $design->url('xml','sitemap','xmlrouter','game') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.8</priority>
-</url>
+  <url>
+    <loc>{{ $design->url('xml','sitemap','xmlrouter','game') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 {/if}
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
@@ -6,14 +6,14 @@
     >
 
     <!-- Output in HTML5 with doctype-system="about:legacy-compat" -->
-    <xsl:output method="html" doctype-system="about:legacy-compat" encoding="utf-8" indent="yes"/>
+    <xsl:output method="html" doctype-system="about:legacy-compat" encoding="utf-8" indent="yes" />
     <xsl:template match="/">
         <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
-            <meta charset="utf-8"/>
+            <meta charset="utf-8" />
             <title>{lang 'XML Sitemap - %site_name%'}</title>
-            <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-            <link rel="stylesheet" href="{url_tpl_mod_css}style.css"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+            <link rel="stylesheet" href="{url_tpl_mod_css}style.css" />
         </head>
         <body>
         <header>
@@ -27,34 +27,33 @@
                     <th>{lang 'Change Frequency'}</th>
                     <th>{lang 'Last Change (UTC)'}</th>
                 </tr>
-                <xsl:variable name="alpha_lower" select="'abcdefghijklmnopqrstuvwxyz'"/>
-                <xsl:variable name="alpha_upper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+                <xsl:variable name="alpha_lower" select="'abcdefghijklmnopqrstuvwxyz'" />
+                <xsl:variable name="alpha_upper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
                 <xsl:for-each select="sitemap:urlset/sitemap:url">
-
-                    <xsl:sort select="sitemap:priority" order="descending"/>
-                    <xsl:sort select="sitemap:lastmod" order="descending"/>
+                    <xsl:sort select="sitemap:priority" order="descending" />
+                    <xsl:sort select="sitemap:lastmod" order="descending" />
                     <tr>
                         <xsl:if test="position() mod 2 != 1">
                             <xsl:attribute name="class">high</xsl:attribute>
                         </xsl:if>
                         <td>
                             <xsl:variable name="itemUrl">
-                                <xsl:value-of select="sitemap:loc"/>
+                                <xsl:value-of select="sitemap:loc" />
                             </xsl:variable>
                             <a href="{$itemUrl}">
-                                <xsl:value-of select="sitemap:loc"/>
+                                <xsl:value-of select="sitemap:loc" />
                             </a>
                         </td>
                         <td>
-                            <xsl:value-of select="concat(sitemap:priority*100,'%')"/>
+                            <xsl:value-of select="concat(sitemap:priority*100,'%')" />
                         </td>
                         <td>
                             <xsl:value-of
-                                select="concat(translate(substring(sitemap:changefreq, 1, 1),concat($alpha_lower, $alpha_upper),concat($alpha_upper, $alpha_lower)),substring(sitemap:changefreq, 2))"/>
+                                select="concat(translate(substring(sitemap:changefreq, 1, 1),concat($alpha_lower, $alpha_upper),concat($alpha_upper, $alpha_lower)),substring(sitemap:changefreq, 2))" />
                         </td>
                         <td>
                             <xsl:value-of
-                                select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))"/>
+                                select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))" />
                         </td>
                     </tr>
                 </xsl:for-each>

--- a/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
@@ -1,63 +1,69 @@
 {{ $design->xmlHeader() }}
-<xsl:stylesheet version="2.0" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet
+    version="2.0"
+    xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
 
-<!-- Output in HTML5 with doctype-system="about:legacy-compat" -->
-<xsl:output method="html" doctype-system="about:legacy-compat" encoding="utf-8" indent="yes" />
+    <!-- Output in HTML5 with doctype-system="about:legacy-compat" -->
+    <xsl:output method="html" doctype-system="about:legacy-compat" encoding="utf-8" indent="yes"/>
     <xsl:template match="/">
-          <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-                <meta charset="utf-8" />
-                <title>{lang 'XML Sitemap - %site_name%'}</title>
-                <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-                <link rel="stylesheet" href="{url_tpl_mod_css}style.css" />
-            </head>
-           <body>
-              <header>
-                <h1>{lang 'Site Map'} - <a href="{url_root}">{site_name}</a></h1>
-              </header>
-                <section>
-                    <table>
-                        <tr class="border-bottom">
-                            <th>{lang 'URL'}</th>
-                            <th>{lang 'Priority'}</th>
-                            <th>{lang 'Change Frequency'}</th>
-                            <th>{lang 'Last Change (UTC)'}</th>
-                        </tr>
-                        <xsl:variable name="alpha_lower" select="'abcdefghijklmnopqrstuvwxyz'"/>
-                        <xsl:variable name="alpha_upper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
-                        <xsl:for-each select="sitemap:urlset/sitemap:url">
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+            <meta charset="utf-8"/>
+            <title>{lang 'XML Sitemap - %site_name%'}</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+            <link rel="stylesheet" href="{url_tpl_mod_css}style.css"/>
+        </head>
+        <body>
+        <header>
+            <h1>{lang 'Site Map'} - <a href="{url_root}">{site_name}</a></h1>
+        </header>
+        <section>
+            <table>
+                <tr class="border-bottom">
+                    <th>{lang 'URL'}</th>
+                    <th>{lang 'Priority'}</th>
+                    <th>{lang 'Change Frequency'}</th>
+                    <th>{lang 'Last Change (UTC)'}</th>
+                </tr>
+                <xsl:variable name="alpha_lower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+                <xsl:variable name="alpha_upper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+                <xsl:for-each select="sitemap:urlset/sitemap:url">
 
-                        <xsl:sort select="sitemap:priority" order="descending" />
-                        <xsl:sort select="sitemap:lastmod" order="descending" />
-                            <tr>
-                                <xsl:if test="position() mod 2 != 1">
-                                    <xsl:attribute  name="class">high</xsl:attribute>
-                                </xsl:if>
-                                <td>
-                                    <xsl:variable name="itemUrl">
-                                        <xsl:value-of select="sitemap:loc"/>
-                                    </xsl:variable>
-                                    <a href="{$itemUrl}">
-                                        <xsl:value-of select="sitemap:loc"/>
-                                    </a>
-                                </td>
-                                <td>
-                                    <xsl:value-of select="concat(sitemap:priority*100,'%')"/>
-                                </td>
-                                <td>
-                                    <xsl:value-of select="concat(translate(substring(sitemap:changefreq, 1, 1),concat($alpha_lower, $alpha_upper),concat($alpha_upper, $alpha_lower)),substring(sitemap:changefreq, 2))"/>
-                                </td>
-                                <td>
-                                    <xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))"/>
-                                </td>
-                            </tr>
-                        </xsl:for-each>
-                    </table>
-                </section>
-                <footer>
-                    <p>{{ $design->smallLink() }}</p>
-                </footer>
-            </body>
+                    <xsl:sort select="sitemap:priority" order="descending"/>
+                    <xsl:sort select="sitemap:lastmod" order="descending"/>
+                    <tr>
+                        <xsl:if test="position() mod 2 != 1">
+                            <xsl:attribute name="class">high</xsl:attribute>
+                        </xsl:if>
+                        <td>
+                            <xsl:variable name="itemUrl">
+                                <xsl:value-of select="sitemap:loc"/>
+                            </xsl:variable>
+                            <a href="{$itemUrl}">
+                                <xsl:value-of select="sitemap:loc"/>
+                            </a>
+                        </td>
+                        <td>
+                            <xsl:value-of select="concat(sitemap:priority*100,'%')"/>
+                        </td>
+                        <td>
+                            <xsl:value-of
+                                select="concat(translate(substring(sitemap:changefreq, 1, 1),concat($alpha_lower, $alpha_upper),concat($alpha_upper, $alpha_lower)),substring(sitemap:changefreq, 2))"/>
+                        </td>
+                        <td>
+                            <xsl:value-of
+                                select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))"/>
+                        </td>
+                    </tr>
+                </xsl:for-each>
+            </table>
+        </section>
+        <footer>
+            <p>{{ $design->smallLink() }}</p>
+        </footer>
+        </body>
         </html>
     </xsl:template>
 </xsl:stylesheet>

--- a/_protected/app/system/modules/xml/views/base/tpl/main.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/main.sitemap.xml.tpl
@@ -15,61 +15,77 @@
   <priority>0.8</priority>
 </url>
 
-<url>
-  <loc>{{ $design->url('webcam','webcam','picture') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.6</priority>
-</url>
+{if $is_webcam_enabled}
+  <url>
+    <loc>{{ $design->url('webcam','webcam','picture') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('forum','forum','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.6</priority>
-</url>
+{if $is_forum_enabled}
+  <url>
+    <loc>{{ $design->url('forum','forum','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('picture','main','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.5</priority>
-</url>
+{if $is_picture_enabled}
+  <url>
+    <loc>{{ $design->url('picture','main','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('video','main','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>weekly</changefreq>
-  <priority>0.7</priority>
-</url>
+{if $is_video_enabled}
+  <url>
+    <loc>{{ $design->url('video','main','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('chat','home','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.7</priority>
-</url>
+{if $is_chat_enabled}
+  <url>
+    <loc>{{ $design->url('chat','home','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('chatroulette','home','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.7</priority>
-</url>
+{if $is_chatroulette_enabled}
+  <url>
+    <loc>{{ $design->url('chatroulette','home','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('blog','main','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.8</priority>
-</url>
+{if $is_blog_enabled}
+  <url>
+    <loc>{{ $design->url('blog','main','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+{/if}
 
-<url>
-  <loc>{{ $design->url('game','main','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.7</priority>
-</url>
+{if $is_game_enabled}
+  <url>
+    <loc>{{ $design->url('game','main','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+{/if}
 
 <url>
   <loc>{{ $design->url('page','main','about') }}</loc>
@@ -106,11 +122,13 @@
   <priority>0.4</priority>
 </url>
 
-<url>
-  <loc>{{ $design->url('affiliate','home','index') }}</loc>
-  <lastmod>{current_date}</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.4</priority>
-</url>
+{if $is_affiliate_enabled}
+  <url>
+    <loc>{{ $design->url('affiliate','home','index') }}</loc>
+    <lastmod>{current_date}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+{/if}
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/main.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/main.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 <url>
   <loc>{url_root}</loc>
   <lastmod>{current_date}</lastmod>
@@ -113,6 +112,5 @@
   <changefreq>monthly</changefreq>
   <priority>0.4</priority>
 </url>
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/note.rss.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/note.rss.xml.tpl
@@ -6,18 +6,20 @@
   <link>{{ $design->url('note','main','index') }}</link>
   <description>{lang 'Latest Notes %site_name%'}</description>
 
-{each $post in $notes}
-  <item>
-    <title>{% escape(Framework\Security\Ban\Ban::filterWord($post->pageTitle, false)) %}</title>
-    <link>{{ $design->url('note','main','read',"$post->username,$post->postId") }}</link>
-    <pubDate>{% DateFormat::getRss($post->createdDate) %}</pubDate>
-    {if !empty($post->updatedDate)}<lastBuildDate>{% DateFormat::getRss($post->updatedDate) %}</lastBuildDate>{/if}
-    <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($post->content, false) %}]]></description>
-    <language>{% $post->langId %}</language>
-    <copyright>{% Framework\Security\Ban\Ban::filterWord($post->metaCopyright, false) %} </copyright>
-    <dc:creator>{% $post->firstName %}{if !empty($post->lastName)} {% $post->lastName %}{/if}</dc:creator>
-  </item>
-{/each}
-
+  {each $post in $notes}
+    <item>
+      <title>{% escape(Framework\Security\Ban\Ban::filterWord($post->pageTitle, false)) %}</title>
+      <link>{{ $design->url('note','main','read',"$post->username,$post->postId") }}</link>
+      <pubDate>{% DateFormat::getRss($post->createdDate) %}</pubDate>
+      {if !empty($post->updatedDate)}
+        <lastBuildDate>{% DateFormat::getRss($post->updatedDate) %}</lastBuildDate>
+      {/if}
+      <description><![CDATA[{% Framework\Security\Ban\Ban::filterWord($post->content, false) %}]]></description>
+      <language>{% $post->langId %}</language>
+      <copyright>{% Framework\Security\Ban\Ban::filterWord($post->metaCopyright, false) %}</copyright>
+      <dc:creator>{% $post->firstName %}{if !empty($post->lastName)} {% $post->lastName %} {/if}</dc:creator>
+    </item>
+  {/each}
 </channel>
+
 {{ XmlDesign::rssFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/note.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/note.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $post in $notes}
   <url>
     <loc>{{ $design->url('note','main','read',"$post->username,$post->postId") }}</loc>
@@ -10,6 +9,5 @@
     <priority>0.6</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/picture.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/picture.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $album in $albums_pictures}
   <url>
     <loc>{{ $design->url('picture','main','album',"$album->username,$album->name,$album->albumId") }}</loc>
@@ -19,6 +18,5 @@
     <priority>0.6</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/rss_links.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/rss_links.xml.tpl
@@ -1,38 +1,37 @@
 {{ $design->xmlHeader() }}
 
 <url>
-{if $is_blog_enabled}
-  <link title="{lang 'Blogs'}" url="{{ $design->url('xml','rss','xmlrouter','blog') }}" />
-{/if}
+  {if $is_blog_enabled}
+    <link title="{lang 'Blogs'}" url="{{ $design->url('xml','rss','xmlrouter','blog') }}" />
+  {/if}
 
-{if $is_note_enabled}
-<link title="{lang 'Notes'}" url="{{ $design->url('xml','rss','xmlrouter','note') }}" />
-{/if}
+  {if $is_note_enabled}
+  <link title="{lang 'Notes'}" url="{{ $design->url('xml','rss','xmlrouter','note') }}" />
+  {/if}
 
-{if $is_forum_enabled}
-  <link title="{lang 'Forum Topics'}" url="{{ $design->url('xml','rss','xmlrouter','forum-topic') }}" />
-{/if}
+  {if $is_forum_enabled}
+    <link title="{lang 'Forum Topics'}" url="{{ $design->url('xml','rss','xmlrouter','forum-topic') }}" />
+  {/if}
 
-<link title="{lang 'Profile Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-profile') }}" />
+  <link title="{lang 'Profile Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-profile') }}" />
 
-{if $is_blog_enabled}
-  <link title="{lang 'Blog Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-blog') }}" />
-{/if}
+  {if $is_blog_enabled}
+    <link title="{lang 'Blog Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-blog') }}" />
+  {/if}
 
-{if $is_note_enabled}
-  <link title="{lang 'Note Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-note') }}" />
-{/if}
+  {if $is_note_enabled}
+    <link title="{lang 'Note Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-note') }}" />
+  {/if}
 
-{if $is_picture_enabled}
-  <link title="{lang 'Picture Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-picture') }}" />
-{/if}
+  {if $is_picture_enabled}
+    <link title="{lang 'Picture Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-picture') }}" />
+  {/if}
 
-{if $is_video_enabled}
-  <link title="{lang 'Video Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-video') }}" />
-{/if}
+  {if $is_video_enabled}
+    <link title="{lang 'Video Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-video') }}" />
+  {/if}
 
-{if $is_game_enabled}
-  <link title="{lang 'Game Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-game') }}" />
-{/if}
-
+  {if $is_game_enabled}
+    <link title="{lang 'Game Comments'}" url="{{ $design->url('xml','rss','xmlrouter','comment-game') }}" />
+  {/if}
 </url>

--- a/_protected/app/system/modules/xml/views/base/tpl/sitemap/index.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/sitemap/index.tpl
@@ -9,8 +9,7 @@
                 </li>
             {/each}
         </ul>
-        {else}
-
-    <p>{lang 'Oops! No links to display. Come back later ;)'}</p>
+    {else}
+        <p>{lang 'Oops! No links to display. Come back later ;)'}</p>
     {/if}
 </div>

--- a/_protected/app/system/modules/xml/views/base/tpl/user.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/user.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $user in $members}
   <url>
     <loc>{% (new UserCore)->getProfileLink($user->username) %}</loc>
@@ -10,6 +9,5 @@
     <priority>0.5</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}

--- a/_protected/app/system/modules/xml/views/base/tpl/video.sitemap.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/video.sitemap.xml.tpl
@@ -1,7 +1,6 @@
 {{ $design->xmlHeader() }}
 {{ XmlDesign::xslHeader() }}
 
-
 {each $album in $albums_videos}
   <url>
     <loc>{{ $design->url('video','main','album',"$album->username,$album->name,$album->albumId") }}</loc>
@@ -19,6 +18,5 @@
     <priority>0.6</priority>
   </url>
 {/each}
-
 
 {{ XmlDesign::xslFooter() }}


### PR DESCRIPTION
* Cleanup XML indentation in the view files of the XML module.
* Display ONLY appropriate module comments if enabled (before, all comments from all modules were always shown, even if the particular module was disabled).
* Make sure modules are installed before showing them on the main XML feed page (before, all of them were showed, even if disabled).
* Remove extra new lines.