### PR TITLE
Store generic form string field length to constants

### DIFF
--- a/_protected/app/includes/classes/Form.php
+++ b/_protected/app/includes/classes/Form.php
@@ -17,6 +17,9 @@ class Form extends Framework\Layout\Form\Form
 {
     use Framework\Layout\Form\Message;
 
+    const MIN_STRING_FIELD_LENGTH = 2;
+    const MAX_STRING_FIELD_LENGTH = 200;
+
     /**
      * To get Value Data from the database.
      *

--- a/_protected/app/system/modules/admin123/forms/MetaMainForm.php
+++ b/_protected/app/system/modules/admin123/forms/MetaMainForm.php
@@ -43,13 +43,13 @@ class MetaMainForm
 
         $oForm->addElement(new \PFBC\Element\Textbox(t('Headline:'), 'headline', ['description' => t('Right headline mainly displaying on the visitors homepage'), 'value' => $oMeta->headline, 'validation' => new \PFBC\Validation\Str(2, 50), 'required' => 1]));
 
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['description' => t('Left slogan (headline) mainly displaying on the visitors homepage'), 'value' => $oMeta->slogan, 'validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['description' => t('Left slogan (headline) mainly displaying on the visitors homepage'), 'value' => $oMeta->slogan, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
 
         $oForm->addElement(new \PFBC\Element\CKEditor(t('SEO text:'), 'promo_text', ['description' => t('Promotional text displaying on the visitors homepage.'), 'value' => $oMeta->promoText, 'required' => 1]));
 
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['value' => $oMeta->metaDescription, 'validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['value' => $oMeta->metaDescription, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
 
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'value' => $oMeta->metaKeywords, 'validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'value' => $oMeta->metaKeywords, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
 
         $oForm->addElement(new \PFBC\Element\Textbox(t('Robots (meta tag):'), 'meta_robots', ['value' => $oMeta->metaRobots, 'validation' => new \PFBC\Validation\Str(2, 50), 'required' => 1]));
 

--- a/_protected/app/system/modules/blog/forms/AdminBlogForm.php
+++ b/_protected/app/system/modules/blog/forms/AdminBlogForm.php
@@ -68,12 +68,12 @@ class AdminBlogForm
         $oForm->addElement(new \PFBC\Element\HTMLExternal('</div>'));
         $oForm->addElement(new \PFBC\Element\CKEditor(t('Body:'), 'content', ['validation' => new \PFBC\Validation\Str(30), 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Language of the article:'), 'lang_id', ['description' => t('e.g., "en", "fr", "es", "js"'), 'value' => PH7_LANG_CODE, 'pattern' => '[a-z]{2}', 'validation' => new \PFBC\Validation\Str(2, 2), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['validation' => new \PFBC\Validation\Str(2, 190)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
         $oForm->addElement(new \PFBC\Element\File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Title (meta tag):'), 'page_title', ['validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(2, 190)]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Title (meta tag):'), 'page_title', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Robots (meta tag):'), 'meta_robots', ['validation' => new \PFBC\Validation\Str(2, 50)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Author (meta tag):'), 'meta_author', ['validation' => new \PFBC\Validation\Str(2, 50)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Copyright (meta tag):'), 'meta_copyright', ['validation' => new \PFBC\Validation\Str(2, 50)]));

--- a/_protected/app/system/modules/blog/forms/EditAdminBlogForm.php
+++ b/_protected/app/system/modules/blog/forms/EditAdminBlogForm.php
@@ -90,7 +90,7 @@ class EditAdminBlogForm
             $oForm->addElement(new \PFBC\Element\HTMLExternal('</div>'));
             $oForm->addElement(new \PFBC\Element\CKEditor(t('Body:'), 'content', ['value' => $oPost->content, 'validation' => new \PFBC\Validation\Str(30), 'required' => 1]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Language of your article:'), 'lang_id', ['value' => $oPost->langId, 'description' => t('e.g., "en", "fr", "es", "jp"'), 'pattern' => '[a-z]{2}', 'validation' => new \PFBC\Validation\Str(2, 2), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['value' => $oPost->slogan, 'validation' => new \PFBC\Validation\Str(2, 190)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['value' => $oPost->slogan, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
             $oForm->addElement(new \PFBC\Element\File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
             $oForm->addElement(new \PFBC\Element\HTMLExternal('<p><br /><img src="' . Blog::getThumb($oPost->blogId) . '" alt="' . t('Thumbnail') . '" title="' . t('The current thumbnail of your post.') . '" class="avatar" /></p>'));
 
@@ -102,10 +102,10 @@ class EditAdminBlogForm
                 ));
             }
 
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['value' => $oPost->tags, 'description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['value' => $oPost->tags, 'description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Title (meta tag):'), 'page_title', ['value' => $oPost->pageTitle, 'validation' => new \PFBC\Validation\Str(2, 100), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['value' => $oPost->metaDescription, 'validation' => new \PFBC\Validation\Str(2, 190)]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'value' => $oPost->metaKeywords, 'validation' => new \PFBC\Validation\Str(2, 190)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['value' => $oPost->metaDescription, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas.'), 'value' => $oPost->metaKeywords, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Robots (meta tag):'), 'meta_robots', ['value' => $oPost->metaRobots, 'validation' => new \PFBC\Validation\Str(2, 50)]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Author (meta tag):'), 'meta_author', ['value' => $oPost->metaAuthor, 'validation' => new \PFBC\Validation\Str(2, 50)]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Copyright (meta tag):'), 'meta_copyright', ['value' => $oPost->metaCopyright, 'validation' => new \PFBC\Validation\Str(2, 50)]));

--- a/_protected/app/system/modules/game/forms/AdminEditForm.php
+++ b/_protected/app/system/modules/game/forms/AdminEditForm.php
@@ -49,8 +49,8 @@ class AdminEditForm
             $oForm->addElement(new \PFBC\Element\Select(t('Category Name:'), 'category_id', $aCategoriesName, ['value' => $oGame->categoryId, 'required' => 1]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Name of the Game:'), 'name', ['value' => $oGame->name, 'pattern' => $sTitlePattern, 'validation' => new \PFBC\Validation\RegExp($sTitlePattern), 'required' => 1]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Title of the Game:'), 'title', ['value' => $oGame->title, 'validation' => new \PFBC\Validation\Str(2, 120), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Description:'), 'description', ['value' => $oGame->description, 'validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords:'), 'keywords', ['value' => $oGame->keywords, 'validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Description:'), 'description', ['value' => $oGame->description, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords:'), 'keywords', ['value' => $oGame->keywords, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
             $oForm->addElement(new \PFBC\Element\Button);
             $oForm->render();
         } else {

--- a/_protected/app/system/modules/game/forms/AdminForm.php
+++ b/_protected/app/system/modules/game/forms/AdminForm.php
@@ -41,8 +41,8 @@ class AdminForm
         $oForm->addElement(new \PFBC\Element\Select(t('Category Name:'), 'category_id', $aCategoriesName, ['required' => 1]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Name of the Game:'), 'name', ['pattern' => $sTitlePattern, 'validation' => new \PFBC\Validation\RegExp($sTitlePattern), 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Title of the Game:'), 'title', ['validation' => new \PFBC\Validation\Str(2, 120), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Description:'), 'description', ['validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords:'), 'keywords', ['validation' => new \PFBC\Validation\Str(2, 190), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Description:'), 'description', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords:'), 'keywords', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\File(t('Thumbnail of the Game:'), 'thumb', ['accept' => 'image/*', 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\File(t('File of the Game:'), 'file', ['accept' => 'application/x-shockwave-flash', 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\Button);

--- a/_protected/app/system/modules/note/forms/EditNoteForm.php
+++ b/_protected/app/system/modules/note/forms/EditNoteForm.php
@@ -96,7 +96,7 @@ class EditNoteForm
             $oForm->addElement(new \PFBC\Element\HTMLExternal('</div>'));
             $oForm->addElement(new \PFBC\Element\CKEditor(t('Body:'), 'content', ['value' => $oPost->content, 'validation' => new \PFBC\Validation\Str(30), 'required' => 1]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Language of your post:'), 'lang_id', ['value' => $oPost->langId, 'description' => t('e.g., "en", "fr", "es", "js"'), 'pattern' => '[a-z]{2}', 'validation' => new \PFBC\Validation\Str(2, 2), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['value' => $oPost->slogan, 'validation' => new \PFBC\Validation\Str(2, 190)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['value' => $oPost->slogan, 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
             $oForm->addElement(new \PFBC\Element\File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
 
             if (!empty($oPost->thumb)) {
@@ -104,10 +104,10 @@ class EditNoteForm
                 $oForm->addElement(new \PFBC\Element\HTMLExternal('<a href="' . Uri::get('note', 'main', 'removethumb', $oPost->noteId . (new Token)->url(), false) . '">' . t('Remove this thumbnail?') . '</a>'));
             }
 
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['value' => $oPost->tags, 'description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['value' => $oPost->tags, 'description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Title (meta tag):'), 'page_title', ['value' => $oPost->pageTitle, 'validation' => new \PFBC\Validation\Str(2, 100), 'required' => 1]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(2, 190), 'value' => $oPost->metaDescription]));
-            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190), 'value' => $oPost->metaKeywords]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'value' => $oPost->metaDescription]));
+            $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH), 'value' => $oPost->metaKeywords]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Robots (meta tag):'), 'meta_robots', ['validation' => new \PFBC\Validation\Str(2, 50), 'value' => $oPost->metaRobots]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Author (meta tag):'), 'meta_author', ['validation' => new \PFBC\Validation\Str(2, 50), 'value' => $oPost->metaAuthor]));
             $oForm->addElement(new \PFBC\Element\Textbox(t('Copyright (meta tag):'), 'meta_copyright', ['validation' => new \PFBC\Validation\Str(2, 50), 'value' => $oPost->metaCopyright]));

--- a/_protected/app/system/modules/note/forms/NoteForm.php
+++ b/_protected/app/system/modules/note/forms/NoteForm.php
@@ -71,12 +71,12 @@ class NoteForm
         $oForm->addElement(new \PFBC\Element\HTMLExternal('</div>'));
         $oForm->addElement(new \PFBC\Element\CKEditor(t('Body:'), 'content', ['validation' => new \PFBC\Validation\Str(30), 'required' => 1]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Language of the post:'), 'lang_id', ['description' => t('e.g., "en", "fr", "es", "js"'), 'value' => PH7_LANG_CODE, 'pattern' => '[a-z]{2}', 'validation' => new \PFBC\Validation\Str(2, 2), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['validation' => new \PFBC\Validation\Str(2, 190)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Slogan:'), 'slogan', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
         $oForm->addElement(new \PFBC\Element\File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Tags:'), 'tags', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Title (meta tag):'), 'page_title', ['validation' => new \PFBC\Validation\Str(2, 100), 'required' => 1]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(2, 190)]));
-        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(2, 190)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Description (meta tag):'), 'meta_description', ['validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
+        $oForm->addElement(new \PFBC\Element\Textbox(t('Keywords (meta tag):'), 'meta_keywords', ['description' => t('Separate keywords by commas and without spaces between the commas.'), 'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Robots (meta tag):'), 'meta_robots', ['validation' => new \PFBC\Validation\Str(2, 50)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Author (meta tag):'), 'meta_author', ['validation' => new \PFBC\Validation\Str(2, 50)]));
         $oForm->addElement(new \PFBC\Element\Textbox(t('Copyright (meta tag):'), 'meta_copyright', ['validation' => new \PFBC\Validation\Str(2, 50)]));

--- a/_protected/app/system/modules/picture/forms/AlbumForm.php
+++ b/_protected/app/system/modules/picture/forms/AlbumForm.php
@@ -45,7 +45,7 @@ class AlbumForm
                 t('Album Cover Description:'),
                 'description',
                 [
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/picture/forms/EditAlbumForm.php
+++ b/_protected/app/system/modules/picture/forms/EditAlbumForm.php
@@ -57,7 +57,7 @@ class EditAlbumForm
                 'description',
                 [
                     'value' => $oAlbum->description,
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/picture/forms/EditPictureForm.php
+++ b/_protected/app/system/modules/picture/forms/EditPictureForm.php
@@ -61,7 +61,7 @@ class EditPictureForm
                 'description',
                 [
                     'value' => $oPhoto->description,
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/picture/forms/PictureForm.php
+++ b/_protected/app/system/modules/picture/forms/PictureForm.php
@@ -82,7 +82,7 @@ class PictureForm
                 t('Description for your photo(s):'),
                 'description',
                 [
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/video/forms/AlbumForm.php
+++ b/_protected/app/system/modules/video/forms/AlbumForm.php
@@ -45,7 +45,7 @@ class AlbumForm
                 t('Album Cover Description:'),
                 'description',
                 [
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/video/forms/EditAlbumForm.php
+++ b/_protected/app/system/modules/video/forms/EditAlbumForm.php
@@ -57,7 +57,7 @@ class EditAlbumForm
                 'description',
                 [
                     'value' => $oAlbum->description,
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/video/forms/EditVideoForm.php
+++ b/_protected/app/system/modules/video/forms/EditVideoForm.php
@@ -61,7 +61,7 @@ class EditVideoForm
                 'description',
                 [
                     'value' => $oVideo->description,
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/video/forms/VideoForm.php
+++ b/_protected/app/system/modules/video/forms/VideoForm.php
@@ -118,7 +118,7 @@ class VideoForm
                 t('Video Description:'),
                 'description',
                 [
-                    'validation' => new \PFBC\Validation\Str(2, 190)
+                    'validation' => new \PFBC\Validation\Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
                 ]
             )
         );


### PR DESCRIPTION
Avoid having some generic string field lengths hardcoded in forms. Store them into constants, in Form's class.