### PR TITLE
Fixed bug in login procedure

### DIFF
--- a/_protected/app/system/modules/admin123/forms/processing/LoginFormProcess.php
+++ b/_protected/app/system/modules/admin123/forms/processing/LoginFormProcess.php
@@ -124,8 +124,8 @@ class LoginFormProcess extends Form implements LoginableForm
      */
     public function updatePwdHashIfNeeded(string $sPassword, string $sUserPasswordHash, string $sEmail): void
     {
-        if ($sNewPwdHash = Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
-            $this->oAdminModel->changePassword($sEmail, $sNewPwdHash, DbTableName::ADMIN);
+        if (Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
+            $this->oAdminModel->changePassword($sEmail, $sPassword, DbTableName::ADMIN);
         }
     }
 

--- a/_protected/app/system/modules/affiliate/forms/processing/LoginFormProcess.php
+++ b/_protected/app/system/modules/affiliate/forms/processing/LoginFormProcess.php
@@ -126,8 +126,8 @@ class LoginFormProcess extends Form implements LoginableForm
      */
     public function updatePwdHashIfNeeded(string $sPassword, string $sUserPasswordHash, string $sEmail): void
     {
-        if ($sNewPwdHash = Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
-            $this->oAffModel->changePassword($sEmail, $sNewPwdHash, DbTableName::AFFILIATE);
+        if (Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
+            $this->oAffModel->changePassword($sEmail, $sPassword, DbTableName::AFFILIATE);
         }
     }
 

--- a/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
@@ -161,8 +161,8 @@ class LoginFormProcess extends Form implements LoginableForm
      */
     public function updatePwdHashIfNeeded(string $sPassword, string $sUserPasswordHash, string $sEmail): void
     {
-        if ($sNewPwdHash = Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
-            $this->oUserModel->changePassword($sEmail, $sNewPwdHash, DbTableName::MEMBER);
+        if (Security::pwdNeedsRehash($sPassword, $sUserPasswordHash)) {
+            $this->oUserModel->changePassword($sEmail, $sPassword, DbTableName::MEMBER);
         }
     }
 

--- a/_protected/framework/Security/Security.class.php
+++ b/_protected/framework/Security/Security.class.php
@@ -79,7 +79,7 @@ final class Security
     public static function pwdNeedsRehash($sPassword, $sHash)
     {
         if (password_needs_rehash($sHash, self::PWD_ALGORITHM, self::$aPwdOptions)) {
-            return self::hashPwd($sPassword);
+            return true;
         }
 
         return false;

--- a/_protected/framework/Security/Security.class.php
+++ b/_protected/framework/Security/Security.class.php
@@ -74,7 +74,7 @@ final class Security
      * @param string $sPassword
      * @param string $sHash
      *
-     * @return string|bool Returns the new password if the password needs to be rehash, otherwise FALSE
+     * @return bool Returns TRUE if the password needs to be rehash, otherwise FALSE
      */
     public static function pwdNeedsRehash($sPassword, $sHash)
     {


### PR DESCRIPTION
Fix the bug in the login procedure:
Every time users log in, the password changes automatically, causing the user to not be able to log in 2nd time.

In the original code, this is what happens:
When user logs in, the `updatePwdHashIfNeeded` function in `LoginFormsProcess` is called.
That function then calls `pwdNeedsRehash` function to check if the password needs rehash, and if so, receives
new password hash.
That password hash then is sent to `changePassword` function as an argument in the `UserCoreModel`.

The `changePassword` function then takes the password hash as an argument instead of the password itself and runs this code:
`$rStmt->bindValue(':newPassword', Security::hashPwd($sNewPassword), PDO::PARAM_STR);`, which decrypts the already password hash instead of decrypting the password itself.

There is nothing wrong with `changePassword`. But the `changePassword` shouldn't get password hash, but the password itself is an argument. Which in current code wasn't the case, which caused the password to be changed without any intention. So, I made some changes to fix this bug.

To fix this, I changed the following:
- `pwdNeedsRehash` function on Security.class.php changed: instead of returning the password hash, it just returns TRUE or FALSE.
- `updatePwdHashIfNeeded` function on LoginFormProcess changed: instead of sending the password hash as arugment, it sends the password itself as argument to the `changePassword` function. I changed the "if" statement as there is no need to save TRUE or FALSE value returned from pwdNeedsRehash function on Security.class.php.

I controlled where the `pwdNeedsRehash` function is used, and my changes don't break any other parts of the project.