### PR TITLE
[Admin Homepage] Add "Tips; Getting Started" section for new installations

### DIFF
--- a/_protected/app/system/modules/admin123/controllers/MainController.php
+++ b/_protected/app/system/modules/admin123/controllers/MainController.php
@@ -10,6 +10,7 @@
 
 namespace PH7;
 
+use PH7\Framework\Core\Kernel;
 use PH7\Framework\Layout\Html\Meta;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Router\Uri;
@@ -38,9 +39,9 @@ class MainController extends Controller
         $this->view->is_news_feed = (bool)DbConfig::getSetting('isSoftwareNewsFeed');
         $this->view->software_blog_url = self::SOFTWARE_BLOG_URL;
         $this->view->show_get_started_section = $this->isWebsiteNew();
+        $this->view->patreon_url = Kernel::PATREON_URL;
 
         $this->checkUpdates();
-
         $this->addStats();
 
         $this->output();

--- a/_protected/app/system/modules/admin123/controllers/MainController.php
+++ b/_protected/app/system/modules/admin123/controllers/MainController.php
@@ -344,7 +344,7 @@ class MainController extends Controller
     {
         $iSiteCreationDate = VDate::getTime(StatisticCoreModel::getDateOfCreation());
 
-        return VDate::setTime('-' . self::DURATION_SITE_CONSIDERED_NEW) >= $iSiteCreationDate;
+        return VDate::setTime('-' . self::DURATION_SITE_CONSIDERED_NEW) <= $iSiteCreationDate;
     }
 
     /**

--- a/_protected/app/system/modules/admin123/controllers/MainController.php
+++ b/_protected/app/system/modules/admin123/controllers/MainController.php
@@ -14,10 +14,12 @@ use PH7\Framework\Layout\Html\Meta;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Security\Version;
+use PH7\Framework\Date\Various as VDate;
 use PH7\Framework\Url\Header;
 
 class MainController extends Controller
 {
+    const DURATION_SITE_CONSIDERED_NEW = '15 days';
     const SOFTWARE_BLOG_URL = 'http://ph7cms.com/blog/';
 
     public function index()
@@ -35,6 +37,7 @@ class MainController extends Controller
 
         $this->view->is_news_feed = (bool)DbConfig::getSetting('isSoftwareNewsFeed');
         $this->view->software_blog_url = self::SOFTWARE_BLOG_URL;
+        $this->view->show_get_started_section = $this->isWebsiteNew();
 
         $this->checkUpdates();
 
@@ -332,6 +335,16 @@ class MainController extends Controller
 
             $this->design->setMessage($sMsg);
         }
+    }
+
+    /**
+     * @return bool
+     */
+    private function isWebsiteNew()
+    {
+        $iSiteCreationDate = VDate::getTime(StatisticCoreModel::getDateOfCreation());
+
+        return VDate::setTime('-' . self::DURATION_SITE_CONSIDERED_NEW) >= $iSiteCreationDate;
     }
 
     /**

--- a/_protected/app/system/modules/admin123/forms/SettingForm.php
+++ b/_protected/app/system/modules/admin123/forms/SettingForm.php
@@ -82,7 +82,7 @@ class SettingForm
         unset($oFile);
 
         /********** Logo Settings **********/
-        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><div class="content" id="logo"><div class="col-md-10"><h2 class="underline">' . t('Icon Logo') . '</h2>'));
+        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><div class="content" id="icon"><div class="col-md-10"><h2 class="underline">' . t('Icon Logo') . '</h2>'));
 
         $oForm->addElement(new \PFBC\Element\File('', 'logo', ['description' => t('Add your small logo/icon that represents/distinguishes the best your site/concept/brand.'), 'accept' => 'image/*']));
 
@@ -300,7 +300,7 @@ class SettingForm
 
         $oForm->addElement(new \PFBC\Element\Number(t('User inactivity timeout:'), 'user_timeout', ['description' => t('The number of minutes that a member becomes inactive (offline).'), 'value' => DbConfig::getSetting('userTimeout'), 'required' => 1]));
 
