### PR TITLE
[Optimization] Check unwanted images only if set as auto-approved

### DIFF
--- a/_protected/app/system/modules/picture/forms/processing/AlbumFormProcess.php
+++ b/_protected/app/system/modules/picture/forms/processing/AlbumFormProcess.php
@@ -45,7 +45,7 @@ class AlbumFormProcess extends Form
         } else {
             $this->sApproved = DbConfig::getSetting('pictureManualApproval') == 0 ? '1' : '0';
 
-            if ($this->sApproved === '1') {
+            if ($this->isNudityFilterEligible()) {
                 $this->checkNudityFilter();
             }
 
@@ -87,11 +87,19 @@ class AlbumFormProcess extends Form
     }
 
     /**
+     * @return bool
+     */
+    private function isNudityFilterEligible()
+    {
+        return $this->sApproved === '1' && DbConfig::getSetting('nudityFilter');
+    }
+
+    /**
      * @return void
      */
     private function checkNudityFilter()
     {
-        if (DbConfig::getSetting('nudityFilter') && Filter::isNudity($_FILES['album']['tmp_name'])) {
+        if (Filter::isNudity($_FILES['album']['tmp_name'])) {
             // The photo doesn't seem suitable for everyone. Overwrite "$sApproved" and set for moderation
             $this->sApproved = '0';
         }

--- a/_protected/app/system/modules/picture/forms/processing/AlbumFormProcess.php
+++ b/_protected/app/system/modules/picture/forms/processing/AlbumFormProcess.php
@@ -45,7 +45,9 @@ class AlbumFormProcess extends Form
         } else {
             $this->sApproved = DbConfig::getSetting('pictureManualApproval') == 0 ? '1' : '0';
 
-            $this->checkNudityFilter();
+            if ($this->sApproved === '1') {
+                $this->checkNudityFilter();
+            }
 
             $sFileName = Various::genRnd($oPicture->getFileName(), 1) . '-thumb.' . $oPicture->getExt();
 

--- a/_protected/app/system/modules/picture/forms/processing/PictureFormProcess.php
+++ b/_protected/app/system/modules/picture/forms/processing/PictureFormProcess.php
@@ -117,7 +117,9 @@ class PictureFormProcess extends Form
 
             $this->sApproved = DbConfig::getSetting('pictureManualApproval') == 0 ? '1' : '0';
 
-            $this->checkNudityFilter($aPhotos[$iPhotoIndex]);
+            if ($this->sApproved === '1') {
+                $this->checkNudityFilter($aPhotos[$iPhotoIndex]);
+            }
 
             // It creates a nice title if no title is specified.
             $sTitle = $this->getImageTitle($iPhotoIndex, $oPicture1);

--- a/_protected/app/system/modules/picture/forms/processing/PictureFormProcess.php
+++ b/_protected/app/system/modules/picture/forms/processing/PictureFormProcess.php
@@ -117,7 +117,7 @@ class PictureFormProcess extends Form
 
             $this->sApproved = DbConfig::getSetting('pictureManualApproval') == 0 ? '1' : '0';
 
-            if ($this->sApproved === '1') {
+            if ($this->isNudityFilterEligible()) {
                 $this->checkNudityFilter($aPhotos[$iPhotoIndex]);
             }
 
@@ -153,13 +153,21 @@ class PictureFormProcess extends Form
     }
 
     /**
+     * @return bool
+     */
+    private function isNudityFilterEligible()
+    {
+        return $this->sApproved === '1' && DbConfig::getSetting('nudityFilter');
+    }
+
+    /**
      * @param string $sFile File path.
      *
      * @return void
      */
     private function checkNudityFilter($sFile)
     {
-        if (DbConfig::getSetting('nudityFilter') && Filter::isNudity($sFile)) {
+        if (Filter::isNudity($sFile)) {
             // The photo(s) seems to be suitable for adults only, so set for moderation
             $this->sApproved = '0';
         }

--- a/_protected/app/system/modules/user/forms/processing/AvatarFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/AvatarFormProcess.php
@@ -33,7 +33,10 @@ class AvatarFormProcess extends Form
             $sUsername = $this->session->get('member_username');
         }
 
-        $this->checkNudityFilter();
+        if ($this->iApproved === 1 || !AdminCore::auth()) {
+            $this->checkNudityFilter();
+        }
+
         $bAvatar = (new UserCore)->setAvatar($iProfileId, $sUsername, $_FILES['avatar']['tmp_name'], $this->iApproved);
 
         if (!$bAvatar) {

--- a/_protected/app/system/modules/user/forms/processing/AvatarFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/AvatarFormProcess.php
@@ -33,7 +33,7 @@ class AvatarFormProcess extends Form
             $sUsername = $this->session->get('member_username');
         }
 
-        if ($this->iApproved === 1 || !AdminCore::auth()) {
+        if ($this->isNudityFilterEligible()) {
             $this->checkNudityFilter();
         }
 
@@ -51,11 +51,19 @@ class AvatarFormProcess extends Form
     }
 
     /**
+     * @return bool
+     */
+    private function isNudityFilterEligible()
+    {
+        return ($this->iApproved === 1 || !AdminCore::auth()) && DbConfig::getSetting('nudityFilter');
+    }
+
+    /**
      * @return void
      */
     private function checkNudityFilter()
     {
-        if (DbConfig::getSetting('nudityFilter') && Filter::isNudity($_FILES['avatar']['tmp_name'])) {
+        if (Filter::isNudity($_FILES['avatar']['tmp_name'])) {
             // Avatar doesn't seem suitable for everyone. Overwrite "$iApproved" to set it for moderation
             $this->iApproved = 0;
         }

--- a/_protected/app/system/modules/user/forms/processing/DesignFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/DesignFormProcess.php
@@ -33,7 +33,7 @@ class DesignFormProcess extends Form
             $sUsername = $this->session->get('member_username');
         }
 
-        if ($this->iApproved === 1 || !AdminCore::auth()) {
+        if ($this->isNudityFilterEligible()) {
             $this->checkNudityFilter();
         }
 
@@ -50,11 +50,19 @@ class DesignFormProcess extends Form
     }
 
     /**
+     * @return bool
+     */
+    private function isNudityFilterEligible()
+    {
+        return ($this->iApproved === 1 || !AdminCore::auth()) && DbConfig::getSetting('nudityFilter');
+    }
+
+    /**
      * @return void
      */
     private function checkNudityFilter()
     {
-        if (DbConfig::getSetting('nudityFilter') && Filter::isNudity($_FILES['wallpaper']['tmp_name'])) {
+        if (Filter::isNudity($_FILES['wallpaper']['tmp_name'])) {
             // The wallpaper doesn't seem suitable for everyone. Overwrite "$iApproved" and set the image for approval
             $this->iApproved = 0;
         }

--- a/_protected/app/system/modules/user/forms/processing/DesignFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/DesignFormProcess.php
@@ -33,7 +33,9 @@ class DesignFormProcess extends Form
             $sUsername = $this->session->get('member_username');
         }
 
-        $this->checkNudityFilter();
+        if ($this->iApproved === 1 || !AdminCore::auth()) {
+            $this->checkNudityFilter();
+        }
 
         $bWallpaper = (new UserCore)->setBackground($iProfileId, $sUsername, $_FILES['wallpaper']['tmp_name'], $this->iApproved);
 

--- a/_protected/app/system/modules/video/forms/processing/AlbumFormProcess.php
+++ b/_protected/app/system/modules/video/forms/processing/AlbumFormProcess.php
@@ -44,7 +44,7 @@ class AlbumFormProcess extends Form
         } else {
             $this->sApproved = DbConfig::getSetting('videoManualApproval') == 0 ? '1' : '0';
 
-            if ($this->sApproved === '1') {
+            if ($this->isNudityFilterEligible()) {
                 $this->checkNudityFilter();
             }
 
@@ -86,9 +86,17 @@ class AlbumFormProcess extends Form
         }
     }
 
+    /**
+     * @return bool
+     */
+    private function isNudityFilterEligible()
+    {
+        return $this->sApproved === '1' && DbConfig::getSetting('nudityFilter');
+    }
+
     private function checkNudityFilter()
     {
-        if (DbConfig::getSetting('nudityFilter') && Filter::isNudity($_FILES['album']['tmp_name'])) {
+        if (Filter::isNudity($_FILES['album']['tmp_name'])) {
             // The image doesn't seem suitable for everyone. Overwrite "$sApproved" and set the image for approval
             $this->sApproved = '0';
         }

--- a/_protected/app/system/modules/video/forms/processing/AlbumFormProcess.php
+++ b/_protected/app/system/modules/video/forms/processing/AlbumFormProcess.php
@@ -44,7 +44,9 @@ class AlbumFormProcess extends Form
         } else {
             $this->sApproved = DbConfig::getSetting('videoManualApproval') == 0 ? '1' : '0';
 
-            $this->checkNudityFilter();
+            if ($this->sApproved === '1') {
+                $this->checkNudityFilter();
+            }
 
             $sFileName = Various::genRnd($oPicture->getFileName(), 1) . '-thumb.' . $oPicture->getExt();
 


### PR DESCRIPTION
* Use Nudity Detector only if photos haven't been already set to "moderation queue"
* Don't check if images may contain nudity when admins add/change Profile Wallpaper or Profile Photo.