### PR TITLE
[Readability] Use HTTP status constant names

### DIFF
--- a/_protected/app/includes/classes/Cron.php
+++ b/_protected/app/includes/classes/Cron.php
@@ -9,6 +9,7 @@
 namespace PH7;
 
 use PH7\Framework\Http\Http;
+use Teapot\StatusCode;
 
 abstract class Cron extends Framework\Cron\Run\Cron
 {
@@ -30,7 +31,7 @@ abstract class Cron extends Framework\Cron\Run\Cron
     public function isAlreadyExec()
     {
         if (!$this->checkDelay()) {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
 
             exit(t('This cron has already been executed.'));
         }

--- a/_protected/app/system/core/assets/ajax/RatingCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/RatingCoreAjax.php
@@ -18,6 +18,7 @@ use PH7\Framework\Cookie\Cookie;
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Session\Session;
+use Teapot\StatusCode;
 
 class RatingCoreAjax
 {
@@ -66,7 +67,7 @@ class RatingCoreAjax
                 }
             }
         } else {
-            Http::setHeadersByCode(400);
+            Http::setHeadersByCode(StatusCode::BAD_REQUEST);
             exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/core/assets/ajax/StatCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/StatCoreAjax.php
@@ -16,6 +16,7 @@ defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
+use Teapot\StatusCode;
 
 class StatCoreAjax
 {
@@ -47,7 +48,7 @@ class StatCoreAjax
 
             // If we receive another invalid value, we display a message with a HTTP header.
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/core/assets/ajax/ValidateCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/ValidateCoreAjax.php
@@ -21,6 +21,7 @@ use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\Spam\Captcha\Captcha;
 use PH7\Framework\Security\Validate\Validate;
 use PH7\Framework\Str\Str;
+use Teapot\StatusCode;
 
 class ValidateCoreAjax
 {
@@ -101,7 +102,7 @@ class ValidateCoreAjax
 
                 // If we receive another invalid value, we display a message with a HTTP header.
                 default:
-                    Http::setHeadersByCode(400);
+                    Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                     exit('Bad Request Error!');
             }
         }

--- a/_protected/app/system/core/assets/cron/96h/DatabaseCoreCron.php
+++ b/_protected/app/system/core/assets/cron/96h/DatabaseCoreCron.php
@@ -20,6 +20,7 @@ use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PH7\Framework\Mvc\Model\Engine\Util\Backup;
 use PH7\Framework\Mvc\Model\Engine\Util\Various as DbVarious;
+use Teapot\StatusCode;
 
 class DatabaseCoreCron extends Cron
 {
@@ -51,7 +52,7 @@ class DatabaseCoreCron extends Cron
                     break;
 
                 default:
-                    Http::setHeadersByCode(400);
+                    Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                     exit('Bad Request Error!');
             }
         }

--- a/_protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
+++ b/_protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
@@ -15,6 +15,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Model\Design as DesignModel;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token;
+use Teapot\StatusCode;
 
 class AdsAjax
 {
@@ -58,7 +59,7 @@ class AdsAjax
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error');
         }
     }

--- a/_protected/app/system/modules/admin123/assets/ajax/CacheAjax.php
+++ b/_protected/app/system/modules/admin123/assets/ajax/CacheAjax.php
@@ -16,6 +16,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Layout\Gzip\Gzip;
 use PH7\Framework\Layout\Tpl\Engine\PH7Tpl\PH7Tpl;
 use PH7\Framework\Security\CSRF\Token;
+use Teapot\StatusCode;
 
 class CacheAjax extends Kernel
 {
@@ -50,7 +51,7 @@ class CacheAjax extends Kernel
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error');
         }
 

--- a/_protected/app/system/modules/api/config/Permission.php
+++ b/_protected/app/system/modules/api/config/Permission.php
@@ -14,6 +14,7 @@ defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Api\Tool;
 use PH7\Framework\Http\Http;