-        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><script src="' . PH7_URL_STATIC . PH7_JS . 'tabs.js"></script><script>tabs(\'p\', [\'general\',\'logo\',\'registration\',\'pic_vid\',\'moderation\',\'email\',\'security\',\'spam\',\'design\',\'api\',\'automation\']);</script>'));
+        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><script src="' . PH7_URL_STATIC . PH7_JS . 'tabs.js"></script><script>tabs(\'p\', [\'general\',\'icon\',\'registration\',\'pic_vid\',\'moderation\',\'email\',\'security\',\'spam\',\'design\',\'api\',\'automation\']);</script>'));
 
 
         $oForm->addElement(new \PFBC\Element\Button(t('Save'), 'submit', ['icon' => 'check']));

--- a/_protected/app/system/modules/admin123/forms/SettingForm.php
+++ b/_protected/app/system/modules/admin123/forms/SettingForm.php
@@ -82,7 +82,7 @@ class SettingForm
         unset($oFile);
 
         /********** Logo Settings **********/
-        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><div class="content" id="logotype"><div class="col-md-10"><h2 class="underline">' . t('Icon Logo') . '</h2>'));
+        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><div class="content" id="logo"><div class="col-md-10"><h2 class="underline">' . t('Icon Logo') . '</h2>'));
 
         $oForm->addElement(new \PFBC\Element\File('', 'logo', ['description' => t('Add your small logo/icon that represents/distinguishes the best your site/concept/brand.'), 'accept' => 'image/*']));
 
@@ -300,7 +300,7 @@ class SettingForm
 
         $oForm->addElement(new \PFBC\Element\Number(t('User inactivity timeout:'), 'user_timeout', ['description' => t('The number of minutes that a member becomes inactive (offline).'), 'value' => DbConfig::getSetting('userTimeout'), 'required' => 1]));
 
-        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><script src="' . PH7_URL_STATIC . PH7_JS . 'tabs.js"></script><script>tabs(\'p\', [\'general\',\'logotype\',\'registration\',\'pic_vid\',\'moderation\',\'email\',\'security\',\'spam\',\'design\',\'api\',\'automation\']);</script>'));
+        $oForm->addElement(new \PFBC\Element\HTMLExternal('</div></div><script src="' . PH7_URL_STATIC . PH7_JS . 'tabs.js"></script><script>tabs(\'p\', [\'general\',\'logo\',\'registration\',\'pic_vid\',\'moderation\',\'email\',\'security\',\'spam\',\'design\',\'api\',\'automation\']);</script>'));
 
 
         $oForm->addElement(new \PFBC\Element\Button(t('Save'), 'submit', ['icon' => 'check']));

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
@@ -1,49 +1,51 @@
 <div class="center">
-    <h2 class="underline">{lang 'Getting Started Smoothly'}</h2>
-    <p>{lang 'Welcome to your admin dashboard! You will find everything you need to customize and manage your website in here 🙂'}</p>
-    <p class="underline">{lang 'Below are a few steps to start well your webapp!'}</p>
+    <div class="border">
+        <h2 class="underline">{lang 'Getting Started Smoothly'}</h2>
+        <p>{lang 'Welcome to your admin dashboard! You will find everything you need to customize and manage your website in here 🙂'}</p>
+        <p class="underline">{lang 'Below are a few steps to start well your webapp!'}</p>
 
-    <ul>
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=general">
-                {lang 'General Useful Settings'}
-            </a>
-        </li>
+        <ul>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=general">
+                    {lang 'General Useful Settings'}
+                </a>
+            </li>
 
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'metamain') }}">
-                {lang 'Homepage texts and other site information'}
-            </a>
-        </li>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'metamain') }}">
+                    {lang 'Homepage texts and other site information'}
+                </a>
+            </li>
 
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">
-                {lang 'Icon Logo'}
-            </a>
-        </li>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">
+                    {lang 'Icon Logo'}
+                </a>
+            </li>
 
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">
-                {lang "Website's Color"}
-            </a>
-        </li>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">
+                    {lang "Website's Colors"}
+                </a>
+            </li>
 
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">
-                {lang 'Email Setting'}
-            </a>
-        </li>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">
+                    {lang 'Email Settings'}
+                </a>
+            </li>
 
