### PR TITLE
Removed duplicate column

### DIFF
--- a/_install/data/sql/MySQL/pH7_Core.sql
+++ b/_install/data/sql/MySQL/pH7_Core.sql
@@ -333,7 +333,6 @@ CREATE TABLE IF NOT EXISTS ph7_pictures (
   description varchar(191) DEFAULT NULL,
   file varchar(40) NOT NULL,
   file_cdn_url varchar(40) NOT NULL,
-  file_cdn_url varchar(40) NOT NULL,
   approved enum('1','0') DEFAULT '1',
   votes int(9) unsigned DEFAULT 0,
   score float(9) unsigned DEFAULT 0,


### PR DESCRIPTION
There is a duplicate column on ph7_pictures table in /_install/data/sql/MySQL/pH7_Core.sql
This was breaking the installation
#948