+use Teapot\StatusCode;
 
 class Permission extends PermissionCore
 {
@@ -22,7 +23,7 @@ class Permission extends PermissionCore
         parent::__construct();
 
         if (!Tool::checkAccess($this->config, $this->httpRequest)) {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
             t("Your API key and/or the URL of your external application don't match with the one in your pH7CMS's configuration system!");
             exit;
         }

--- a/_protected/app/system/modules/blog/controllers/MainController.php
+++ b/_protected/app/system/modules/blog/controllers/MainController.php
@@ -16,6 +16,7 @@ use PH7\Framework\Navigation\Page;
 use PH7\Framework\Parse\Emoticon;
 use PH7\Framework\Url\Header;
 use stdClass;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -209,7 +210,7 @@ class MainController extends Controller
     protected function notFound($b404Status = true)
     {
         if ($b404Status) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $this->view->page_title = $this->view->h2_title = $this->sTitle;

--- a/_protected/app/system/modules/comment/assets/ajax/CommentAjax.php
+++ b/_protected/app/system/modules/comment/assets/ajax/CommentAjax.php
@@ -14,6 +14,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Session\Session;
+use Teapot\StatusCode;
 
 class Comment
 {
@@ -49,7 +50,7 @@ class Comment
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/modules/comment/controllers/CommentController.php
+++ b/_protected/app/system/modules/comment/controllers/CommentController.php
@@ -14,6 +14,7 @@ use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Security\CSRF\Token as CSRFToken;
 use PH7\Framework\Url\Header;
+use Teapot\StatusCode;
 
 class CommentController extends Controller
 {
@@ -178,7 +179,7 @@ class CommentController extends Controller
      */
     private function notFound()
     {
-        Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+        Http::setHeadersByCode(StatusCode::NOT_FOUND);
 
         $this->view->page_title = t('Comment Not Found');
         $this->view->error = t('No comments yet, <a class="bold" href="%0%">add one</a>!', Uri::get('comment', 'comment', 'add', $this->sTable . ',' . $this->str->escape($this->httpRequest->get('id'))));

--- a/_protected/app/system/modules/forum/controllers/ForumController.php
+++ b/_protected/app/system/modules/forum/controllers/ForumController.php
@@ -14,6 +14,7 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Url\Header;
+use Teapot\StatusCode;
 
 class ForumController extends Controller
 {
@@ -401,7 +402,7 @@ class ForumController extends Controller
     private function notFound($b404Status = true)
     {
         if ($b404Status === true) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $sErrMsg = '';

--- a/_protected/app/system/modules/friend/assets/ajax/FriendAjax.php
+++ b/_protected/app/system/modules/friend/assets/ajax/FriendAjax.php
@@ -15,6 +15,7 @@ use PH7\Framework\Mail\Mail;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Security\CSRF\Token;
+use Teapot\StatusCode;
 
 class FriendAjax extends Core
 {
@@ -51,7 +52,7 @@ class FriendAjax extends Core
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/modules/game/controllers/MainController.php
+++ b/_protected/app/system/modules/game/controllers/MainController.php
@@ -12,6 +12,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Model\Statistic as StatModel;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -269,7 +270,7 @@ class MainController extends Controller
      */
     private function notFound()
     {
-        Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+        Http::setHeadersByCode(StatusCode::NOT_FOUND);
 
         $this->view->page_title = $this->sTitle;
         $this->view->h2_title = $this->sTitle;

--- a/_protected/app/system/modules/hotornot/controllers/MainController.php
+++ b/_protected/app/system/modules/hotornot/controllers/MainController.php
@@ -9,6 +9,7 @@
 namespace PH7;
 
 use PH7\Framework\Http\Http;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -48,7 +49,7 @@ class MainController extends Controller
         $oData = $this->oHoNModel->getPicture($iProfileId);
 
         if (empty($oData)) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
             $this->view->error = t("Sorry, we haven't found any photo to Hot Or Not Party.");
         } else {
             $this->view->avatarDesign = new AvatarDesignCore; // Avatar Design Class

--- a/_protected/app/system/modules/im/assets/ajax/MessengerAjax.php
+++ b/_protected/app/system/modules/im/assets/ajax/MessengerAjax.php
@@ -23,6 +23,7 @@ use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Parse\Emoticon;
 use PH7\Framework\Session\Session;
+use Teapot\StatusCode;
 
 class MessengerAjax extends PermissionCore
 {
@@ -61,7 +62,7 @@ class MessengerAjax extends PermissionCore
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
 

--- a/_protected/app/system/modules/mail/assets/ajax/MailAjax.php
+++ b/_protected/app/system/modules/mail/assets/ajax/MailAjax.php
@@ -14,6 +14,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token as SecurityToken;
 use PH7\Framework\Session\Session;
+use Teapot\StatusCode;
 
 class Mail
 {
@@ -55,7 +56,7 @@ class Mail
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/modules/newsletter/forms/processing/SubscriptionFormProcess.php
+++ b/_protected/app/system/modules/newsletter/forms/processing/SubscriptionFormProcess.php
@@ -17,6 +17,7 @@ use PH7\Framework\Ip\Ip;
 use PH7\Framework\Mail\Mail;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Util\Various;
+use Teapot\StatusCode;
 
 class SubscriptionFormProcess extends Form
 {
@@ -63,7 +64,7 @@ class SubscriptionFormProcess extends Form
             } break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
         unset($oSubscriptionModel);

--- a/_protected/app/system/modules/note/controllers/MainController.php
+++ b/_protected/app/system/modules/note/controllers/MainController.php
@@ -18,6 +18,7 @@ use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Security\CSRF\Token as SecurityToken;
 use PH7\Framework\Url\Header;
 use stdClass;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -375,7 +376,7 @@ class MainController extends Controller
     protected function notFound($b404Status = true)
     {
         if ($b404Status) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $this->view->page_title = $this->view->h2_title = $this->sTitle;

--- a/_protected/app/system/modules/picture/controllers/MainController.php
+++ b/_protected/app/system/modules/picture/controllers/MainController.php
@@ -14,6 +14,7 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Url\Header;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -284,7 +285,7 @@ class MainController extends Controller
     private function notFound($b404Status = true)
     {
         if ($b404Status === true) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $sErrMsg = '';

--- a/_protected/app/system/modules/report/assets/ajax/ReportAjax.php
+++ b/_protected/app/system/modules/report/assets/ajax/ReportAjax.php
@@ -13,6 +13,7 @@ defined('PH7') or exit('Restricted access');
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token;
+use Teapot\StatusCode;
 
 class ReportAjax
 {
@@ -68,7 +69,7 @@ class ReportAjax
      */
     private function badRequest()
     {
-        Http::setHeadersByCode(400);
+        Http::setHeadersByCode(StatusCode::BAD_REQUEST);
 
         return 'Bad Request Error';
     }

--- a/_protected/app/system/modules/user/assets/ajax/ApiAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/ApiAjax.php
@@ -14,6 +14,7 @@ defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
+use Teapot\StatusCode;
 
 class ApiAjax
 {
@@ -48,7 +49,7 @@ class ApiAjax
 
             // If we receive another invalid value, we display a message with a HTTP header.
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
         }
     }

--- a/_protected/app/system/modules/user/assets/ajax/WallAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/WallAjax.php
@@ -72,7 +72,12 @@ class WallAjax extends Core
 
     private function show()
     {
-        $this->mContents = $this->oWallModel->get($this->session->get('member_id'), null, 0, self::MAX_ITEMS_SHOWN);
+        $this->mContents = $this->oWallModel->get(
+            $this->session->get('member_id'),
+            null,
+            0,
+            self::MAX_ITEMS_SHOWN
+        );
 
         if (!$this->mContents) {
             echo '<p class="alert alert-danger">', t('Oops...! No news feed available at the moment.'), '</p>';
@@ -93,7 +98,11 @@ class WallAjax extends Core
 
     private function showCommentProfile()
     {
-        $this->mContents = $this->oWallModel->getCommentProfile(null, 0, self::MAX_ITEMS_SHOWN);
+        $this->mContents = $this->oWallModel->getCommentProfile(
+            null,
+            0,
+            self::MAX_ITEMS_SHOWN
+        );
 
         if (!$this->mContents) {
             echo '<p class="alert alert-danger">', t('No news feed available at the moment. Start commenting some profiles!'), '</p>';
@@ -116,7 +125,11 @@ class WallAjax extends Core
 
     private function add()
     {
-        $this->bStatus = $this->oWallModel->add($this->session->get('member_id'), $this->httpRequest->post('post'));
+        $this->bStatus = $this->oWallModel->add(
+            $this->session->get('member_id'),
+            $this->httpRequest->post('post')
+        );
+
         if (!$this->bStatus) {
             $this->sMsg = jsonMsg(0, t('Oops, your post could not be sent. Please try again later.'));
         } else {
@@ -128,7 +141,11 @@ class WallAjax extends Core
 
     private function edit()
     {
-        $this->bStatus = $this->oWallModel->edit($this->session->get('member_id'), $this->httpRequest->post('post'));
+        $this->bStatus = $this->oWallModel->edit(
+            $this->session->get('member_id'),
+            $this->httpRequest->post('post')
+        );
+
         if (!$this->bStatus) {
             $this->sMsg = jsonMsg(0, t('Oops, your post could not be saved. Please try again later.'));
         } else {
@@ -140,7 +157,11 @@ class WallAjax extends Core
 
     private function delete()
     {
-        $this->bStatus = $this->oWallModel->delete($this->session->get('member_id'), $this->httpRequest->post('post'));
+        $this->bStatus = $this->oWallModel->delete(
+            $this->session->get('member_id'),
+            $this->httpRequest->post('post')
+        );
+
         if (!$this->bStatus) {
             $this->sMsg = jsonMsg(0, t('Your post does not exist anymore.'));
         } else {

--- a/_protected/app/system/modules/user/assets/ajax/WallAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/WallAjax.php
@@ -173,7 +173,7 @@ class WallAjax extends Core
 
     private function badRequest()
     {
-        Http::setHeadersByCode(400);
+        Http::setHeadersByCode(StatusCode::BAD_REQUEST);
         exit('Bad Request Error!');
     }
 }

--- a/_protected/app/system/modules/user/assets/ajax/WallAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/WallAjax.php
@@ -15,6 +15,7 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Parse\Emoticon;
 use PH7\Framework\Parse\User as UserParser;
 use PH7\Framework\Security\Ban\Ban;
+use Teapot\StatusCode;
 
 class WallAjax extends Core
 {

--- a/_protected/app/system/modules/user/controllers/CountryController.php
+++ b/_protected/app/system/modules/user/controllers/CountryController.php
@@ -13,6 +13,7 @@ use PH7\Framework\Geo\Map\Map;
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Navigation\Page;
+use Teapot\StatusCode;
 
 class CountryController extends Controller
 {
@@ -56,7 +57,7 @@ class CountryController extends Controller
             $this->setMetaTags($iTotalUsers);
         } else {
             // Not found page
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
             $this->view->error = t('Error, country is empty.');
         }
 

--- a/_protected/app/system/modules/user/controllers/ProfileController.php
+++ b/_protected/app/system/modules/user/controllers/ProfileController.php
@@ -17,6 +17,7 @@ use PH7\Framework\Module\Various as SysMod;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Url\Header;
 use stdClass;
+use Teapot\StatusCode;
 
 class ProfileController extends ProfileBaseController
 {
@@ -215,7 +216,7 @@ class ProfileController extends ProfileBaseController
      */
     private function notFound()
     {
-        Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+        Http::setHeadersByCode(StatusCode::NOT_FOUND);
 
         /**
          * @internal We can include HTML tags in the title since the template will automatically escape them before displaying it.

--- a/_protected/app/system/modules/video/controllers/MainController.php
+++ b/_protected/app/system/modules/video/controllers/MainController.php
@@ -14,6 +14,7 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Url\Header;
+use Teapot\StatusCode;
 
 class MainController extends Controller
 {
@@ -294,7 +295,7 @@ class MainController extends Controller
     private function notFound($b404Status = true)
     {
         if ($b404Status === true) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $sErrMsg = '';

--- a/_protected/framework/Http/Http.class.php
+++ b/_protected/framework/Http/Http.class.php
@@ -196,7 +196,7 @@ class Http
 
         if (!($sAuthUsr === $sUsr && $sAuthPwd === $sPwd)) {
             header(sprintf('WWW-Authenticate: Basic realm="%s"', $sMsg));
-            static::setHeadersByCode(401);
+            static::setHeadersByCode(StatusCode::UNAUTHORIZED);
             echo t('You must enter a valid login ID and password to access this resource.') . "\n";
             exit(false);
         }

--- a/_protected/framework/Http/Http.class.php
+++ b/_protected/framework/Http/Http.class.php
@@ -14,11 +14,10 @@ namespace PH7\Framework\Http;
 defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Server\Server;
+use Teapot\StatusCode;
 
 class Http
 {
-    const HTTP_OK_CODE = 200;
-
     const STATUS_CODE = [
         100 => '100 Continue',
         101 => '101 Switching Protocols',
@@ -148,10 +147,10 @@ class Http
      *
      * @throws Exception
      */
-    public static function setHeadersByCode($iCode = self::HTTP_OK_CODE)
+    public static function setHeadersByCode($iCode = StatusCode::OK)
     {
         if (!static::getStatusCodes($iCode)) {
-            $iCode = self::HTTP_OK_CODE;
+            $iCode = StatusCode::OK;
         }
 
         // Set header

--- a/_protected/framework/Http/Rest/Rest.class.php
+++ b/_protected/framework/Http/Rest/Rest.class.php
@@ -18,6 +18,7 @@ use PH7\Framework\File\Stream;
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Str\Str;
+use Teapot\StatusCode;
 
 class Rest extends Http
 {
@@ -46,14 +47,15 @@ class Rest extends Http
      *
      * @return void
      */
-    public function response($sData, $iStatus = 200)
+    public function response($sData, $iStatus = StatusCode::OK)
     {
         $this->sData = $sData;
 
         /**
          * @internal Http::getStatusCodes() returns FALSE when it doesn't find any valid HTTP codes.
          */
-        $this->iCode = false !== static::getStatusCodes($iStatus) ? $iStatus : 500; // If it finds nothing, give 500 HTTP code.
+        // If it finds nothing, give 500 HTTP code
+        $this->iCode = false !== static::getStatusCodes($iStatus) ? $iStatus : StatusCode::INTERNAL_SERVER_ERROR;
         $this->output();
     }
 
@@ -94,7 +96,7 @@ class Rest extends Http
                 break;
 
             default:
-                $this->response('', 406);
+                $this->response('', StatusCode::NOT_ACCEPTABLE);
                 break;
         }
     }

--- a/_protected/framework/Layout/Gzip/Gzip.class.php
+++ b/_protected/framework/Layout/Gzip/Gzip.class.php
@@ -23,6 +23,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Layout\Optimization;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Navigation\Browser;
+use Teapot\StatusCode;
 
 class Gzip
 {
@@ -141,7 +142,7 @@ class Gzip
     public function run()
     {
         if (!$this->isValidStaticTypeFile()) {
-            Http::setHeadersByCode(503);
+            Http::setHeadersByCode(StatusCode::SERVICE_UNAVAILABLE);
             exit('Invalid file type!');
         }
 
@@ -149,7 +150,7 @@ class Gzip
 
         // Directory
         if (!$this->oHttpRequest->getExists('d')) {
-            Http::setHeadersByCode(503);
+            Http::setHeadersByCode(StatusCode::SERVICE_UNAVAILABLE);
             exit('No directory specified!');
         }
 
@@ -159,7 +160,7 @@ class Gzip
 
         // The Files
         if (!$this->oHttpRequest->getExists('f')) {
-            Http::setHeadersByCode(503);
+            Http::setHeadersByCode(StatusCode::SERVICE_UNAVAILABLE);
             exit('No file specified!');
         }
 
@@ -170,12 +171,12 @@ class Gzip
             $sPath = realpath($this->sBase . $sElement);
 
             if (!$this->isValidStaticFileExtension($sPath)) {
-                Http::setHeadersByCode(403);
+                Http::setHeadersByCode(StatusCode::FORBIDDEN);
                 exit('Invalid file extension!');
             }
 
             if (!$this->isSourceStaticFileExists($sPath)) {
-                Http::setHeadersByCode(404);
+                Http::setHeadersByCode(StatusCode::NOT_FOUND);
                 exit('File not found!');
             }
         }
@@ -235,7 +236,7 @@ class Gzip
             $oBrowser->cache();
 
             // Warning: following can cause problems (ERR_FILE_NOT_FOUND error)
-            // Http::setHeadersByCode(304); // Not Modified header
+            // Http::setHeadersByCode(StatusCode::NOT_MODIFIED); // Not Modified header
         }
 
         unset($oBrowser);
@@ -268,7 +269,7 @@ class Gzip
                 break;
 
             default:
-                Http::setHeadersByCode(503);
+                Http::setHeadersByCode(StatusCode::SERVICE_UNAVAILABLE);
                 exit('Invalid file type!');
         }
 

--- a/_protected/framework/Mvc/Controller/Controller.class.php
+++ b/_protected/framework/Mvc/Controller/Controller.class.php
@@ -34,10 +34,10 @@ use PH7\Framework\Security\DDoS\Stop as DDoSStoper;
 use PH7\FriendCoreModel;
 use PH7\MailCoreModel;
 use PH7\UserCore;
+use Teapot\StatusCode;
 
 abstract class Controller extends Core
 {
-    const HTTP_NOT_FOUND_CODE = 404;
     const MAINTENANCE_DURATION_SECONDS = 3600;
 
     public function __construct()
@@ -102,7 +102,7 @@ abstract class Controller extends Core
     public function displayPageNotFound($sMsg = '', $b404Status = true)
     {
         if ($b404Status) {
-            Http::setHeadersByCode(self::HTTP_NOT_FOUND_CODE);
+            Http::setHeadersByCode(StatusCode::NOT_FOUND);
         }
 
         $this->view->page_title = (!empty($sMsg)) ? t('%0% - Page Not Found', $sMsg) : t('Page Not Found');
@@ -137,7 +137,7 @@ abstract class Controller extends Core
     public function displayPageDenied($b403Status = true)
     {
         if ($b403Status) {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
         }
 
         $sTitle = t('Access Denied!');

--- a/_protected/framework/Mvc/Router/FrontController.class.php
+++ b/_protected/framework/Mvc/Router/FrontController.class.php
@@ -34,6 +34,7 @@ use PH7\Framework\Url\Header;
 use PH7\Framework\Url\Uri;
 use ReflectionException;
 use ReflectionMethod;
+use Teapot\StatusCode;
 
 /**
  * @class Singleton Class
@@ -507,7 +508,7 @@ final class FrontController
                 $this->notFound('Error while loading the Cron Jobs file<br />File: ' . PH7_PATH_SYS . 'core' . PH7_DS . 'assets' . PH7_DS . 'cron' . PH7_DS . $this->oUri->fragment(2) . PH7_DS . $this->oUri->fragment(3) . 'CoreCron.php does not exist', 1);
             }
         } else {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
             exit('Secret word is invalid for the cron hash!');
         }
     }

--- a/_protected/framework/Page/Page.class.php
+++ b/_protected/framework/Page/Page.class.php
@@ -14,6 +14,7 @@ defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Http\Http;
 use PH7\Framework\Navigation\Browser;
+use Teapot\StatusCode;
 
 class Page
 {
@@ -70,7 +71,7 @@ class Page
     public static function banned()
     {
         // Set the "forbidden" status code
-        Http::setHeadersByCode(403);
+        Http::setHeadersByCode(StatusCode::FORBIDDEN);
 
         // Inclusion of the HTML IP Banned page
         include PH7_PATH_SYS . 'global/' . PH7_VIEWS . PH7_DEFAULT_THEME . '/tpl/other/banned.html.php';
@@ -89,7 +90,7 @@ class Page
     public static function exception(\Exception $oExcept)
     {
         // Set 500 HTTP status code
-        Http::setHeadersByCode(500);
+        Http::setHeadersByCode(StatusCode::INTERNAL_SERVER_ERROR);
 
         // Prevent caching in the browser
         (new Browser)->noCache();
@@ -106,7 +107,7 @@ class Page
     public static function error500()
     {
         // Set 500 HTTP status code
-        Http::setHeadersByCode(500);
+        Http::setHeadersByCode(StatusCode::INTERNAL_SERVER_ERROR);
 
         // Prevent caching in the browser
         (new Browser)->noCache();

--- a/_repository/upgrade/12.9.0-12.9.7/data/file/protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
+++ b/_repository/upgrade/12.9.0-12.9.7/data/file/protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
@@ -15,7 +15,6 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Model\Design as DesignModel;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token;
-use Teapot\StatusCode;
 
 class AdsAjax
 {
@@ -59,7 +58,7 @@ class AdsAjax
                 break;
 
             default:
-                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
+                Http::setHeadersByCode(400);
                 exit('Bad Request Error');
         }
     }

--- a/_repository/upgrade/12.9.0-12.9.7/data/file/protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
+++ b/_repository/upgrade/12.9.0-12.9.7/data/file/protected/app/system/modules/admin123/assets/ajax/AdsAjax.php
@@ -15,6 +15,7 @@ use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Model\Design as DesignModel;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Security\CSRF\Token;
+use Teapot\StatusCode;
 
 class AdsAjax
 {
@@ -58,7 +59,7 @@ class AdsAjax
                 break;
 
             default:
-                Http::setHeadersByCode(400);
+                Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error');
         }
     }

--- a/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Controller/Controller.class.php
+++ b/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Controller/Controller.class.php
@@ -34,7 +34,6 @@ use PH7\Framework\Security\DDoS\Stop as DDoSStoper;
 use PH7\FriendCoreModel;
 use PH7\MailCoreModel;
 use PH7\UserCore;
-use Teapot\StatusCode;
 
 abstract class Controller extends Core
 {
@@ -138,7 +137,7 @@ abstract class Controller extends Core
     public function displayPageDenied($b403Status = true)
     {
         if ($b403Status) {
-            Http::setHeadersByCode(StatusCode::FORBIDDEN);
+            Http::setHeadersByCode(403);
         }
 
         $sTitle = t('Access Denied!');

--- a/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Controller/Controller.class.php
+++ b/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Controller/Controller.class.php
@@ -34,6 +34,7 @@ use PH7\Framework\Security\DDoS\Stop as DDoSStoper;
 use PH7\FriendCoreModel;
 use PH7\MailCoreModel;
 use PH7\UserCore;
+use Teapot\StatusCode;
 
 abstract class Controller extends Core
 {
@@ -137,7 +138,7 @@ abstract class Controller extends Core
     public function displayPageDenied($b403Status = true)
     {
         if ($b403Status) {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
         }
 
         $sTitle = t('Access Denied!');

--- a/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Router/FrontController.class.php
+++ b/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Router/FrontController.class.php
@@ -34,7 +34,6 @@ use PH7\Framework\Url\Header;
 use PH7\Framework\Url\Uri;
 use ReflectionException;
 use ReflectionMethod;
-use Teapot\StatusCode;
 
 /**
  * @class Singleton Class
@@ -508,7 +507,7 @@ final class FrontController
                 $this->notFound('Error while loading the Cron Jobs file<br />File: ' . PH7_PATH_SYS . 'core' . PH7_DS . 'assets' . PH7_DS . 'cron' . PH7_DS . $this->oUri->fragment(2) . PH7_DS . $this->oUri->fragment(3) . 'CoreCron.php does not exist', 1);
             }
         } else {
-            Http::setHeadersByCode(StatusCode::FORBIDDEN);
+            Http::setHeadersByCode(403);
             exit('Secret word is invalid for the cron hash!');
         }
     }

--- a/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Router/FrontController.class.php
+++ b/_repository/upgrade/12.9.7-12.9.8/data/file/protected/framework/Mvc/Router/FrontController.class.php
@@ -34,6 +34,7 @@ use PH7\Framework\Url\Header;
 use PH7\Framework\Url\Uri;
 use ReflectionException;
 use ReflectionMethod;
+use Teapot\StatusCode;
 
 /**
  * @class Singleton Class
@@ -507,7 +508,7 @@ final class FrontController
                 $this->notFound('Error while loading the Cron Jobs file<br />File: ' . PH7_PATH_SYS . 'core' . PH7_DS . 'assets' . PH7_DS . 'cron' . PH7_DS . $this->oUri->fragment(2) . PH7_DS . $this->oUri->fragment(3) . 'CoreCron.php does not exist', 1);
             }
         } else {
-            Http::setHeadersByCode(403);
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
             exit('Secret word is invalid for the cron hash!');
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-pdo_mysql": "*",
-        "braintree/braintree_php": "^3.27"
+        "braintree/braintree_php": "^3.27",
+        "shrikeh/teapot": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b477cb5aa5ad3bd566cff457a1b84d9d",
+    "content-hash": "bdc8dad31f458860b43ef8036ea28595",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -369,6 +369,56 @@
             "time": "2018-07-18T22:29:52+00:00"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "robthree/twofactorauth",
             "version": "1.6.5",
             "source": {
@@ -418,6 +468,59 @@
                 "tfa"
             ],
             "time": "2018-06-09T10:09:59+00:00"
+        },
+        {
+            "name": "shrikeh/teapot",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shrikeh/teapot.git",
+                "reference": "2fea5720963f22eedb920ee65b9d643bfa3e8daf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shrikeh/teapot/zipball/2fea5720963f22eedb920ee65b9d643bfa3e8daf",
+                "reference": "2fea5720963f22eedb920ee65b9d643bfa3e8daf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "psr/http-message": "^1.0",
+                "teapot/status-code": "^1.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.2",
+                "bossa/phpspec2-expect": "^2.0",
+                "escapestudios/symfony2-coding-standard": "^2.9",
+                "phpspec/phpspec": "~3.0.0",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Teapot\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barney Hanlon",
+                    "email": "barney@shrikeh.net"
+                },
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "PHP HTTP Response Status library",
+            "homepage": "https://shrikeh.github.io/teapot/",
+            "keywords": [
+                "http"
+            ],
+            "time": "2017-09-01T13:56:48+00:00"
         },
         {
             "name": "stripe/stripe-php",
@@ -527,6 +630,50 @@
                 "mailer"
             ],
             "time": "2018-01-23T07:37:21+00:00"
+        },
+        {
+            "name": "teapot/status-code",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/teapot-php/status-code.git",
+                "reference": "3f8e4cf0b185c1192dcf11ce4482380dcbd6e847"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/teapot-php/status-code/zipball/3f8e4cf0b185c1192dcf11ce4482380dcbd6e847",
+                "reference": "3f8e4cf0b185c1192dcf11ce4482380dcbd6e847",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "escapestudios/symfony2-coding-standard": "^3.0",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Teapot\\StatusCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barney Hanlon",
+                    "email": "barney@shrikeh.net"
+                }
+            ],
+            "description": "PHP HTTP Response Status code library",
+            "homepage": "http://shrikeh.github.com/teapot",
+            "keywords": [
+                "http"
+            ],
+            "time": "2018-01-15T19:17:51+00:00"
         }
     ],
     "packages-dev": [
@@ -1894,56 +2041,6 @@
                 "xunit"
             ],
             "time": "2017-06-30T09:13:00+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
* Use readable HTTP status constant names, instead of unclear HTTP codes.
* Replace the few pH7Framework's HTTP status constants with the Teapot's constants.
* Use the lightweight [Teapot Status Code library](https://github.com/teapot-php/status-code) to make these changes easily.