-        <li>
-            <a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">
-                {lang 'Edit Static Pages'}
-            </a>
-        </li>
+            <li>
+                <a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">
+                    {lang 'Edit Static Pages'}
+                </a>
+            </li>
 
-        <li>
-            <a href="{patreon_url}" target="_blank" rel="noopener noreferrer">
-                {lang 'Become a Patron TODAY'}
-            </a> 🚀
-        </li>
-    </ul>
+            <li>
+                <a class="underline" href="{patreon_url}" target="_blank" rel="noopener noreferrer">
+                    {lang 'Become a Patron TODAY'}
+                </a> 🚀
+            </li>
+        </ul>
+    </div>
 </div>

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
@@ -9,7 +9,7 @@
         <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">{lang 'Icon Logo'}</a></li>
         <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">{lang "Website's Color"}</a></li>
         <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">{lang 'Email'}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">{lang 'Page'}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">{lang 'Edit Static Pages'}</a></li>
         <li><a href="{patreon_url}" target="_blank" rel="noopener noreferrer">{lang 'Become a Patron TODAY'}</a> 🚀</li>
     </ul>
 </div>

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
@@ -1,6 +1,7 @@
 <div class="center">
     <div class="border">
         <h2 class="underline">{lang 'Getting Started Smoothly'}</h2>
+
         <p>{lang 'Welcome to your admin dashboard! You will find everything you need to customize and manage your website in here 🙂'}</p>
         <p class="underline">{lang 'Below are a few steps to start well your webapp!'}</p>
 

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
@@ -1,15 +1,49 @@
 <div class="center">
-    <h2 class="underline">{lang 'Getting Started'}</h2>
+    <h2 class="underline">{lang 'Getting Started Smoothly'}</h2>
     <p>{lang 'Welcome to your admin dashboard! You will find everything you need to customize and manage your website in here 🙂'}</p>
     <p class="underline">{lang 'Below are a few steps to start well your webapp!'}</p>
 
     <ul>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=general">{lang 'General Useful Settings'}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'metamain') }}">{lang 'Homepage texts and other site information'}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">{lang 'Icon Logo'}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">{lang "Website's Color"}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">{lang 'Email'}</a></li>
-        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">{lang 'Edit Static Pages'}</a></li>
-        <li><a href="{patreon_url}" target="_blank" rel="noopener noreferrer">{lang 'Become a Patron TODAY'}</a> 🚀</li>
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=general">
+                {lang 'General Useful Settings'}
+            </a>
+        </li>
+
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'metamain') }}">
+                {lang 'Homepage texts and other site information'}
+            </a>
+        </li>
+
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">
+                {lang 'Icon Logo'}
+            </a>
+        </li>
+
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">
+                {lang "Website's Color"}
+            </a>
+        </li>
+
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">
+                {lang 'Email Setting'}
+            </a>
+        </li>
+
+        <li>
+            <a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">
+                {lang 'Edit Static Pages'}
+            </a>
+        </li>
+
+        <li>
+            <a href="{patreon_url}" target="_blank" rel="noopener noreferrer">
+                {lang 'Become a Patron TODAY'}
+            </a> 🚀
+        </li>
     </ul>
 </div>

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/get_started_intro.inc.tpl
@@ -1,0 +1,15 @@
+<div class="center">
+    <h2 class="underline">{lang 'Getting Started'}</h2>
+    <p>{lang 'Welcome to your admin dashboard! You will find everything you need to customize and manage your website in here 🙂'}</p>
+    <p class="underline">{lang 'Below are a few steps to start well your webapp!'}</p>
+
+    <ul>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=general">{lang 'General Useful Settings'}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'metamain') }}">{lang 'Homepage texts and other site information'}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=icon">{lang 'Icon Logo'}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=design">{lang "Website's Color"}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting', 'general') }}#p=email">{lang 'Email'}</a></li>
+        <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'file', 'pagedisplay') }}">{lang 'Page'}</a></li>
+        <li><a href="{patreon_url}" target="_blank" rel="noopener noreferrer">{lang 'Become a Patron TODAY'}</a> 🚀</li>
+    </ul>
+</div>

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/index.tpl
@@ -1,3 +1,8 @@
+{if $show_get_started_section}
+  {manual_include 'get_started_intro.inc.tpl'}
+{/if}
+
+
 {manual_include 'stat.tpl'}
 
 {if $is_news_feed}

