### PR TITLE
Protect users passwords on failed attempt

### DIFF
--- a/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
@@ -76,7 +76,7 @@ class LoginFormProcess extends Form implements LoginableForm
                 $oSecurityModel->addLoginLog(
                     $sEmail,
                     'Guest',
-                    $sPassword,
+                    '*****',
                     'Failed! Incorrect Password'
                 );
 


### PR DESCRIPTION
Change is to stop password from being logged in database in clear text. If a user enters wrong password currently that password is stored in clear text in the database in TABLE: members_users_login. This is bad practice since, say the user forgets his password and tries a few of his regular passwords for other websites. The user has unknowingly stored a legitimate password and email address in a database and doesn't even know what has gone on.