--- a/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
@@ -1,6 +1,6 @@
 <ol id="toc">
     <li><a href="#general"><span>{lang 'General Settings'}</span></a></li>
-    <li><a href="#logo"><span>{lang 'Logo'}</span></a></li>
+    <li><a href="#icon"><span>{lang 'Logo'}</span></a></li>
     <li><a href="#registration"><span>{lang 'Registration'}</span></a></li>
     <li><a href="#pic_vid"><span>{lang 'Picture and Video'}</span></a></li>
     <li><a href="#moderation"><span>{lang 'Moderation'}</span></a></li>

--- a/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
@@ -17,7 +17,7 @@
     /* Check if the Setting page is loading from 'p=registration'
      * If so, scroll down to show the "Default Membership Group" first (this is used by the Payment module) */
     var sHash = location.hash.substr(1);
-    if (sHash == 'p=registration') {
+    if (sHash === 'p=registration') {
         var $target = $('html, body');
         $target.animate({scrollTop: $target.height()}, 1000);
     }

--- a/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/setting/general.tpl
@@ -1,6 +1,6 @@
 <ol id="toc">
     <li><a href="#general"><span>{lang 'General Settings'}</span></a></li>
-    <li><a href="#logotype"><span>{lang 'Logo'}</span></a></li>
+    <li><a href="#logo"><span>{lang 'Logo'}</span></a></li>
     <li><a href="#registration"><span>{lang 'Registration'}</span></a></li>
     <li><a href="#pic_vid"><span>{lang 'Picture and Video'}</span></a></li>
     <li><a href="#moderation"><span>{lang 'Moderation'}</span></a></li>

--- a/templates/themes/base/tpl/top_menu.inc.tpl
+++ b/templates/themes/base/tpl/top_menu.inc.tpl
@@ -279,7 +279,7 @@
         <li class="dropdown"><a href="{{ $design->url(PH7_ADMIN_MOD,'setting','index') }}" title="{lang 'Settings'}" class="dropdown-toggle" role="button" aria-expanded="false" data-toggle="dropdown"><i class="fa fa-cog fa-fw"></i> {lang 'Setting'} <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="{{ $design->url(PH7_ADMIN_MOD,'setting','index') }}" title="{lang 'General Settings'}"><i class="fa fa-tachometer"></i> {lang 'General'}</a></li>
-            <li><a href="{{ $design->url(PH7_ADMIN_MOD, 'setting','metamain') }}" title="{lang 'Meta Tags/Homepage Texts'}"><i class="fa fa-tag"></i> {lang 'Meta Tags/Homepage Texts'}</a></li>
+            <li><a href="{{ $design->url(PH7_ADMIN_MOD,'setting','metamain') }}" title="{lang 'Meta Tags/Homepage Texts'}"><i class="fa fa-tag"></i> {lang 'Meta Tags/Homepage Texts'}</a></li>
             <li><a href="{{ $design->url(PH7_ADMIN_MOD,'setting','ads') }}" title="{lang 'Add Banners on the best click-through-rate locations'}"><i class="fa fa-money"></i> {lang 'Ad Banners'}</a></li>
             <li><a href="{{ $design->url(PH7_ADMIN_MOD,'setting','analyticsapi') }}" title="{lang 'Analytics Code'}"><i class="fa fa-bar-chart"></i> {lang 'Analytics Code'}</a></li>
             <li><a href="{{ $design->url(PH7_ADMIN_MOD,'setting', 'style') }}" title="{lang 'Custom CSS Style'}"><i class="fa fa-code"></i> {lang 'Custom CSS'}</a></li>


### PR DESCRIPTION
 Add "Tips; Getting Started" section for new installations (new installations fewer than 15 days) in order to help new users to get started with the software's settings.

### How It Looks Like...
<img width="1034" alt="screen shot 2018-12-11 at 12 38 06 am" src="https://user-images.githubusercontent.com/1325411/49730399-1da31880-fcdd-11e8-9e4c-bc85106dd9d1.png">
