### PR TITLE
Harden security boundaries across user-controlled workflows

### DIFF
--- a/_install/data/sql/MySQL/pH7_Core.sql
+++ b/_install/data/sql/MySQL/pH7_Core.sql
@@ -1035,7 +1035,7 @@ INSERT INTO ph7_settings (settingName, settingValue, description, settingGroup) 
 ('watermarkTextImage', 'pH7Builder.com', 'Watermark text', 'image'),
 ('sizeWatermarkTextImage', 2, 'Between 0 to 5', 'image'),
 ('banWordReplace', '[removed]',  '',  'security'),
-('securityToken', 0, '0 to disable or 1 to enable the CSRF security token in the forms', 'security'),
+('securityToken', 1, 'Legacy compatibility flag; CSRF security tokens are always enabled', 'security'),
 ('securityTokenLifetime', 720, 'Time in seconds to the CSRF security token. Default 720 seconds (12 mins)', 'security'),
 ('DDoS', 0,  '0 to disabled or 1 to enabled DDoS attack protection',  'security'),
 ('isSiteValidated', 0,  '0 = site not validated | 1 = site validated',  'security'),

--- a/_install/data/sql/PostgreSQL/pH7_Core.sql
+++ b/_install/data/sql/PostgreSQL/pH7_Core.sql
@@ -1194,7 +1194,7 @@ INSERT INTO ph7_settings (settingName, settingValue, description, settingGroup) 
 ('watermarkTextImage', 'pH7Builder.com', 'Watermark text', 'image'),
 ('sizeWatermarkTextImage', 2, 'Between 0 to 5', 'image'),
 ('banWordReplace', '[removed]',  '',  'security'),
-('securityToken', 0, '0 to disable or 1 to enable the CSRF security token in the forms', 'security'),
+('securityToken', 1, 'Legacy compatibility flag; CSRF security tokens are always enabled', 'security'),
 ('securityTokenLifetime', 720, 'Time in seconds to the CSRF security token. Default 720 seconds (12 mins)', 'security'),
 ('DDoS', 0,  '0 to disabled or 1 to enabled DDoS attack protection',  'security'),
 ('isSiteValidated', 0,  '0 = site not validated | 1 = site validated',  'security'),

--- a/_protected/app/Bootstrap.php
+++ b/_protected/app/Bootstrap.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2023, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @link           https://ph7builder.com
- * @package        PH7 / App / Core
+ *
+ * @see           https://ph7builder.com
  */
 
 declare(strict_types=1);
@@ -13,7 +14,6 @@ namespace PH7;
 
 defined('PH7') or exit('Restricted access');
 
-use Exception;
 use PH7\App\Includes\Classes\Loader\Autoloader as AppLoader;
 use PH7\Framework\Config\Config;
 use PH7\Framework\Config\FileNotFoundException;
@@ -34,17 +34,22 @@ class Bootstrap
     /**
      * Set constructor/cloning to private since it's a singleton class.
      */
-    private function __construct() {}
-    private function __clone() {}
+    private function __construct()
+    {
+    }
+
+    private function __clone()
+    {
+    }
 
     /**
      * Get instance of class.
      *
-     * @return Bootstrap Returns the instance class or create initial instance of the class.
+     * @return Bootstrap returns the instance class or create initial instance of the class
      */
     public static function getInstance(): self
     {
-        return null === self::$oInstance ? self::$oInstance = new self : self::$oInstance;
+        return null === self::$oInstance ? self::$oInstance = new self() : self::$oInstance;
     }
 
     /**
@@ -60,7 +65,7 @@ class Bootstrap
     /**
      * Initialize the app, load the files and launch the main FrontController router.
      *
-     * @throws Exception
+     * @throws \Exception
      * @throws Except\PH7Exception
      * @throws Except\UserException
      * @throws FileNotFoundException
@@ -70,16 +75,16 @@ class Bootstrap
         try {
             $this->loadInitFiles();
 
-            //** Temporary code. In the near future, pH7Builder will be working without mod_rewrite
+            // ** Temporary code. In the near future, pH7Builder will be working without mod_rewrite
             if (!Server::cachedIsRewriteMod()) {
                 $this->notRewriteModEnabledError();
                 exit;
-            }  //*/
+            }  // */
 
             // Enable client browser cache
-            (new Browser)->cache();
+            (new Browser())->cache();
 
-            new Server; // Start Server
+            new Server(); // Start Server
 
             $this->startPageBenchmark();
             // Framework\Compress\Compress::enableZlipCompression();
@@ -87,10 +92,10 @@ class Bootstrap
             // Initialize the FrontController, we are asking the front controller to process the HTTP request
             FrontController::getInstance()->runRouter();
         } catch (FileNotFoundException|Except\UserException $oE) {
-            echo $oE->getMessage();
+            echo htmlspecialchars($oE->getMessage(), ENT_QUOTES, PH7_ENCODING);
         } catch (Except\PH7Exception $oE) {
             Except\PH7Exception::launch($oE);
-        } catch (Exception $oE) {
+        } catch (\Exception $oE) {
             Except\PH7Exception::launch($oE);
         } finally {
             $this->closeAppSession();
@@ -106,7 +111,7 @@ class Bootstrap
         require PH7_PATH_FRAMEWORK . 'Loader/Autoloader.php';
         FrameworkLoader::getInstance()->init();
 
-        /** Loading configuration files environments **/
+        /* Loading configuration files environments * */
         // For All environment
         Import::file(PH7_PATH_APP . 'configs/environment/all.env');
         // Specific to the current environment
@@ -131,7 +136,7 @@ class Bootstrap
     }
 
     /**
-     * Initialize the benchmark time. It is calculated in Framework\Layout\Html\Design::stat()
+     * Initialize the benchmark time. It is calculated in Framework\Layout\Html\Design::stat().
      */
     private function startPageBenchmark(): void
     {
@@ -151,7 +156,7 @@ class Bootstrap
     /**
      * Display an error message if the Apache mod_rewrite is not enabled.
      *
-     * @return void HTML output.
+     * @return void HTML output
      */
     private function notRewriteModEnabledError(): void
     {

--- a/_protected/app/includes/classes/Controller.php
+++ b/_protected/app/includes/classes/Controller.php
@@ -1,16 +1,15 @@
 <?php
+
 /**
  * @author           Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright        (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / App / Include / Class
  */
 
 namespace PH7;
 
 use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Mvc\Controller\Controller as FwkController;
-use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Url\Header;
@@ -36,11 +35,7 @@ abstract class Controller extends FwkController
 
     private function requireUrlToken(string $sUrl): void
     {
-        if (!(bool)DbConfig::getSetting('securityToken')) {
-            return;
-        }
-
-        if ((new Token)->check(Token::getNameFromUrl($sUrl))) {
+        if ((new Token())->check(Token::getNameFromUrl($sUrl))) {
             return;
         }
 

--- a/_protected/app/system/core/assets/ajax/LikeCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/LikeCoreAjax.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @desc           Simple Like Page Ajax Class.
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2022, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Asset / Ajax
+ *
  * @version        1.2
  */
 
@@ -13,8 +14,11 @@ namespace PH7;
 
 defined('PH7') or exit('Restricted access');
 
+use PH7\Framework\Http\Http;
 use PH7\Framework\Ip\Ip;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
+use PH7\Framework\Security\CSRF\Token;
+use PH7\JustHttp\StatusCode;
 
 class LikeCoreAjax
 {
@@ -34,9 +38,9 @@ class LikeCoreAjax
 
     public function __construct()
     {
-        $this->oHttpRequest = new HttpRequest;
+        $this->oHttpRequest = new HttpRequest();
 
-        ($this->oHttpRequest->postExists('key') ? $this->initialize() : exit('-1'));
+        $this->oHttpRequest->postExists('key') ? $this->initialize() : exit('-1');
     }
 
     /**
@@ -48,7 +52,13 @@ class LikeCoreAjax
             nt('You and one other have voted for this!', 'You and %n% other people have voted for this!', static::$iVotesLike - 1) :
             t("Congrats! You're the first one!");
 
-        return '{"votes":' . static::$iVotesLike . ',"txt":"' . $sTxt . '"}';
+        return json_encode(
+            [
+                'votes' => static::$iVotesLike,
+                'txt' => $sTxt
+            ],
+            JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
     }
 
     /**
@@ -56,10 +66,16 @@ class LikeCoreAjax
      */
     private function initialize(): void
     {
-        $this->oLikeModel = new LikeCoreModel;
+        $this->oLikeModel = new LikeCoreModel();
         $this->sKey = $this->oHttpRequest->post('key');
         $this->iVote = (int)$this->oHttpRequest->post('vote');
         $this->sLastIp = Ip::get();
+
+        if ($this->iVote === 1 && (!UserCore::auth() || !(new Token())->checkUrl())) {
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
+            exit('Forbidden');
+        }
+
         $this->select();
     }
 
@@ -85,21 +101,11 @@ class LikeCoreAjax
     }
 
     /**
-     * Check the permissions so only members can like, but you can disable this check so even visitors will be able to like pages.
-     *
-     * @return bool Returns true if the user is connected, false otherwise.
-     */
-    private function checkPerm(): bool
-    {
-        return UserCore::auth();
-    }
-
-    /**
      * Adds voting into the database and increment the static vote attribute.
      */
     private function insert(): void
     {
-        static::$iVotesLike++;
+        ++static::$iVotesLike;
         $this->oLikeModel->insert($this->sKey, $this->sLastIp);
     }
 
@@ -108,16 +114,16 @@ class LikeCoreAjax
      */
     private function update(): void
     {
-        if ($this->sLastIpVoted != $this->sLastIp) {
-            static::$iVotesLike++;
+        if ($this->sLastIpVoted !== $this->sLastIp) {
+            ++static::$iVotesLike;
             $this->oLikeModel->update($this->sKey, $this->sLastIp);
         }
     }
 
     private function isUserVoting(): bool
     {
-        return $this->iVote && $this->checkPerm();
+        return $this->iVote === 1;
     }
 }
 
-echo (new LikeCoreAjax)->show();
+echo (new LikeCoreAjax())->show();

--- a/_protected/app/system/core/assets/ajax/RatingCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/RatingCoreAjax.php
@@ -1,12 +1,14 @@
 <?php
+
 /**
  * @title          Rating Ajax Class
+ *
  * @desc           Simple Rating Page Class with Ajax.
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Asset / Ajax
+ *
  * @version        1.2
  */
 
@@ -19,11 +21,15 @@ defined('PH7') or exit('Restricted access');
 use PH7\Framework\Cookie\Cookie;
 use PH7\Framework\Http\Http;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
+use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Session\Session;
 use PH7\JustHttp\StatusCode;
 
 class RatingCoreAjax
 {
+    private const MIN_SCORE = 0.1;
+    private const MAX_SCORE = 5.0;
+
     /**
      * Cache lifetime set to 1 week.
      */
@@ -47,7 +53,7 @@ class RatingCoreAjax
 
     public function __construct()
     {
-        $this->oHttpRequest = new HttpRequest;
+        $this->oHttpRequest = new HttpRequest();
 
         if ($this->isValidRequestToRate()) {
             if ($this->oHttpRequest->post('action') === 'rating') {
@@ -55,6 +61,9 @@ class RatingCoreAjax
                 if (!UserCore::auth()) {
                     $this->iStatus = 0;
                     $this->sTxt = t('Please <b>register</b> or <b>login</b> to vote.');
+                } elseif (!(new Token())->checkUrl()) {
+                    $this->iStatus = 0;
+                    $this->sTxt = Form::errorTokenMsg();
                 } else {
                     $this->initialize();
                 }
@@ -78,22 +87,34 @@ class RatingCoreAjax
      */
     private function initialize(): void
     {
-        $this->oRatingModel = new RatingCoreModel;
+        $this->oRatingModel = new RatingCoreModel();
         $this->sTable = $this->oHttpRequest->post('table');
         $this->iId = (int)$this->oHttpRequest->post('id');
+        $fScore = (float)$this->oHttpRequest->post('score');
+
+        if ($fScore < self::MIN_SCORE || $fScore > self::MAX_SCORE) {
+            $this->iStatus = 0;
+            $this->sTxt = t('The rating score is invalid.');
+
+            return;
+        }
 
         if ($this->hasCorrectDbTable()) {
-            $iProfileId = (int)(new Session)->get('member_id');
+            $iProfileId = (int)(new Session())->get('member_id');
 
             if ($iProfileId === $this->iId) {
                 $this->iStatus = 0;
                 $this->sTxt = t('You can not vote your own profile!');
+
                 return;
             }
         }
 
-        $this->eligibilityChecker();
-        $this->select();
+        if (!$this->isEligibleToVote()) {
+            return;
+        }
+
+        $this->select($fScore);
         $this->update();
         $this->iStatus = 1;
         $sVoteTxt = self::$iVotes > 1 ? t('Votes') : t('Vote');
@@ -108,15 +129,13 @@ class RatingCoreAjax
     /**
      * Adds voting in the database and increment the static attribute to vote.
      */
-    private function select(): void
+    private function select(float $fSubmittedScore): void
     {
         $iVotes = $this->oRatingModel->getVote($this->iId, $this->sTable);
         $fRate = $this->oRatingModel->getScore($this->iId, $this->sTable);
 
-        self::$iVotes = $iVotes += 1;
-        $fScore = (float)$this->oHttpRequest->post('score');
-
-        $this->fScore = $fRate += $fScore;
+        self::$iVotes = ++$iVotes;
+        $this->fScore = $fRate + $fSubmittedScore;
     }
 
     /**
@@ -128,29 +147,33 @@ class RatingCoreAjax
         $this->oRatingModel->updateScore($this->fScore, $this->iId, $this->sTable);
     }
 
-    private function eligibilityChecker(): void
+    private function isEligibleToVote(): bool
     {
         /**
-         * @internal In today's world, IP address is also easier to change than deleting a cookie,
-         * so we have chosen the cookie approach instead of saving the IP address in the database.
+         * @internal in today's world, IP address is also easier to change than deleting a cookie,
+         * so we have chosen the cookie approach instead of saving the IP address in the database
          */
-        $oCookie = new Cookie;
+        $oCookie = new Cookie();
         $sCookieName = 'pHSVoting' . $this->iId . $this->sTable;
         if ($oCookie->exists($sCookieName)) {
             $this->iStatus = 0;
             $this->sTxt = t('You have already voted!');
+            $bIsEligible = false;
         } else {
             $oCookie->set($sCookieName, '1', self::COOKIE_LIFETIME);
+            $bIsEligible = true;
         }
         unset($oCookie);
+
+        return $bIsEligible;
     }
 
     private function isValidRequestToRate(): bool
     {
-        return $this->oHttpRequest->postExists('action') &&
-            $this->oHttpRequest->postExists('table') &&
-            $this->oHttpRequest->postExists('score') &&
-            $this->oHttpRequest->postExists('id');
+        return $this->oHttpRequest->postExists('action')
+            && $this->oHttpRequest->postExists('table')
+            && $this->oHttpRequest->postExists('score')
+            && $this->oHttpRequest->postExists('id');
     }
 
     private function hasCorrectDbTable(): bool
@@ -159,4 +182,4 @@ class RatingCoreAjax
     }
 }
 
-echo (new RatingCoreAjax)->show();
+echo (new RatingCoreAjax())->show();

--- a/_protected/app/system/core/classes/PictureCore.php
+++ b/_protected/app/system/core/classes/PictureCore.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Class
  */
 
 namespace PH7;
@@ -13,8 +13,24 @@ use PH7\Framework\File\File;
 
 class PictureCore
 {
+    public function deleteAlbum($iAlbumId, $sUsername, File $oFile): bool
+    {
+        $sUsername = (string)$sUsername;
+        $sSafeUsername = File::getFileBasename($sUsername);
+        $iAlbumId = (int)$iAlbumId;
+
+        if ($sSafeUsername === '' || $sSafeUsername !== $sUsername || $iAlbumId < 1) {
+            return false;
+        }
+
+        $sAlbumPath = PH7_PATH_PUBLIC_DATA_SYS_MOD .
+            'picture/img/' . $sSafeUsername . PH7_DS . $iAlbumId . PH7_DS;
+
+        return $oFile->deleteDir($sAlbumPath);
+    }
+
     /**
-     * @param int $iAlbumId
+     * @param int    $iAlbumId
      * @param string $sUsername
      * @param string $sPictureLink (file with the extension)
      *
@@ -29,11 +45,11 @@ class PictureCore
         $iAlbumId = (int)$iAlbumId;
 
         if (
-            $sSafeUsername === '' ||
-            $sSafeUsername !== $sUsername ||
-            $sSafePictureLink === '' ||
-            $sSafePictureLink !== $sPictureLink ||
-            $iAlbumId < 1
+            $sSafeUsername === ''
+            || $sSafeUsername !== $sUsername
+            || $sSafePictureLink === ''
+            || $sSafePictureLink !== $sPictureLink
+            || $iAlbumId < 1
         ) {
             return;
         }
@@ -50,13 +66,13 @@ class PictureCore
             $sDir . str_replace('original', '1200', $sSafePictureLink)
         ];
 
-        (new File)->deleteFile($aFiles);
+        (new File())->deleteFile($aFiles);
         unset($aFiles);
     }
 
     public static function clearCache()
     {
-        (new Cache)->start(
+        (new Cache())->start(
             PictureCoreModel::CACHE_GROUP,
             null,
             null

--- a/_protected/app/system/core/classes/VideoCore.php
+++ b/_protected/app/system/core/classes/VideoCore.php
@@ -1,11 +1,11 @@
 <?php
+
 /**
  * @title          Video Core Class
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Class
  */
 
 declare(strict_types=1);
@@ -21,6 +21,22 @@ class VideoCore
 
     private const REGEX_API_URL_FORMAT = '#(^https?://(www\.)?.+\.[a-z]{2,8})#i';
 
+    public function deleteAlbum($iAlbumId, $sUsername, File $oFile): bool
+    {
+        $sUsername = (string)$sUsername;
+        $sSafeUsername = File::getFileBasename($sUsername);
+        $iAlbumId = (int)$iAlbumId;
+
+        if ($sSafeUsername === '' || $sSafeUsername !== $sUsername || $iAlbumId < 1) {
+            return false;
+        }
+
+        $sAlbumPath = PH7_PATH_PUBLIC_DATA_SYS_MOD .
+            'video/file/' . $sSafeUsername . PH7_DS . $iAlbumId . PH7_DS;
+
+        return $oFile->deleteDir($sAlbumPath);
+    }
+
     /**
      * Check if this is a url, if so, this is a video from an external site.
      */
@@ -30,13 +46,11 @@ class VideoCore
     }
 
     /**
-     * @param int $iAlbumId
+     * @param int    $iAlbumId
      * @param string $sUsername
      * @param string $sVideoLink (file with the extension)
-     * @param string $sVideoExt Separate the different extensions with commas (extension with the point. e.g. .ogg,.webm,.mp4)
-     * @param string $sThumbExt (extension of thumbnail with the point
-     *
-     * @return void
+     * @param string $sVideoExt  Separate the different extensions with commas (extension with the point. e.g. .ogg,.webm,.mp4)
+     * @param string $sThumbExt  (extension of thumbnail with the point
      */
     public function deleteVideo(
         $iAlbumId,
@@ -44,8 +58,7 @@ class VideoCore
         $sVideoLink,
         $sVideoExt = '.webm,.mp4',
         $sThumbExt = self::DEFAULT_THUMBNAIL_EXT
-    ): void
-    {
+    ): void {
         $sUsername = (string)$sUsername;
         $sSafeUsername = File::getFileBasename($sUsername);
         $sVideoLink = (string)$sVideoLink;
@@ -53,18 +66,18 @@ class VideoCore
         $iAlbumId = (int)$iAlbumId;
 
         if (
-            $sSafeUsername === '' ||
-            $sSafeUsername !== $sUsername ||
-            $sSafeVideoLink === '' ||
-            $sSafeVideoLink !== $sVideoLink ||
-            $iAlbumId < 1
+            $sSafeUsername === ''
+            || $sSafeUsername !== $sUsername
+            || $sSafeVideoLink === ''
+            || $sSafeVideoLink !== $sVideoLink
+            || $iAlbumId < 1
         ) {
             return;
         }
 
         $sDir = PH7_PATH_PUBLIC_DATA_SYS_MOD . 'video/file/' . $sSafeUsername . PH7_DS . $iAlbumId . PH7_DS;
 
-        $oFile = new File;
+        $oFile = new File();
         $sThumbName = $oFile->getFileWithoutExt($sSafeVideoLink);
 
         // Delete video file
@@ -84,7 +97,7 @@ class VideoCore
 
     public static function clearCache(): void
     {
-        (new Cache)->start(
+        (new Cache())->start(
             VideoCoreModel::CACHE_GROUP,
             null,
             null

--- a/_protected/app/system/core/models/PictureCoreModel.php
+++ b/_protected/app/system/core/models/PictureCoreModel.php
@@ -1,34 +1,48 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Model
  */
 
 namespace PH7;
 
-use PDO;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PH7\Framework\Mvc\Model\Engine\Model;
-use stdClass;
 
 class PictureCoreModel extends Model
 {
-    const CACHE_GROUP = 'db/sys/mod/picture';
-    const CACHE_TIME = 172800;
-    const CREATED = 'createdDate';
-    const UPDATED = 'updatedDate';
+    public const CACHE_GROUP = 'db/sys/mod/picture';
+    public const CACHE_TIME = 172800;
+    public const CREATED = 'createdDate';
+    public const UPDATED = 'updatedDate';
+
+    public function isPhotoOwnedBy(int $iPictureId, int $iAlbumId, int $iProfileId): bool
+    {
+        $rStmt = Db::getInstance()->prepare(
+            'SELECT COUNT(pictureId) FROM' . Db::prefix(DbTableName::PICTURE) .
+            'WHERE pictureId = :pictureId AND albumId = :albumId AND profileId = :profileId'
+        );
+        $rStmt->bindValue(':pictureId', $iPictureId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->execute();
+        $bIsOwned = (int)$rStmt->fetchColumn() === 1;
+        Db::free($rStmt);
+
+        return $bIsOwned;
+    }
 
     /**
-     * @param null|int $iProfileId
-     * @param null|int $iAlbumId
-     * @param string $sApproved '1' = Approved | '0' = Pending
-     * @param int $iOffset
-     * @param int $iLimit
-     * @param string $sOrder
+     * @param int|null $iProfileId
+     * @param int|null $iAlbumId
+     * @param string   $sApproved  '1' = Approved | '0' = Pending
+     * @param int      $iOffset
+     * @param int      $iLimit
+     * @param string   $sOrder
      *
-     * @return stdClass|array
+     * @return \stdClass|array
      */
     public function album($iProfileId, $iAlbumId, $sApproved, $iOffset, $iLimit, $sOrder = self::CREATED)
     {
@@ -49,21 +63,21 @@ class PictureCoreModel extends Model
 
             $rStmt = Db::getInstance()->prepare($sSqlQuery);
             if ($bIsProfileId) {
-                $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
+                $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
             }
 
             if ($bIsAlbumId) {
-                $rStmt->bindValue(':albumId', $iAlbumId, PDO::PARAM_INT);
+                $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
             }
 
-            $rStmt->bindValue(':approved', $sApproved, PDO::PARAM_STR);
+            $rStmt->bindValue(':approved', $sApproved, \PDO::PARAM_STR);
 
-            $rStmt->bindParam(':offset', $iOffset, PDO::PARAM_INT);
-            $rStmt->bindParam(':limit', $iLimit, PDO::PARAM_INT);
+            $rStmt->bindParam(':offset', $iOffset, \PDO::PARAM_INT);
+            $rStmt->bindParam(':limit', $iLimit, \PDO::PARAM_INT);
 
             $rStmt->execute();
 
-            $mData = ($bIsProfileId && $bIsAlbumId) ? $rStmt->fetch(PDO::FETCH_OBJ) : $rStmt->fetchAll(PDO::FETCH_OBJ);
+            $mData = ($bIsProfileId && $bIsAlbumId) ? $rStmt->fetch(\PDO::FETCH_OBJ) : $rStmt->fetchAll(\PDO::FETCH_OBJ);
             Db::free($rStmt);
             $this->cache->put($mData);
         }
@@ -72,9 +86,9 @@ class PictureCoreModel extends Model
     }
 
     /**
-     * @param int $iProfileId
-     * @param int $iAlbumId
-     * @param null|int $iPictureId
+     * @param int      $iProfileId
+     * @param int      $iAlbumId
+     * @param int|null $iPictureId
      *
      * @return bool
      */
@@ -85,10 +99,10 @@ class PictureCoreModel extends Model
         $sSqlPictureId = $bIsPictureId ? ' AND pictureId = :pictureId ' : '';
         $sSql = 'DELETE FROM' . Db::prefix(DbTableName::PICTURE) . 'WHERE profileId = :profileId AND albumId = :albumId' . $sSqlPictureId;
         $rStmt = Db::getInstance()->prepare($sSql);
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':albumId', $iAlbumId, PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
         if ($bIsPictureId) {
-            $rStmt->bindValue(':pictureId', $iPictureId, PDO::PARAM_INT);
+            $rStmt->bindValue(':pictureId', $iPictureId, \PDO::PARAM_INT);
         }
 
         return $rStmt->execute();

--- a/_protected/app/system/core/models/PictureCoreModel.php
+++ b/_protected/app/system/core/models/PictureCoreModel.php
@@ -18,20 +18,20 @@ class PictureCoreModel extends Model
     public const CREATED = 'createdDate';
     public const UPDATED = 'updatedDate';
 
-    public function isPhotoOwnedBy(int $iPictureId, int $iAlbumId, int $iProfileId): bool
+    public function getOwnedPhotoFile(int $iPictureId, int $iAlbumId, int $iProfileId): string|false
     {
         $rStmt = Db::getInstance()->prepare(
-            'SELECT COUNT(pictureId) FROM' . Db::prefix(DbTableName::PICTURE) .
+            'SELECT file FROM' . Db::prefix(DbTableName::PICTURE) .
             'WHERE pictureId = :pictureId AND albumId = :albumId AND profileId = :profileId'
         );
         $rStmt->bindValue(':pictureId', $iPictureId, \PDO::PARAM_INT);
         $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
         $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
         $rStmt->execute();
-        $bIsOwned = (int)$rStmt->fetchColumn() === 1;
+        $mFile = $rStmt->fetchColumn();
         Db::free($rStmt);
 
-        return $bIsOwned;
+        return is_string($mFile) && $mFile !== '' ? $mFile : false;
     }
 
     /**

--- a/_protected/app/system/core/models/VideoCoreModel.php
+++ b/_protected/app/system/core/models/VideoCoreModel.php
@@ -18,20 +18,20 @@ class VideoCoreModel extends Model
     public const CREATED = 'createdDate';
     public const UPDATED = 'updatedDate';
 
-    public function isVideoOwnedBy(int $iVideoId, int $iAlbumId, int $iProfileId): bool
+    public function getOwnedVideoFile(int $iVideoId, int $iAlbumId, int $iProfileId): string|false
     {
         $rStmt = Db::getInstance()->prepare(
-            'SELECT COUNT(videoId) FROM' . Db::prefix(DbTableName::VIDEO) .
+            'SELECT file FROM' . Db::prefix(DbTableName::VIDEO) .
             'WHERE videoId = :videoId AND albumId = :albumId AND profileId = :profileId'
         );
         $rStmt->bindValue(':videoId', $iVideoId, \PDO::PARAM_INT);
         $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
         $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
         $rStmt->execute();
-        $bIsOwned = (int)$rStmt->fetchColumn() === 1;
+        $mFile = $rStmt->fetchColumn();
         Db::free($rStmt);
 
-        return $bIsOwned;
+        return is_string($mFile) && $mFile !== '' ? $mFile : false;
     }
 
     /**

--- a/_protected/app/system/core/models/VideoCoreModel.php
+++ b/_protected/app/system/core/models/VideoCoreModel.php
@@ -1,34 +1,48 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Model
  */
 
 namespace PH7;
 
-use PDO;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PH7\Framework\Mvc\Model\Engine\Model;
-use stdClass;
 
 class VideoCoreModel extends Model
 {
-    const CACHE_GROUP = 'db/sys/mod/video';
-    const CACHE_TIME = 172800;
-    const CREATED = 'createdDate';
-    const UPDATED = 'updatedDate';
+    public const CACHE_GROUP = 'db/sys/mod/video';
+    public const CACHE_TIME = 172800;
+    public const CREATED = 'createdDate';
+    public const UPDATED = 'updatedDate';
+
+    public function isVideoOwnedBy(int $iVideoId, int $iAlbumId, int $iProfileId): bool
+    {
+        $rStmt = Db::getInstance()->prepare(
+            'SELECT COUNT(videoId) FROM' . Db::prefix(DbTableName::VIDEO) .
+            'WHERE videoId = :videoId AND albumId = :albumId AND profileId = :profileId'
+        );
+        $rStmt->bindValue(':videoId', $iVideoId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->execute();
+        $bIsOwned = (int)$rStmt->fetchColumn() === 1;
+        Db::free($rStmt);
+
+        return $bIsOwned;
+    }
 
     /**
-     * @param null|int $iProfileId
-     * @param null|int $iAlbumId
-     * @param string $sApproved '1' = Approved | '0' = Pending
-     * @param int $iOffset
-     * @param int $iLimit
-     * @param string $sOrder
+     * @param int|null $iProfileId
+     * @param int|null $iAlbumId
+     * @param string   $sApproved  '1' = Approved | '0' = Pending
+     * @param int      $iOffset
+     * @param int      $iLimit
+     * @param string   $sOrder
      *
-     * @return array|stdClass
+     * @return array|\stdClass
      */
     public function album($iProfileId, $iAlbumId, $sApproved, $iOffset, $iLimit, $sOrder = self::CREATED)
     {
@@ -51,18 +65,18 @@ class VideoCoreModel extends Model
 
             $rStmt = Db::getInstance()->prepare($sSqlQuery);
             if ($bIsProfileId) {
-                $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
+                $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
             }
             if ($bIsAlbumId) {
-                $rStmt->bindValue(':albumId', $iAlbumId, PDO::PARAM_INT);
+                $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
             }
-            $rStmt->bindValue(':approved', $sApproved, PDO::PARAM_STR);
+            $rStmt->bindValue(':approved', $sApproved, \PDO::PARAM_STR);
 
-            $rStmt->bindParam(':offset', $iOffset, PDO::PARAM_INT);
-            $rStmt->bindParam(':limit', $iLimit, PDO::PARAM_INT);
+            $rStmt->bindParam(':offset', $iOffset, \PDO::PARAM_INT);
+            $rStmt->bindParam(':limit', $iLimit, \PDO::PARAM_INT);
 
             $rStmt->execute();
-            $mData = ($bIsProfileId && $bIsAlbumId) ? $rStmt->fetch(PDO::FETCH_OBJ) : $rStmt->fetchAll(PDO::FETCH_OBJ);
+            $mData = ($bIsProfileId && $bIsAlbumId) ? $rStmt->fetch(\PDO::FETCH_OBJ) : $rStmt->fetchAll(\PDO::FETCH_OBJ);
             Db::free($rStmt);
             $this->cache->put($mData);
         }
@@ -71,9 +85,9 @@ class VideoCoreModel extends Model
     }
 
     /**
-     * @param int $iProfileId
-     * @param int $iAlbumId
-     * @param null|int $iVideoId
+     * @param int      $iProfileId
+     * @param int      $iAlbumId
+     * @param int|null $iVideoId
      *
      * @return bool
      */
@@ -83,10 +97,10 @@ class VideoCoreModel extends Model
 
         $sSqlVideoId = $bVideoId ? ' AND videoId=:videoId ' : '';
         $rStmt = Db::getInstance()->prepare('DELETE FROM' . Db::prefix(DbTableName::VIDEO) . 'WHERE profileId=:profileId AND albumId=:albumId' . $sSqlVideoId);
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':albumId', $iAlbumId, PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':albumId', $iAlbumId, \PDO::PARAM_INT);
         if ($bVideoId) {
-            $rStmt->bindValue(':videoId', $iVideoId, PDO::PARAM_INT);
+            $rStmt->bindValue(':videoId', $iVideoId, \PDO::PARAM_INT);
         }
 
         return $rStmt->execute();

--- a/_protected/app/system/global/views/base/tpl/error/except.html.php
+++ b/_protected/app/system/global/views/base/tpl/error/except.html.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
- * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright      (c) 2012-2026, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Global / View / Base / Error
  */
 
 namespace PH7;
@@ -12,9 +12,43 @@ defined('PH7') or exit('Restricted access');
 
 use PH7\Framework\Layout\Html\Design;
 
-$oDesign = new Design;
+$oDesign = new Design();
 $oDesign->htmlHeader();
 
-echo '<html><head><meta charset="utf-8" /><title>Fatal Error: Exception</title><meta name="author" content="pH7Builder, Pierre-Henry Soria" /><meta name="copyright" content="(c) 2012-2019, Pierre-Henry Soria. All Rights Reserved" /><meta name="creator" content="pH7Builder, Pierre-Henry Soria" /><meta name="designer" content="pH7Builder, Pierre-Henry Soria" /><meta name="generator" content="pH7Builder" /><style>.debug_cont{font-family:Arial,Verdana,Helvetica,sans-serif;font-size:14px;color:#333;padding:15px 0;width:100%;margin:0 auto}.debug_body{background:#fff;border:4px double;padding:5px}.debug_cap{font:bold 13px "Trebuchet MS",Verdana,Helvetica,Arial,serif;color:#fff;padding:5px;border:1px solid #000;width:250px;margin-top:-20px;margin-bottom:10px}.debug_body .notice{background:#fdf403;color:#555}.debug_body .warning{background:#f8b423;color:#555}.debug_body .error{background:#c10505;color:#fff}.debug_body .exception{background:#093dd3;color:#fff}.debug_body .vardump{background:#333;color:#fff}.vardumper .string{color:green}.vardumper .null,.vardumper .array,.vardumper .bool{color:blue}.vardumper .property{color:brown}.vardumper .number{color:red}.vardumper .class{color:black}.vardumper .class_prop{color:brown}pre{font-size:12px;border:1px solid #36c;background-color:#e5ecf9;padding:.5em}</style></head><body><div class="debug_cont"><div class="debug_body"><div class="debug_cap exception">'.Core::SOFTWARE_NAME.' Debug - Exception</div><table><tr><td>Message:</td><td>'.$oExcept->getMessage().'</td></tr><tr><td>File:</td><td>'.$oExcept->getFile().'</td></tr><tr><td>Line:</td><td>'.$oExcept->getLine().'</td></tr><tr><td>Trace:</td><td><pre>'.$oExcept->getTraceAsString().'</pre></td></tr></table></div></div>';
+$sMessage = escape($oExcept->getMessage());
+$sFile = escape($oExcept->getFile());
+$sTrace = escape($oExcept->getTraceAsString());
+$iLine = (int)$oExcept->getLine();
+
+echo '<html><head><meta charset="utf-8" /><title>Fatal Error: Exception</title>',
+'<meta name="author" content="pH7Builder, Pierre-Henry Soria" />',
+'<meta name="copyright" content="(c) 2012-2026, Pierre-Henry Soria. All Rights Reserved" />',
+'<meta name="creator" content="pH7Builder, Pierre-Henry Soria" />',
+'<meta name="designer" content="pH7Builder, Pierre-Henry Soria" />',
+'<meta name="generator" content="pH7Builder" />',
+'<style>',
+'.debug_cont{font-family:Arial,Verdana,Helvetica,sans-serif;font-size:14px;color:#333;padding:15px 0;width:100%;margin:0 auto}',
+'.debug_body{background:#fff;border:4px double;padding:5px}',
+'.debug_cap{font:bold 13px "Trebuchet MS",Verdana,Helvetica,Arial,serif;color:#fff;padding:5px;border:1px solid #000;width:250px;margin-top:-20px;margin-bottom:10px}',
+'.debug_body .notice{background:#fdf403;color:#555}',
+'.debug_body .warning{background:#f8b423;color:#555}',
+'.debug_body .error{background:#c10505;color:#fff}',
+'.debug_body .exception{background:#093dd3;color:#fff}',
+'.debug_body .vardump{background:#333;color:#fff}',
+'.vardumper .string{color:green}',
+'.vardumper .null,.vardumper .array,.vardumper .bool{color:blue}',
+'.vardumper .property{color:brown}',
+'.vardumper .number{color:red}',
+'.vardumper .class{color:black}',
+'.vardumper .class_prop{color:brown}',
+'pre{font-size:12px;border:1px solid #36c;background-color:#e5ecf9;padding:.5em}',
+'</style></head><body>',
+'<div class="debug_cont"><div class="debug_body">',
+'<div class="debug_cap exception">', Core::SOFTWARE_NAME, ' Debug - Exception</div>',
+'<table><tr><td>Message:</td><td>', $sMessage, '</td></tr>',
+'<tr><td>File:</td><td>', $sFile, '</td></tr>',
+'<tr><td>Line:</td><td>', $iLine, '</td></tr>',
+'<tr><td>Trace:</td><td><pre>', $sTrace, '</pre></td></tr></table>',
+'</div></div>';
 
 $oDesign->htmlFooter();

--- a/_protected/app/system/modules/admin123/controllers/ToolController.php
+++ b/_protected/app/system/modules/admin123/controllers/ToolController.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2022, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Admin / Controller
  */
 
 declare(strict_types=1);
@@ -12,6 +12,7 @@ namespace PH7;
 
 use PH7\Framework\Cache\Cache;
 use PH7\Framework\Date\CDateTime;
+use PH7\Framework\File\File;
 use PH7\Framework\Layout\Gzip\Gzip;
 use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Layout\Html\Security as HtmlSecurity;
@@ -46,7 +47,7 @@ class ToolController extends Controller
     public function cache(): void
     {
         // Add a CSRF token for the remove ajax cache request
-        $this->view->csrf_token = (new Token)->generate('cache');
+        $this->view->csrf_token = (new Token())->generate('cache');
 
         $this->addGeneralCssFile();
 
@@ -124,7 +125,7 @@ class ToolController extends Controller
     {
         $this->addGeneralCssFile();
 
-        $this->view->designSecurity = new HtmlSecurity; // Security Design Class
+        $this->view->designSecurity = new HtmlSecurity(); // Security Design Class
 
         $this->sTitle = t('Backup Management');
         $this->view->page_title = $this->sTitle;
@@ -134,14 +135,14 @@ class ToolController extends Controller
         $aDumpList = $this->removePaths($aDumpList);
         $this->view->aDumpList = $aDumpList;
 
-        $oSecurityToken = new Token;
+        $oSecurityToken = new Token();
         if ($this->httpRequest->postExists('backup')) {
             if (!$oSecurityToken->check('backup')) {
                 $this->design->setFlashMsg(Form::errorTokenMsg(), Design::ERROR_TYPE);
             } else {
                 // Clean the site name to avoid bug with the backup path
                 $sSiteName = str_replace([' ', '/', '\\'], '_', $this->registry->site_name);
-                $sCurrentDate = (new CDateTime)->get()->date();
+                $sCurrentDate = (new CDateTime())->get()->date();
 
                 switch ($this->httpRequest->post('backup_type')) {
                     case self::SERVER_ACTION:
@@ -149,25 +150,20 @@ class ToolController extends Controller
                         (new Backup(PH7_PATH_BACKUP_SQL . $sFileName))->back()->save();
                         $this->view->msg_success = t('Data dumped into backup file "%0%"', $sFileName);
                         break;
-
                     case self::SERVER_ARCHIVE_ACTION:
                         $sFileName = 'Database-dump.' . $sCurrentDate . '.sql.gz';
                         (new Backup(PH7_PATH_BACKUP_SQL . $sFileName))->back()->saveArchive();
                         $this->view->msg_success = t('Data dumped into backup file "%0%"', $sFileName);
                         break;
-
                     case self::CLIENT_ACTION:
                         (new Backup($sSiteName . '_' . $sCurrentDate . '.sql'))->back()->download();
                         break;
-
                     case self::CLIENT_ARCHIVE_ACTION:
                         (new Backup($sSiteName . '_' . $sCurrentDate . '.sql.gz'))->back()->downloadArchive();
                         break;
-
                     case self::SHOW_ACTION:
-                        $this->view->sql_content = (new Backup)->back()->show();
+                        $this->view->sql_content = (new Backup())->back()->show();
                         break;
-
                     default:
                         $this->design->setFlashMsg(
                             t('Please select a field.'),
@@ -181,7 +177,7 @@ class ToolController extends Controller
             if (!$oSecurityToken->check('backup')) {
                 $this->design->setFlashMsg(Form::errorTokenMsg(), Design::ERROR_TYPE);
             } else {
-                $sDumpFile = $this->httpRequest->post('dump_file');
+                $sDumpFile = $this->getSelectedDumpFileName();
 
                 if (!empty($sDumpFile)) {
                     if ($this->file->getFileExt($sDumpFile) === Backup::SQL_FILE_EXT) {
@@ -207,7 +203,7 @@ class ToolController extends Controller
             if (!$oSecurityToken->check('backup')) {
                 $this->design->setFlashMsg(Form::errorTokenMsg(), Design::ERROR_TYPE);
             } else {
-                $sDumpFile = $this->httpRequest->post('dump_file');
+                $sDumpFile = $this->getSelectedDumpFileName();
 
                 if (!empty($sDumpFile)) {
                     $this->file->deleteFile(PH7_PATH_BACKUP_SQL . $sDumpFile);
@@ -220,32 +216,34 @@ class ToolController extends Controller
                 }
             }
         }
-        unset($oSecurityToken);
-
-
         if ($this->httpRequest->postExists('restore_sql_file')) {
-            if (!empty($_FILES['sql_file']['tmp_name'])) {
-                $sNameFile = $_FILES['sql_file']['name'];
-                $sTmpFile = $_FILES['sql_file']['tmp_name'];
+            if (!$oSecurityToken->check('backup')) {
+                $this->design->setFlashMsg(Form::errorTokenMsg(), Design::ERROR_TYPE);
+            } else {
+                if (!empty($_FILES['sql_file']['tmp_name'])) {
+                    $sNameFile = $_FILES['sql_file']['name'];
+                    $sTmpFile = $_FILES['sql_file']['tmp_name'];
 
-                if ($this->file->getFileExt($sNameFile) === Backup::SQL_FILE_EXT) {
-                    $mStatus = (new Backup($sTmpFile))->restore();
-                } elseif ($this->file->getFileExt($sNameFile) === Backup::ARCHIVE_FILE_EXT) {
-                    $mStatus = (new Backup($sTmpFile))->restoreArchive();
+                    if ($this->file->getFileExt($sNameFile) === Backup::SQL_FILE_EXT) {
+                        $mStatus = (new Backup($sTmpFile))->restore();
+                    } elseif ($this->file->getFileExt($sNameFile) === Backup::ARCHIVE_FILE_EXT) {
+                        $mStatus = (new Backup($sTmpFile))->restoreArchive();
+                    } else {
+                        $mStatus = t('Dump file must be a SQL type (extension ".sql" or compressed archive ".gz")');
+                    }
+
+                    // Remove the temporary file
+                    $this->file->deleteFile($sTmpFile);
                 } else {
-                    $mStatus = t('Dump file must be a SQL type (extension ".sql" or compressed archive ".gz")');
+                    $mStatus = t('Please select a dump SQL file.');
                 }
 
-                // Remove the temporary file
-                $this->file->deleteFile($sTmpFile);
-            } else {
-                $mStatus = t('Please select a dump SQL file.');
+                $sMsg = ($mStatus === true) ? t('Data successfully restored from desktop!') : $mStatus;
+                $sMsgType = ($mStatus === true) ? Design::SUCCESS_TYPE : Design::ERROR_TYPE;
+                $this->design->setFlashMsg($sMsg, $sMsgType);
             }
-
-            $sMsg = ($mStatus === true) ? t('Data successfully restored from desktop!') : $mStatus;
-            $sMsgType = ($mStatus === true) ? Design::SUCCESS_TYPE : Design::ERROR_TYPE;
-            $this->design->setFlashMsg($sMsg, $sMsgType);
         }
+        unset($oSecurityToken);
 
         $this->output();
     }
@@ -285,10 +283,25 @@ class ToolController extends Controller
         );
     }
 
+    private function getSelectedDumpFileName(): string
+    {
+        $sDumpFile = (string)$this->httpRequest->post('dump_file');
+        $sFileName = File::getFileBasename($sDumpFile);
+
+        if (
+            $sFileName !== $sDumpFile
+            || !in_array(File::getFileExtWithDot($sFileName), self::BACKUP_FILE_EXTS, true)
+        ) {
+            return '';
+        }
+
+        return $sFileName;
+    }
+
     /**
      * Checks and stops the script if the method is not POST.
      *
-     * @return void The text by exit() function.
+     * @return void the text by exit() function
      */
     private function checkPost(): void
     {

--- a/_protected/app/system/modules/admin123/forms/SettingForm.php
+++ b/_protected/app/system/modules/admin123/forms/SettingForm.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2023, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Admin / From
  */
 
 namespace PH7;
@@ -39,7 +39,7 @@ class SettingForm
     {
         if (isset($_POST['submit_setting'])) {
             if (\PFBC\Form::isValid($_POST['submit_setting'])) {
-                new SettingFormProcess;
+                new SettingFormProcess();
             }
 
             Header::redirect();
@@ -57,11 +57,10 @@ class SettingForm
         $oForm->addElement(new Hidden('submit_setting', 'form_setting'));
         $oForm->addElement(new Token('setting'));
 
-
         /********** General Settings **********/
         $oForm->addElement(new HTMLExternal('<div class="content" id="general"><div class="col-md-10"><h2 class="underline">' . t('Global Settings') . '</h2>'));
 
-        $oFile = new File;
+        $oFile = new File();
 
         $oForm->addElement(new Textbox(t('Site Name:'), 'site_name', ['value' => DbConfig::getSetting('siteName'), 'validation' => new Str(2, 50), 'required' => 1]));
 
@@ -199,14 +198,12 @@ class SettingForm
 
         unset($oFile);
 
-
         /********** Logo Settings **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="icon"><div class="col-md-10"><h2 class="underline">' . t('Icon Logo') . '</h2>'));
 
         $oForm->addElement(new \PFBC\Element\File('', 'logo', ['description' => t('Add your small logo/icon that represents/distinguishes the best your site/concept/brand.'), 'accept' => 'image/*']));
 
         $oForm->addElement(new HTMLExternal('<div class="s_marg"><img src="' . PH7_URL_TPL . PH7_TPL_NAME . PH7_SH . PH7_IMG . 'logo.png?v=' . File::version(PH7_PATH_TPL . PH7_TPL_NAME . PH7_DS . PH7_IMG . 'logo.png') . '" alt="' . t('Icon Logo') . '" title="' . t('The current logo of your website.') . '" /></div>'));
-
 
         /********** Design (Color) **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="design"><div class="col-md-10"><h2 class="underline">' . t('Override Website Colors') . '</h2>'));
@@ -230,9 +227,8 @@ class SettingForm
         $oForm->addElement(new Color(t('Links Hover:'), 'link_hover_color', ['value' => DbConfig::getSetting('linkHoverColor')]));
 
         $oForm->addElement(new HTMLExternal(
-            '<div class="right"><a href="' . Uri::get(PH7_ADMIN_MOD, 'setting', 'resetcolor', (new SecurityToken)->url(), false) . '">' . t('Reset Colors') . '</a></div>'
+            '<div class="right"><a href="' . Uri::get(PH7_ADMIN_MOD, 'setting', 'resetcolor', (new SecurityToken())->url(), false) . '">' . t('Reset Colors') . '</a></div>'
         ));
-
 
         /********** Registration **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="registration"><div class="col-md-10"><h2 class="underline">' . t('Registration') . '</h2>'));
@@ -290,7 +286,6 @@ class SettingForm
 
         $oForm->addElement(new Select(t('Default Membership Group:'), 'default_membership_group_id', self::getMembershipGroups(), ['description' => t('The default membership where the users will be added to.'), 'value' => DbConfig::getSetting('defaultMembershipGroupId'), 'required' => 1]));
 
-
         /********** Picture and Video **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="pic_vid"><div class="col-md-10"><h2 class="underline">' . t('Picture and Video') . '</h2>'));
 
@@ -309,7 +304,6 @@ class SettingForm
 
             $oForm->addElement(new Select(t('Autoplay Video:'), 'autoplay_video', ['1' => t('Enable'), '0' => t('Disable')], ['value' => DbConfig::getSetting('autoplayVideo'), 'required' => 1]));
         }
-
 
         /********** Moderation **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="moderation"><div class="col-md-10"><h2 class="underline">' . t('Moderation') . '</h2>'));
@@ -332,7 +326,6 @@ class SettingForm
             $oForm->addElement(new Select(t('Videos Manual Approval:'), 'video_manual_approval', ['1' => t('Enable'), '0' => t('Disable')], ['value' => DbConfig::getSetting('videoManualApproval'), 'required' => 1]));
         }
 
-
         /********** Email **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="email"><div class="col-md-10"><h2 class="underline">' . t('Email Parameters') . '</h2>'));
 
@@ -343,7 +336,6 @@ class SettingForm
         $oForm->addElement(new Email(t('Feedback Email:'), 'feedback_email', ['value' => DbConfig::getSetting('feedbackEmail'), 'required' => 1]));
 
         $oForm->addElement(new Email(t('Return Email:'), 'return_email', ['description' => 'Usually noreply@yoursite.com', 'value' => DbConfig::getSetting('returnEmail'), 'required' => 1]));
-
 
         /********** Security **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="security"><div class="col-md-10"><h2 class="underline">' . t('Security') . '</h2>'));
@@ -388,8 +380,6 @@ class SettingForm
 
         $oForm->addElement(new Textbox(t('Indicate a word that will replace the banned word in <a href="%0%">the list</a>.', Uri::get(PH7_ADMIN_MOD, 'file', 'protectededit', 'app/configs/banned/word.txt', false)), 'ban_word_replace', ['value' => DbConfig::getSetting('banWordReplace'), 'required' => 1]));
 
-        $oForm->addElement(new Select(t('Enable/Disable CSRF security tokens in forms:'), 'security_token_forms', ['1' => t('Enable'), '0' => t('Disable')], ['description' => t('Sometimes this protection can be annoying for users if there are not fast enough to fulfill the forms. However, if disabled, your website can be vulnerable on CSRF attacks in forms.'), 'value' => DbConfig::getSetting('securityToken'), 'required' => 1]));
-
         $oForm->addElement(new Number(t('CSRF token lifetime:'), 'security_token_lifetime', ['description' => t('Time in seconds.'), 'value' => DbConfig::getSetting('securityTokenLifetime'), 'required' => 1]));
 
         $oForm->addElement(new Select(t('Protect for Users against session cookies hijacking:'), 'is_user_session_ip_check', ['1' => t('Yes (recommended for security reasons)'), '0' => t('No')], ['description' => t('This protection can cause problems for logged in users with dynamic IPs. Please disable if their IP changes frequently during their session.'), 'value' => DbConfig::getSetting('isUserSessionIpCheck'), 'required' => 1]));
@@ -401,7 +391,6 @@ class SettingForm
         $oForm->addElement(new Select(t('Protect for Admins against session cookies hijacking:'), 'is_admin_session_ip_check', ['1' => t('Yes (highly recommended for security reasons)'), '0' => t('No')], ['description' => t('This protection can cause problems for admins with dynamic IPs. Please disable if their IP changes frequently during their session.'), 'value' => DbConfig::getSetting('isAdminSessionIpCheck'), 'required' => 1]));
 
         $oForm->addElement(new Select(t('System against DDoS attacks:'), 'stop_DDoS', ['1' => t('Activate'), '0' => t('Deactivate')], ['description' => t('Enable it ONLY if you think your website has real DDoS attacks or if your server is highly overloaded.'), 'value' => DbConfig::getSetting('DDoS'), 'required' => 1]));
-
 
         /********** Spam **********/
         $oForm->addElement(new HTMLExternal('</div></div><div class="content" id="spam"><div class="col-md-10"><h2 class="underline">' . t('Spam') . '</h2>'));
@@ -463,7 +452,6 @@ class SettingForm
 
         $oForm->addElement(new Number(t('Delete old IM Messages:'), 'clean_messenger', ['description' => t('Delete IM messages older than X days. 0 to disable.'), 'value' => DbConfig::getSetting('cleanMessenger'), 'required' => 1]));
 
-
         /********** API **********/
         $oForm->addElement(
             new HTMLExternal(
@@ -499,7 +487,6 @@ class SettingForm
         );
 
         $oForm->addElement(new Number(t('User inactivity timeout:'), 'user_timeout', ['description' => t('The number of minutes that a member becomes inactive (offline).'), 'value' => DbConfig::getSetting('userTimeout'), 'required' => 1]));
-
 
         $oForm->addElement(new HTMLExternal('</div></div><script src="' . PH7_URL_STATIC . PH7_JS . 'tabs.js"></script><script>tabs(\'p\', [\'general\',\'icon\',\'registration\',\'pic_vid\',\'moderation\',\'email\',\'security\',\'spam\',\'design\',\'api\',\'automation\']);</script>'));
         $oForm->addElement(new Button(t('Save'), 'submit', ['icon' => 'check']));
@@ -552,7 +539,7 @@ class SettingForm
     {
         $aGroupNames = [];
 
-        $oGroupIds = (new AdminCoreModel)->getMemberships();
+        $oGroupIds = (new AdminCoreModel())->getMemberships();
         foreach ($oGroupIds as $iId) {
             $aGroupNames[$iId->groupId] = $iId->name;
         }

--- a/_protected/app/system/modules/admin123/forms/processing/SettingFormProcess.php
+++ b/_protected/app/system/modules/admin123/forms/processing/SettingFormProcess.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Admin / From / Processing
  */
 
 namespace PH7;
@@ -17,11 +17,11 @@ use PH7\Framework\Navigation\Browser;
 
 class SettingFormProcess extends Form
 {
-    const LOGO_FILENAME = 'logo.png';
-    const MIN_CSRF_TOKEN_LIFETIME = 10;
-    const LOGO_WIDTH = 47;
-    const LOGO_HEIGHT = 45;
-    const MAX_WATERMARK_SIZE = 5;
+    public const LOGO_FILENAME = 'logo.png';
+    public const MIN_CSRF_TOKEN_LIFETIME = 10;
+    public const LOGO_WIDTH = 47;
+    public const LOGO_HEIGHT = 45;
+    public const MAX_WATERMARK_SIZE = 5;
 
     /** @var bool */
     private $bIsErr = false;
@@ -106,7 +106,6 @@ class SettingFormProcess extends Form
         'ban_word_replace' => 'banWordReplace',
 
         // CSRF
-        'security_token_forms' => 'securityToken',
         'security_token_lifetime' => 'securityTokenLifetime',
 
         // Session hijacking protection
@@ -181,41 +180,37 @@ class SettingFormProcess extends Form
                 }
             } elseif ($this->hasDataChanged($sKey, $sVal)) {
                 switch ($sKey) {
-                    case 'min_username_length': {
-                        $iMaxUsernameLength = $this->httpRequest->post('max_username_length')-1;
+                    case 'min_username_length':
+                        $iMaxUsernameLength = $this->httpRequest->post('max_username_length') - 1;
                         if ($this->httpRequest->post('min_username_length') > $iMaxUsernameLength) {
                             \PFBC\Form::setError('form_setting', t('The minimum length of the username cannot exceed %0% characters.', $iMaxUsernameLength));
-                             $this->bIsErr = true;
-                         } else {
+                            $this->bIsErr = true;
+                        } else {
                             DbConfig::setSetting($this->httpRequest->post('min_username_length'), 'minUsernameLength');
                         }
-                    } break;
-
-                    case 'max_username_length': {
+                        break;
+                    case 'max_username_length':
                         if ($this->httpRequest->post('max_username_length') > PH7_MAX_USERNAME_LENGTH) {
                             \PFBC\Form::setError('form_setting', t('The maximum length of the username cannot exceed %0% characters.', PH7_MAX_USERNAME_LENGTH));
                             $this->bIsErr = true;
                         } else {
                             DbConfig::setSetting($this->httpRequest->post('max_username_length'), 'maxUsernameLength');
                         }
-                    } break;
-
-                    case 'min_age_registration': {
+                        break;
+                    case 'min_age_registration':
                         if ($this->httpRequest->post('min_age_registration') >= $this->httpRequest->post('max_age_registration')) {
                             \PFBC\Form::setError('form_setting', t('You cannot specify a minimum age higher than the maximum age.'));
                             $this->bIsErr = true;
                         } else {
                             DbConfig::setSetting($this->httpRequest->post('min_age_registration'), 'minAgeRegistration');
                         }
-                    } break;
-
-                    case 'size_watermark_text_image': {
-                        if ($this->httpRequest->post('size_watermark_text_image') >= 0 &&
-                            $this->httpRequest->post('size_watermark_text_image') <= self::MAX_WATERMARK_SIZE) {
+                        break;
+                    case 'size_watermark_text_image':
+                        if ($this->httpRequest->post('size_watermark_text_image') >= 0
+                            && $this->httpRequest->post('size_watermark_text_image') <= self::MAX_WATERMARK_SIZE) {
                             DbConfig::setSetting($this->httpRequest->post('size_watermark_text_image'), 'sizeWatermarkTextImage');
                         }
-                    } break;
-
+                        break;
                     case 'background_color':
                     case 'text_color':
                     case 'heading1_color':
@@ -223,17 +218,15 @@ class SettingFormProcess extends Form
                     case 'heading3_color':
                     case 'link_color':
                     case 'footer_link_color':
-                    case 'link_hover_color': {
+                    case 'link_hover_color':
                         // Prevent to override color style if the value isn't changed by user but set by the Web browser due to empty field values
                         if (!Browser::isDefaultBrowserHexCodeFound($this->httpRequest->post($sKey))) {
                             DbConfig::setSetting($this->httpRequest->post($sKey), $sVal);
                         }
-                    } break;
-
-                    default: {
+                        break;
+                    default:
                         $sMethod = ($sKey === 'site_status' ? 'setSiteMode' : ($sKey === 'social_media_widgets' ? 'setSocialWidgets' : 'setSetting'));
                         DbConfig::$sMethod($this->httpRequest->post($sKey, null, true), $sVal);
-                    }
                 }
             }
         }
@@ -251,7 +244,7 @@ class SettingFormProcess extends Form
                 $this->bIsErr = true;
             } else {
                 /**
-                 * @internal File::deleteFile() first tests if the file exists, and then deletes it.
+                 * @internal file::deleteFile() first tests if the file exists, and then deletes it
                  */
                 $sPathName = PH7_PATH_TPL . PH7_TPL_NAME . PH7_DS . PH7_IMG . self::LOGO_FILENAME;
                 $this->file->deleteFile($sPathName); // It erases the old logo.
@@ -271,15 +264,15 @@ class SettingFormProcess extends Form
      * @param string $sKey
      * @param string $sVal
      *
-     * @return bool
-     *
      * @throws Framework\Mvc\Request\WrongRequestMethodException
+     *
+     * @return bool
      */
     private function hasDataChanged($sKey, $sVal)
     {
         return
-            isset($_POST[$sKey]) &&
-            !$this->str->equals($this->httpRequest->post($sKey), DbConfig::getSetting($sVal));
+            isset($_POST[$sKey])
+            && !$this->str->equals($this->httpRequest->post($sKey), DbConfig::getSetting($sVal));
     }
 
     /**

--- a/_protected/app/system/modules/admin123/views/base/tpl/admin/browse.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/admin/browse.tpl
@@ -48,13 +48,13 @@
                     {{ $adminId = (int)$admin->profileId }}
                     <tr>
                       <td>
-                          <input type="checkbox" name="action[]" value="{adminId}_{% $admin->username %}" />
+                          <input type="checkbox" name="action[]" value="{adminId}_{% $str->escapeAttribute($admin->username) %}" />
                       </td>
                       <td>{adminId}</td>
-                      <td>{% $admin->email %}</td>
+                      <td>{% escape($admin->email) %}</td>
                       <td>
-                          {% $admin->username %}<br />
-                          <span class="gray">{% $admin->firstName %}</span>
+                          {% escape($admin->username) %}<br />
+                          <span class="gray">{% escape($admin->firstName) %}</span>
                       </td>
                       <td>{{ $design->ip($admin->ip) }}</td>
                       <td class="small">{% $dateTime->get($admin->joinDate)->dateTime() %}</td>

--- a/_protected/app/system/modules/admin123/views/base/tpl/tool/backup.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/tool/backup.tpl
@@ -64,7 +64,7 @@
 
             <tr>
                 <td class="border vs_padd">
-                    <textarea id="backup">{sql_content}</textarea>
+                    <textarea id="backup">{% escape($sql_content) %}</textarea>
                 </td>
             </tr>
         {/if}

--- a/_protected/app/system/modules/admin123/views/base/tpl/user/browse.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/user/browse.tpl
@@ -77,23 +77,23 @@
                 {each $user in $browse}
                     <tr>
                         <td>
-                            <input type="checkbox" name="action[]" value="{% $user->profileId %}_{% $user->username %}" />
+                            <input type="checkbox" name="action[]" value="{% $user->profileId %}_{% $str->escapeAttribute($user->username) %}" />
                         </td>
                         <td>{% $user->profileId %}</td>
                         <td>
-                            <a href="mailto:{% $user->email %}" title="{lang 'Email the User'}">
-                                {% $user->email %}
+                            <a href="mailto:{% $str->escapeAttribute($user->email) %}" title="{lang 'Email the User'}">
+                                {% escape($user->email) %}
                             </a>
                         </td>
                         <td>
                             {{ $design->getProfileLink($user->username) }}<br />
-                            <span class="gray">{% $user->firstName %}</span>
+                            <span class="gray">{% escape($user->firstName) %}</span>
                         </td>
                         <td>{{ $avatarDesign->get($user->username, $user->firstName, null, 32) }}</td>
                         <td>
                             <img src="{{ $design->getSmallFlagIcon(Framework\Geo\Ip\Geo::getCountryCode($user->ip)) }}" title="{lang 'Country Flag'}" alt="{lang 'Country Flag'}" /> {{ $design->ip($user->ip) }}
                         </td>
-                        <td>{% $user->membershipName %} ({% $user->groupId %})</td> {* Name of the Membership Group *}
+                        <td>{% escape($user->membershipName) %} ({% $user->groupId %})</td> {* Name of the Membership Group *}
                         <td class="small">{% $dateTime->get($user->joinDate)->dateTime() %}</td>
                         <td class="small">
                             {if !empty($user->lastActivity)}
@@ -109,7 +109,7 @@
                                 {lang 'No editing'}
                             {/if}
                         </td>
-                        <td class="small">{% $user->reference %}</td>
+                        <td class="small">{% escape($user->reference) %}</td>
                         <td class="small">
                             <a href="{{ $design->url('user', 'setting', 'edit', $user->profileId) }}" title="{lang "Edit User's Profile Information"}">{lang 'Edit'}</a> •
                             <a href="{{ $design->url('user', 'setting', 'avatar', "$user->profileId,$user->username,$user->firstName,$user->sex", false) }}" title="{lang "Edit User's Profile Photo"}">{lang 'Profile Photo'}</a> •

--- a/_protected/app/system/modules/affiliate/controllers/AdminController.php
+++ b/_protected/app/system/modules/affiliate/controllers/AdminController.php
@@ -18,6 +18,7 @@ use PH7\Framework\Mail\Mail;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\CSRF\Token as SecurityToken;
+use PH7\Framework\Security\Validate\Validate;
 use PH7\Framework\Url\Header;
 use PH7\Framework\Util\Various;
 use stdClass;
@@ -121,6 +122,7 @@ class AdminController extends Controller implements UserModeratable
             // Assigns variables for views
             $this->view->designSecurity = new HtmlSecurity; // Security Design Class
             $this->view->dateTime = $this->dateTime; // Date Time Class
+            $this->view->validate = new Validate;
 
             $this->sTitle = t('Browse Affiliates');
             $this->view->page_title = $this->sTitle;

--- a/_protected/app/system/modules/affiliate/views/base/tpl/admin/browse.tpl
+++ b/_protected/app/system/modules/affiliate/views/base/tpl/admin/browse.tpl
@@ -81,23 +81,25 @@
                 {each $aff in $browse}
                     <tr>
                         <td>
-                            <input type="checkbox" name="action[]" value="{% $aff->profileId %}_{% $aff->username %}" />
+                            <input type="checkbox" name="action[]" value="{% $aff->profileId %}_{% $str->escapeAttribute($aff->username) %}" />
                         </td>
                         <td>{% $aff->profileId %}</td>
                         <td>
-                            <a href="mailto:{% $aff->email %}" title="{lang 'Email the Affiliate'}">
-                                {% $aff->email %}
+                            <a href="mailto:{% $str->escapeAttribute($aff->email) %}" title="{lang 'Email the Affiliate'}">
+                                {% escape($aff->email) %}
                             </a>
                         </td>
                         <td>
-                            {% $aff->username %}<br />
-                            <span class="small gray">{% $aff->firstName %} {% $aff->lastName %}</span>
+                            {% escape($aff->username) %}<br />
+                            <span class="small gray">{% escape($aff->firstName) %} {% escape($aff->lastName) %}</span>
                         </td>
-                        <td>{% $aff->refer %}</td>
-                        <td>{% $aff->bankAccount %}</td>
+                        <td>{% escape($aff->refer) %}</td>
+                        <td>{% escape($aff->bankAccount) %}</td>
                         <td>
-                            {if !empty($aff->website)}
-                                <a href="{% $aff->website %}">{% $aff->website %}</a>
+                            {if !empty($aff->website) AND $validate->url($aff->website)}
+                                <a href="{% $str->escapeAttribute($aff->website) %}">{% escape($aff->website) %}</a>
+                            {elseif !empty($aff->website)}
+                                {% escape($aff->website) %}
                             {else}
                                 {lang 'No website'}
                             {/if}

--- a/_protected/app/system/modules/api/controllers/UserController.php
+++ b/_protected/app/system/modules/api/controllers/UserController.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2015-2023, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Api / Controller
- * @link           https://ph7builder.com
- * @link           https://github.com/pH7Software/pH7Builder-HTTP-REST-Push-Data
+ *
+ * @see           https://ph7builder.com
+ * @see           https://github.com/pH7Software/pH7Builder-HTTP-REST-Push-Data
  */
 
 namespace PH7;
@@ -27,9 +28,9 @@ class UserController extends MainController
     {
         parent::__construct();
 
-        $this->oUser = new UserCore;
-        $this->oUserModel = new UserCoreModel;
-        $this->oValidate = new Validate;
+        $this->oUser = new UserCore();
+        $this->oUserModel = new UserCoreModel();
+        $this->oValidate = new Validate();
     }
 
     public function createAccount(): void
@@ -47,7 +48,7 @@ class UserController extends MainController
             $iMinAge = DbConfig::getSetting('minAgeRegistration');
             $iMaxAge = DbConfig::getSetting('maxAgeRegistration');
 
-            $sBirthDate = (new CDateTime)->get($aData['birth_date'])->date('m/d/Y');
+            $sBirthDate = (new CDateTime())->get($aData['birth_date'])->date('m/d/Y');
 
             $aRequiredFields = [
                 'email',
@@ -114,10 +115,9 @@ class UserController extends MainController
                 ];
                 $iUserId = $this->oUserModel->add(escape($aValidData, true));
 
-                // Add 'profile_id' key into the array
+                unset($aValidData['password']);
                 $aValidData['profile_id'] = $iUserId;
 
-                // Display the new user's details and ID
                 $this->oRest->response($this->set($aValidData));
             }
         }
@@ -140,8 +140,9 @@ class UserController extends MainController
             elseif ($this->oUserModel->login($aData['email'], $aData['password']) === true) {
                 $iId = $this->oUserModel->getId($aData['email']);
                 $oUserData = $this->oUserModel->readProfile($iId);
-                $this->oUser->setAuth($oUserData, $this->oUserModel, $this->session, new SecurityModel);
+                $this->oUser->setAuth($oUserData, $this->oUserModel, $this->session, new SecurityModel());
 
+                unset($aData['password']);
                 $this->oRest->response($this->set($aData));
             } else {
                 $aResults = [
@@ -181,10 +182,6 @@ class UserController extends MainController
 
     /**
      * Get all profile data.
-     *
-     * @param string $sOrder
-     * @param int|null $iOffset
-     * @param int|null $iLimit
      */
     public function users(
         string $sOrder = SearchCoreModel::LAST_ACTIVITY,
@@ -209,10 +206,6 @@ class UserController extends MainController
      * Get profiles from geo location.
      *
      * @param string $sCountryCode The country code. e.g. US, CA, FR, ES, BE, NL
-     * @param string $sCity
-     * @param string $sOrder
-     * @param int|null $iOffset
-     * @param int|null $iLimit
      */
     public function usersFromLocation(
         string $sCountryCode,
@@ -246,7 +239,7 @@ class UserController extends MainController
     }
 
     /**
-     * Delete a user
+     * Delete a user.
      */
     public function deleteUser(int $iProfileId): void
     {

--- a/_protected/app/system/modules/api/controllers/UserController.php
+++ b/_protected/app/system/modules/api/controllers/UserController.php
@@ -115,7 +115,6 @@ class UserController extends MainController
                 ];
                 $iUserId = $this->oUserModel->add(escape($aValidData, true));
 
-                unset($aValidData['password']);
                 $aValidData['profile_id'] = $iUserId;
 
                 $this->oRest->response($this->set($aValidData));
@@ -142,7 +141,6 @@ class UserController extends MainController
                 $oUserData = $this->oUserModel->readProfile($iId);
                 $this->oUser->setAuth($oUserData, $this->oUserModel, $this->session, new SecurityModel());
 
-                unset($aData['password']);
                 $this->oRest->response($this->set($aData));
             } else {
                 $aResults = [

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/index.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/index.tpl
@@ -1,7 +1,7 @@
 <div class="center">
     {if empty($error)}
         {each $category in $categories}
-            <h2 class="s_tMarg underline">{% $category->title %}</h2>
+            <h2 class="s_tMarg underline">{% escape($category->title) %}</h2>
             {if AdminCore::auth()}
                 <a class="btn btn-default btn-sm" href="{{ $design->url('forum', 'admin', 'editcategory', $category->categoryId) }}">{lang 'Edit'}</a> | {{ $design->popupLinkConfirm(t('Delete'), 'forum', 'admin', 'deletecategory', $category->categoryId, 'btn btn-default btn-sm') }}<br /><br />
             {/if}

--- a/_protected/app/system/modules/forum/views/base/tpl/forum/post.tpl
+++ b/_protected/app/system/modules/forum/views/base/tpl/forum/post.tpl
@@ -18,7 +18,9 @@
 
         <p>
             {% Framework\Parse\Emoticon::init(
-                Framework\Security\Ban\Ban::filterWord(escape($post->message))
+                (new Framework\Security\Validate\Purifier)->xssClean(
+                    Framework\Security\Ban\Ban::filterWord($post->message)
+                )
             ) %}
         </p>
 
@@ -67,7 +69,9 @@
                     <p>
                         {% Framework\Parse\Emoticon::init(
                             Framework\Parse\User::atUsernameToLink(
-                                Framework\Security\Ban\Ban::filterWord(escape($msg->message))
+                                (new Framework\Security\Validate\Purifier)->xssClean(
+                                    Framework\Security\Ban\Ban::filterWord($msg->message)
+                                )
                             )
                         ) %}
                     </p>

--- a/_protected/app/system/modules/friend/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/friend/views/base/tpl/main/index.tpl
@@ -8,7 +8,7 @@
         {each $f in $friends}
             <div class="s_photo" id="friend_{% $f->fdId %}">
                 {{ $avatarDesign->get($f->username, $f->firstName, $f->sex, 64, $bRollover = true) }}
-                <em><abbr title="{% $f->firstName %}">{% $f->username %}</abbr></em><br />
+                <em><abbr title="{% $str->escapeAttribute($f->firstName) %}">{% escape($f->username) %}</abbr></em><br />
 
                 {if $is_user_auth AND $sess_member_id == $member_id}
                     {if $sess_member_id == $f->friendId AND $f->pending == FriendCoreModel::PENDING_REQUEST}

--- a/_protected/app/system/modules/friend/views/premium/tpl/main/index.tpl
+++ b/_protected/app/system/modules/friend/views/premium/tpl/main/index.tpl
@@ -8,7 +8,7 @@
         {each $f in $friends}
             <div class="s_photo" id="friend_{% $f->fdId %}">
                 {{ $avatarDesign->get($f->username, $f->firstName, $f->sex, 64) }}
-                <em><abbr title="{% $f->firstName %}">{% $f->username %}</abbr></em><br />
+                <em><abbr title="{% $str->escapeAttribute($f->firstName) %}">{% escape($f->username) %}</abbr></em><br />
 
                 {if $is_user_auth AND $sess_member_id == $member_id}
                     {if $sess_member_id == $f->friendId AND $f->pending == FriendCoreModel::PENDING_REQUEST}

--- a/_protected/app/system/modules/im/assets/ajax/MessengerAjax.php
+++ b/_protected/app/system/modules/im/assets/ajax/MessengerAjax.php
@@ -1,12 +1,14 @@
 <?php
+
 /**
  * @title          Chat Messenger Ajax
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / IM / Asset / Ajax
+ *
  * @version        1.6
+ *
  * @required       PHP 5.4 or higher.
  */
 
@@ -23,6 +25,7 @@ use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Request\Http as HttpRequest;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Parse\Emoticon;
+use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Session\Session;
 use PH7\JustHttp\StatusCode;
 
@@ -38,28 +41,29 @@ class MessengerAjax extends PermissionCore
     {
         parent::__construct();
 
+        if (!(new Token())->checkUrl()) {
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
+            exit(jsonMsg(0, Form::errorTokenMsg()));
+        }
+
         Import::pH7App(PH7_SYS . PH7_MOD . 'im.models.MessengerModel');
 
-        $this->oHttpRequest = new HttpRequest;
-        $this->oMessengerModel = new MessengerModel;
+        $this->oHttpRequest = new HttpRequest();
+        $this->oMessengerModel = new MessengerModel();
 
         switch ($this->oHttpRequest->get('act')) {
             case 'heartbeat':
                 $this->heartbeat();
                 break;
-
             case 'send':
                 $this->send();
                 break;
-
             case 'close':
                 $this->close();
                 break;
-
             case 'startsession':
                 $this->startSession();
                 break;
-
             default:
                 Http::setHeadersByCode(StatusCode::BAD_REQUEST);
                 exit('Bad Request Error!');
@@ -202,7 +206,7 @@ class MessengerAjax extends PermissionCore
                 $sMsgTransform = '<small><em>' . t('%0% is currently offline. Maybe, try to chat later on? 😉', $sTo) . '</em></small>';
             }
         } else {
-            $this->oMessengerModel->insert($sFrom, $sTo, $sMsg, (new CDateTime)->get()->dateTime(self::DATETIME_FORMAT));
+            $this->oMessengerModel->insert($sFrom, $sTo, $sMsg, (new CDateTime())->get()->dateTime(self::DATETIME_FORMAT));
         }
 
         $_SESSION['messenger_history'][$this->oHttpRequest->post('to')] .= $this->setJsonContent(['status' => '1', 'user' => $sTo, 'msg' => $sMsgTransform]);
@@ -238,13 +242,11 @@ class MessengerAjax extends PermissionCore
         // Update array
         $aData += $aDefData;
 
-        $sJsonData = <<<EOD
-        {
-            "status": "{$aData['status']}",
-            "user": "{$aData['user']}",
-            "msg": "{$aData['msg']}"
-        }
-EOD;
+        $sJsonData = json_encode(
+            $aData,
+            JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+
         return $bEndComma ? $sJsonData . ',' : $sJsonData;
     }
 
@@ -255,7 +257,7 @@ EOD;
      */
     protected function isOnline($sUsername)
     {
-        $oUserModel = new UserCoreModel;
+        $oUserModel = new UserCoreModel();
         $iProfileId = $oUserModel->getId(null, $sUsername);
         $bIsOnline = $oUserModel->isOnline($iProfileId, DbConfig::getSetting('userTimeout'));
         unset($oUserModel);
@@ -270,10 +272,10 @@ EOD;
      */
     protected function sanitize($sText)
     {
-        $sText = escape($sText, true);
+        $sText = escape($sText);
         $sText = str_replace("\n\r", "\n", $sText);
         $sText = str_replace("\r\n", "\n", $sText);
-        $sText = str_replace("\n", "<br>", $sText);
+        $sText = str_replace("\n", '<br>', $sText);
 
         return $sText;
     }
@@ -281,11 +283,11 @@ EOD;
 
 // Go only if the user is logged
 if (UserCore::auth()) {
-    $oSession = new Session; // Initialize session & start_session() func
+    $oSession = new Session(); // Initialize session & start_session() func
     if (empty($_SESSION['messenger_username'])) {
         $_SESSION['messenger_username'] = $oSession->get('member_username');
     }
     unset($oSession);
 
-    new MessengerAjax;
+    new MessengerAjax();
 }

--- a/_protected/app/system/modules/mail/controllers/MainController.php
+++ b/_protected/app/system/modules/mail/controllers/MainController.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Mail / Controller
  */
 
 namespace PH7;
@@ -15,13 +15,12 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Url\Header;
-use stdClass;
 
 class MainController extends Controller
 {
     use BulkAction;
 
-    const EMAILS_PER_PAGE = 10;
+    public const EMAILS_PER_PAGE = 10;
 
     /** @var MailModel */
     protected $oMailModel;
@@ -51,15 +50,15 @@ class MainController extends Controller
     {
         parent::__construct();
 
-        $this->oMailModel = new MailModel;
-        $this->oPage = new Page;
+        $this->oMailModel = new MailModel();
+        $this->oPage = new Page();
         $this->iProfileId = $this->session->get('member_id');
         $this->bAdminLogged = (AdminCore::auth() && !UserCore::auth());
 
-        $this->view->avatarDesign = new AvatarDesignCore; // Avatar Design Class
-        $this->view->designSecurity = new Security; // Security Design Class
+        $this->view->avatarDesign = new AvatarDesignCore(); // Avatar Design Class
+        $this->view->designSecurity = new Security(); // Security Design Class
 
-        $this->view->csrf_token = (new Token)->generate('mail');
+        $this->view->csrf_token = (new Token())->generate('mail');
 
         $this->view->member_id = $this->iProfileId;
 
@@ -85,7 +84,7 @@ class MainController extends Controller
 
     public function inbox()
     {
-        /** Default title **/
+        /* Default title * */
         $this->sTitle = t('Messages');
         $this->view->page_title = $this->sTitle;
         $this->view->h2_title = $this->sTitle;
@@ -280,7 +279,7 @@ class MainController extends Controller
     {
         $sKeywords = $this->httpRequest->get('looking');
         $sOrder = $this->httpRequest->get('order');
-        $iSort = $this->httpRequest->get('sort',Type::INTEGER);
+        $iSort = $this->httpRequest->get('sort', Type::INTEGER);
         $iType = $this->httpRequest->get('where', Type::INTEGER);
 
         $this->iTotalMails = $this->oMailModel->search(
@@ -343,7 +342,7 @@ class MainController extends Controller
         );
 
         if ($this->bStatus) {
-            $this->oMailModel->setReadMsg($iId);
+            $this->oMailModel->setReadMsg($this->iProfileId, $iId);
             $this->sMsg = t('Message has been moved to the trash.');
         } else {
             $this->sMsg = t("Your message doesn't exist in your inbox.");
@@ -360,19 +359,20 @@ class MainController extends Controller
         $aActions = $this->httpRequest->post('action');
         $bActionsEligible = $this->areActionsEligible($aActions);
 
-        if (!(new Token)->check('mail_action')) {
+        if (!(new Token())->check('mail_action')) {
             $this->sMsg = Form::errorTokenMsg();
         } else {
             if ($bActionsEligible) {
                 foreach ($aActions as $iId) {
                     $iId = (int)$iId;
 
-                    $this->oMailModel->setReadMsg($iId);
-                    $this->oMailModel->setTo(
+                    if ($this->oMailModel->setTo(
                         $this->iProfileId,
                         $iId,
                         MailModel::TRASH_MODE
-                    );
+                    )) {
+                        $this->oMailModel->setReadMsg($this->iProfileId, $iId);
+                    }
                 }
                 $this->sMsg = t('Your message(s) has/have been moved to the trash.');
             }
@@ -417,7 +417,7 @@ class MainController extends Controller
         $aActions = $this->httpRequest->post('action');
         $bActionsEligible = $this->areActionsEligible($aActions);
 
-        if (!(new Token)->check('mail_action')) {
+        if (!(new Token())->check('mail_action')) {
             $this->sMsg = Form::errorTokenMsg();
         } else {
             if ($bActionsEligible) {
@@ -458,7 +458,7 @@ class MainController extends Controller
             );
 
             if ($this->bStatus) {
-                $this->oMailModel->setReadMsg($iId);
+                $this->oMailModel->setReadMsg($this->iProfileId, $iId);
             }
         }
 
@@ -477,7 +477,7 @@ class MainController extends Controller
         $aActions = $this->httpRequest->post('action');
         $bActionsEligible = $this->areActionsEligible($aActions);
 
-        if (!(new Token)->check('mail_action')) {
+        if (!(new Token())->check('mail_action')) {
             $this->sMsg = Form::errorTokenMsg();
         } else {
             if ($bActionsEligible) {
@@ -487,12 +487,13 @@ class MainController extends Controller
                     if ($this->bAdminLogged) {
                         $this->oMailModel->adminDeleteMsg($iId);
                     } else {
-                        $this->oMailModel->setReadMsg($iId);
-                        $this->oMailModel->setTo(
+                        if ($this->oMailModel->setTo(
                             $this->iProfileId,
                             $iId,
                             MailModel::DELETE_MODE
-                        );
+                        )) {
+                            $this->oMailModel->setReadMsg($this->iProfileId, $iId);
+                        }
                     }
                 }
                 $this->sMsg = t('Your message(s) has/have been successfully removed.');
@@ -506,7 +507,7 @@ class MainController extends Controller
     private function isSingleActionTokenValid(string $sAction): bool
     {
         $sActionToken = Token::getNameFromUrl(Uri::get('mail', 'main', $sAction));
-        $oToken = new Token;
+        $oToken = new Token();
 
         return $oToken->check($sActionToken) || $oToken->check('mail_action');
     }
@@ -554,10 +555,10 @@ class MainController extends Controller
         return $this->bStatus ? Design::SUCCESS_TYPE : Design::ERROR_TYPE;
     }
 
-    private function setRead(stdClass $oMsg): void
+    private function setRead(\stdClass $oMsg): void
     {
-        if ($oMsg->status == MailModel::UNREAD_STATUS) {
-            $this->oMailModel->setReadMsg($oMsg->messageId);
+        if ($oMsg->status === MailModel::UNREAD_STATUS) {
+            $this->oMailModel->setReadMsg($this->iProfileId, (int)$oMsg->messageId);
         }
     }
 }

--- a/_protected/app/system/modules/mail/models/MailModel.php
+++ b/_protected/app/system/modules/mail/models/MailModel.php
@@ -1,34 +1,32 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Mail / Model
  */
 
 namespace PH7;
 
-use PDO;
 use PH7\Framework\Error\CException\PH7InvalidArgumentException;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PH7\Framework\Mvc\Model\Spam as SpamModel;
-use stdClass;
 
 class MailModel extends MailCoreModel
 {
-    const ALL = 0;
-    const INBOX = 1;
-    const OUTBOX = 2;
-    const TRASH = 3;
+    public const ALL = 0;
+    public const INBOX = 1;
+    public const OUTBOX = 2;
+    public const TRASH = 3;
 
-    const RECIPIENT_DB_FIELD = 'recipient';
-    const SENDER_DB_FIELD = 'sender';
+    public const RECIPIENT_DB_FIELD = 'recipient';
+    public const SENDER_DB_FIELD = 'sender';
 
-    const TRASH_MODE = 'trash';
-    const RESTORE_MODE = 'restore';
-    const DELETE_MODE = 'delete';
+    public const TRASH_MODE = 'trash';
+    public const RESTORE_MODE = 'restore';
+    public const DELETE_MODE = 'delete';
 
-    const MODES = [
+    public const MODES = [
         self::TRASH_MODE,
         self::RESTORE_MODE,
         self::DELETE_MODE
@@ -38,7 +36,7 @@ class MailModel extends MailCoreModel
      * @param int $iRecipient
      * @param int $iMessageId
      *
-     * @return stdClass
+     * @return \stdClass
      */
     public function readMsg($iRecipient, $iMessageId)
     {
@@ -48,18 +46,18 @@ class MailModel extends MailCoreModel
             WHERE msg.recipient = :recipient AND msg.messageId = :messageId AND NOT FIND_IN_SET(\'recipient\', msg.trash) LIMIT 1'
         );
 
-        $rStmt->bindValue(':recipient', $iRecipient, PDO::PARAM_INT);
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':recipient', $iRecipient, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
         $rStmt->execute();
 
-        return $rStmt->fetch(PDO::FETCH_OBJ);
+        return $rStmt->fetch(\PDO::FETCH_OBJ);
     }
 
     /**
      * @param int $iSender
      * @param int $iMessageId
      *
-     * @return stdClass
+     * @return \stdClass
      */
     public function readSentMsg($iSender, $iMessageId)
     {
@@ -69,18 +67,18 @@ class MailModel extends MailCoreModel
             WHERE msg.sender = :sender AND msg.messageId = :messageId AND NOT FIND_IN_SET(\'sender\', msg.toDelete) LIMIT 1'
         );
 
-        $rStmt->bindValue(':sender', $iSender, PDO::PARAM_INT);
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':sender', $iSender, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
         $rStmt->execute();
 
-        return $rStmt->fetch(PDO::FETCH_OBJ);
+        return $rStmt->fetch(\PDO::FETCH_OBJ);
     }
 
     /**
      * @param int $iProfileId
      * @param int $iMessageId
      *
-     * @return stdClass
+     * @return \stdClass
      */
     public function readTrashMsg($iProfileId, $iMessageId)
     {
@@ -91,23 +89,23 @@ class MailModel extends MailCoreModel
             AND NOT FIND_IN_SET(\'recipient\', msg.toDelete) LIMIT 1'
         );
 
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
         $rStmt->execute();
 
-        return $rStmt->fetch(PDO::FETCH_OBJ);
+        return $rStmt->fetch(\PDO::FETCH_OBJ);
     }
 
     /**
      * Send a message.
      *
-     * @param int $iSender
-     * @param int $iRecipient
+     * @param int    $iSender
+     * @param int    $iRecipient
      * @param string $sTitle
      * @param string $sMessage
      * @param string $sCreatedDate
      *
-     * @return bool|int Returns the ID of the message on success or FALSE on failure.
+     * @return bool|int returns the ID of the message on success or FALSE on failure
      */
     public function sendMsg($iSender, $iRecipient, $sTitle, $sMessage, $sCreatedDate)
     {
@@ -115,12 +113,12 @@ class MailModel extends MailCoreModel
             'INSERT INTO' . Db::prefix(DbTableName::MESSAGE) . '(sender, recipient, title, message, sendDate, status)
             VALUES (:sender, :recipient, :title, :message, :sendDate, :status)'
         );
-        $rStmt->bindValue(':sender', $iSender, PDO::PARAM_INT);
-        $rStmt->bindValue(':recipient', $iRecipient, PDO::PARAM_INT);
-        $rStmt->bindValue(':title', $sTitle, PDO::PARAM_STR);
-        $rStmt->bindValue(':message', $sMessage, PDO::PARAM_STR);
-        $rStmt->bindValue(':sendDate', $sCreatedDate, PDO::PARAM_STR);
-        $rStmt->bindValue(':status', self::UNREAD_STATUS, PDO::PARAM_INT);
+        $rStmt->bindValue(':sender', $iSender, \PDO::PARAM_INT);
+        $rStmt->bindValue(':recipient', $iRecipient, \PDO::PARAM_INT);
+        $rStmt->bindValue(':title', $sTitle, \PDO::PARAM_STR);
+        $rStmt->bindValue(':message', $sMessage, \PDO::PARAM_STR);
+        $rStmt->bindValue(':sendDate', $sCreatedDate, \PDO::PARAM_STR);
+        $rStmt->bindValue(':status', self::UNREAD_STATUS, \PDO::PARAM_INT);
 
         return $rStmt->execute() ? Db::getInstance()->lastInsertId() : false;
     }
@@ -134,8 +132,8 @@ class MailModel extends MailCoreModel
     public function deleteMsg($iRecipient, $iMessageId)
     {
         $rStmt = Db::getInstance()->prepare('DELETE FROM' . Db::prefix(DbTableName::MESSAGE) . 'WHERE recipient = :recipient AND messageId = :messageId LIMIT 1');
-        $rStmt->bindValue(':recipient', $iRecipient, PDO::PARAM_INT);
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':recipient', $iRecipient, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
 
         return $rStmt->execute();
     }
@@ -148,19 +146,20 @@ class MailModel extends MailCoreModel
     public function adminDeleteMsg($iMessageId)
     {
         $rStmt = Db::getInstance()->prepare('DELETE FROM' . Db::prefix(DbTableName::MESSAGE) . 'WHERE messageId = :messageId LIMIT 1');
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
 
         return $rStmt->execute();
     }
 
-    /**
-     * @param int $iMessageId
-     */
-    public function setReadMsg($iMessageId)
+    public function setReadMsg(int $iProfileId, int $iMessageId): void
     {
-        $rStmt = Db::getInstance()->prepare('UPDATE' . Db::prefix(DbTableName::MESSAGE) . 'SET status = :status WHERE messageId = :messageId LIMIT 1');
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
-        $rStmt->bindValue(':status', self::READ_STATUS, PDO::PARAM_INT);
+        $rStmt = Db::getInstance()->prepare(
+            'UPDATE' . Db::prefix(DbTableName::MESSAGE) .
+            'SET status = :status WHERE recipient = :recipient AND messageId = :messageId LIMIT 1'
+        );
+        $rStmt->bindValue(':recipient', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':status', self::READ_STATUS, \PDO::PARAM_INT);
         $rStmt->execute();
         Db::free($rStmt);
     }
@@ -168,38 +167,45 @@ class MailModel extends MailCoreModel
     /**
      * @param int $iMessageId
      *
-     * @return stdClass
+     * @return \stdClass|false
      */
     public function getMsg($iMessageId)
     {
         $rStmt = Db::getInstance()->prepare('SELECT * FROM' . Db::prefix(DbTableName::MESSAGE) . 'WHERE messageId = :messageId LIMIT 1');
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
         $rStmt->execute();
 
-        return $rStmt->fetch(PDO::FETCH_OBJ);
+        return $rStmt->fetch(\PDO::FETCH_OBJ);
     }
 
     /**
      * Set message to 'trash' or 'toDelete'.
      *
-     * @param int $iProfileId User ID
-     * @param int $iMessageId Message ID
-     * @param string $sMode Set to this category. Choose between 'trash', 'restore' and 'delete'
-     *
-     * @return bool
+     * @param int    $iProfileId User ID
+     * @param int    $iMessageId Message ID
+     * @param string $sMode      Set to this category. Choose between 'trash', 'restore' and 'delete'
      *
      * @throws PH7InvalidArgumentException
+     *
+     * @return bool
      */
     public function setTo($iProfileId, $iMessageId, $sMode)
     {
         if (!in_array($sMode, self::MODES, true)) {
-            throw new PH7InvalidArgumentException(
-                sprintf('Invalid set mode: "%s"!', $sMode)
-            );
+            throw new PH7InvalidArgumentException(sprintf('Invalid set mode: "%s"!', $sMode));
         }
 
         $oData = $this->getMsg($iMessageId);
-        $sFieldId = $oData->sender == $iProfileId ? self::SENDER_DB_FIELD : self::RECIPIENT_DB_FIELD;
+        if (
+            !$oData
+            || ((int)$oData->sender !== (int)$iProfileId && (int)$oData->recipient !== (int)$iProfileId)
+        ) {
+            return false;
+        }
+
+        $sFieldId = (int)$oData->sender === (int)$iProfileId ?
+            self::SENDER_DB_FIELD :
+            self::RECIPIENT_DB_FIELD;
         if ($sMode === self::RESTORE_MODE) {
             $sTrashVal = str_replace([$sFieldId, Db::SET_DELIMITER], '', $oData->trash);
         } else {
@@ -215,22 +221,22 @@ class MailModel extends MailCoreModel
             $sFieldId
         );
         $rStmt = Db::getInstance()->prepare($sSqlQuery);
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':messageId', $iMessageId, PDO::PARAM_INT);
-        $rStmt->bindValue(':val', $sTrashVal, PDO::PARAM_STR);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':messageId', $iMessageId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':val', $sTrashVal, \PDO::PARAM_STR);
 
         return $rStmt->execute();
     }
 
     /**
      * @param int|string $mLooking
-     * @param bool $bCount
-     * @param string $sOrderBy
-     * @param int $iSort
-     * @param int $iOffset
-     * @param int $iLimit
-     * @param int|null $iProfileId
-     * @param int $iType
+     * @param bool       $bCount
+     * @param string     $sOrderBy
+     * @param int        $iSort
+     * @param int        $iOffset
+     * @param int        $iLimit
+     * @param int|null   $iProfileId
+     * @param int        $iType
      *
      * @return int|array
      */
@@ -251,16 +257,13 @@ class MailModel extends MailCoreModel
             case $iType === self::INBOX && $iProfileId !== null:
                 $sSql = 'msg.sender = m.profileId WHERE (msg.recipient = :profileId) AND (NOT FIND_IN_SET(\'recipient\', msg.trash)) AND';
                 break;
-
             case $iType === self::OUTBOX && $iProfileId !== null:
                 $sSql = 'msg.recipient = m.profileId WHERE (msg.sender = :profileId) AND (NOT FIND_IN_SET(\'sender\', msg.toDelete)) AND';
                 break;
-
             case $iType === self::TRASH && $iProfileId !== null:
                 $sSql = 'msg.sender = m.profileId WHERE (msg.recipient = :profileId) AND (FIND_IN_SET(\'recipient\', msg.trash)) AND
                 (NOT FIND_IN_SET(\'recipient\', msg.toDelete)) AND';
                 break;
-
             default:
                 // All messages
                 $sSql = 'msg.sender = m.profileId WHERE ';
@@ -270,24 +273,24 @@ class MailModel extends MailCoreModel
             $sSql . $sSqlFind . $sSqlOrder . $sSqlLimit);
 
         if ($bDigitSearch) {
-            $rStmt->bindValue(':looking', $mLooking, PDO::PARAM_INT);
+            $rStmt->bindValue(':looking', $mLooking, \PDO::PARAM_INT);
         } else {
-            $rStmt->bindValue(':looking', '%' . $mLooking . '%', PDO::PARAM_STR);
+            $rStmt->bindValue(':looking', '%' . $mLooking . '%', \PDO::PARAM_STR);
         }
 
         if ($iProfileId !== null) {
             $iProfileId = (int)$iProfileId;
-            $rStmt->bindParam(':profileId', $iProfileId, PDO::PARAM_INT);
+            $rStmt->bindParam(':profileId', $iProfileId, \PDO::PARAM_INT);
         }
 
         if (!$bCount) {
-            $rStmt->bindParam(':offset', $iOffset, PDO::PARAM_INT);
-            $rStmt->bindParam(':limit', $iLimit, PDO::PARAM_INT);
+            $rStmt->bindParam(':offset', $iOffset, \PDO::PARAM_INT);
+            $rStmt->bindParam(':limit', $iLimit, \PDO::PARAM_INT);
         }
 
         $rStmt->execute();
 
-        $mData = $bCount ?  (int)$rStmt->fetchColumn() : $rStmt->fetchAll(PDO::FETCH_OBJ);
+        $mData = $bCount ? (int)$rStmt->fetchColumn() : $rStmt->fetchAll(\PDO::FETCH_OBJ);
 
         Db::free($rStmt);
 
@@ -297,10 +300,10 @@ class MailModel extends MailCoreModel
     /**
      * Check Duplicate Contents.
      *
-     * @param int $iSenderId Sender's ID
-     * @param string $sMsg Message content
+     * @param int    $iSenderId Sender's ID
+     * @param string $sMsg      Message content
      *
-     * @return bool Returns TRUE if similar content was found in the table, FALSE otherwise.
+     * @return bool returns TRUE if similar content was found in the table, FALSE otherwise
      */
     public function isDuplicateContent($iSenderId, $sMsg)
     {
@@ -317,8 +320,8 @@ class MailModel extends MailCoreModel
     /**
      * To prevent spam!
      *
-     * @param int $iSenderId
-     * @param int $iWaitTime In minutes!
+     * @param int    $iSenderId
+     * @param int    $iWaitTime    In minutes!
      * @param string $sCurrentTime In date format: 0000-00-00 00:00:00
      *
      * @return bool Return TRUE if the weather was fine, otherwise FALSE
@@ -326,9 +329,9 @@ class MailModel extends MailCoreModel
     public function checkWaitSend($iSenderId, $iWaitTime, $sCurrentTime)
     {
         $rStmt = Db::getInstance()->prepare('SELECT messageId FROM' . Db::prefix(DbTableName::MESSAGE) . 'WHERE sender = :sender AND DATE_ADD(sendDate, INTERVAL :waitTime MINUTE) > :currentTime LIMIT 1');
-        $rStmt->bindValue(':sender', $iSenderId, PDO::PARAM_INT);
-        $rStmt->bindValue(':waitTime', $iWaitTime, PDO::PARAM_INT);
-        $rStmt->bindValue(':currentTime', $sCurrentTime, PDO::PARAM_STR);
+        $rStmt->bindValue(':sender', $iSenderId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':waitTime', $iWaitTime, \PDO::PARAM_INT);
+        $rStmt->bindValue(':currentTime', $sCurrentTime, \PDO::PARAM_STR);
         $rStmt->execute();
 
         return $rStmt->rowCount() === 0;

--- a/_protected/app/system/modules/newsletter/views/base/tpl/admin/browse.tpl
+++ b/_protected/app/system/modules/newsletter/views/base/tpl/admin/browse.tpl
@@ -40,14 +40,14 @@
             <tbody>
                 {each $user in $browse}
                     <tr>
-                        <td><input type="checkbox" name="action[]" value="{% $user->email %}" /></td>
+                        <td><input type="checkbox" name="action[]" value="{% $str->escapeAttribute($user->email) %}" /></td>
                         <td>{% $user->profileId %}</td>
                         <td>
-                            <a href="mailto:{% $user->email %}" title="{lang 'Email the Subscriber'}">
-                                {% $user->email %}
+                            <a href="mailto:{% $str->escapeAttribute($user->email) %}" title="{lang 'Email the Subscriber'}">
+                                {% escape($user->email) %}
                             </a>
                         </td>
-                        <td>{% $user->name %}</td>
+                        <td>{% escape($user->name) %}</td>
                         <td>
                             <img src="{{ $design->getSmallFlagIcon(Framework\Geo\Ip\Geo::getCountryCode($user->ip)) }}" title="{lang 'Country Flag'}" alt="{lang 'Country Flag'}" /> {{ $design->ip($user->ip) }}
                         </td>

--- a/_protected/app/system/modules/note/controllers/MainController.php
+++ b/_protected/app/system/modules/note/controllers/MainController.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Note / Controller
  */
 
 namespace PH7;
@@ -11,6 +11,7 @@ namespace PH7;
 use PH7\Datatype\Type;
 use PH7\Framework\Analytics\Statistic;
 use PH7\Framework\Cache\Cache;
+use PH7\Framework\File\File;
 use PH7\Framework\Http\Http;
 use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Mvc\Router\Uri;
@@ -21,21 +22,20 @@ use PH7\Framework\Security\CSRF\Token as SecurityToken;
 use PH7\Framework\Security\Validate\Filter;
 use PH7\Framework\Url\Header;
 use PH7\JustHttp\StatusCode;
-use stdClass;
 
 class MainController extends Controller
 {
-    const POSTS_PER_PAGE = 10;
-    const CATEGORIES_PER_PAGE = 10;
-    const AUTHORS_PER_PAGE = 10;
-    const ITEMS_MENU_TOP_VIEWS = 5;
-    const ITEMS_MENU_TOP_RATING = 5;
-    const ITEMS_MENU_AUTHORS = 6;
-    const ITEMS_MENU_CATEGORIES = 10;
-    const MAX_CATEGORIES = 300;
+    public const POSTS_PER_PAGE = 10;
+    public const CATEGORIES_PER_PAGE = 10;
+    public const AUTHORS_PER_PAGE = 10;
+    public const ITEMS_MENU_TOP_VIEWS = 5;
+    public const ITEMS_MENU_TOP_RATING = 5;
+    public const ITEMS_MENU_AUTHORS = 6;
+    public const ITEMS_MENU_CATEGORIES = 10;
+    public const MAX_CATEGORIES = 300;
 
-    const MAX_CATEGORY_LENGTH_SHOWN = 60;
-    const MAX_AUTHOR_LENGTH_SHOWN = 60;
+    public const MAX_CATEGORY_LENGTH_SHOWN = 60;
+    public const MAX_AUTHOR_LENGTH_SHOWN = 60;
 
     /** @var NoteModel */
     protected $oNoteModel;
@@ -56,8 +56,8 @@ class MainController extends Controller
     {
         parent::__construct();
 
-        $this->oNoteModel = new NoteModel;
-        $this->oPage = new Page;
+        $this->oNoteModel = new NoteModel();
+        $this->oPage = new Page();
         $this->iApproved = AdminCore::auth() && !UserCore::isAdminLoggedAs() ? null : 1;
 
         $this->view->member_id = $this->session->get('member_id');
@@ -96,7 +96,7 @@ class MainController extends Controller
     public function read($sUsername, $sPostId)
     {
         if (isset($sUsername, $sPostId)) {
-            $iProfileId = (new UserCoreModel)->getId(null, $sUsername);
+            $iProfileId = (new UserCoreModel())->getId(null, $sUsername);
             $oPost = $this->oNoteModel->readPost($sPostId, $iProfileId, $this->iApproved);
 
             if ($oPost && $this->doesPostExist($sPostId, $oPost)) {
@@ -113,10 +113,10 @@ class MainController extends Controller
 
                     /***** CONTENTS *****/
                     'h1_title' => Ban::filterWord($oPost->title),
-                    'content' => Emoticon::init((new Filter)->xssClean(Ban::filterWord($oPost->content))),
+                    'content' => Emoticon::init((new Filter())->xssClean(Ban::filterWord($oPost->content))),
                     'categories' => $this->oNoteModel->getCategory($oPost->noteId, 0, self::MAX_CATEGORIES),
 
-                    /** Date **/
+                    /* Date * */
                     'dateTime' => $this->dateTime,
                     'post' => $oPost
                 ];
@@ -311,13 +311,21 @@ class MainController extends Controller
     {
         $this->requireActionToken('note', 'main', 'delete');
 
-        $iId = $this->httpRequest->post('id');
-        $iProfileId = $this->session->get('member_id');
+        $iId = $this->httpRequest->post('id', Type::INTEGER);
+        $iProfileId = (int)$this->session->get('member_id');
+        $oPost = $this->getOwnedPost($iId, $iProfileId);
+
+        if (!$oPost) {
+            Header::redirect(
+                Uri::get('note', 'main', 'index'),
+                t('Your post could not be deleted.')
+            );
+        }
 
         CommentCoreModel::deleteRecipient($iId, 'note');
         $this->oNoteModel->deleteCategory($iId);
 
-        $this->deleteThumbFile($iId, $iProfileId);
+        $this->deleteThumbFile($oPost);
         $this->oNoteModel->deletePost($iId, $iProfileId);
 
         Note::clearCache();
@@ -329,14 +337,22 @@ class MainController extends Controller
 
     public function removeThumb($iId)
     {
-        if ((new SecurityToken)->checkUrl()) {
-            $iProfileId = $this->session->get('member_id');
-            $this->deleteThumbFile($iId, $iProfileId);
-            $this->oNoteModel->deleteThumb($iId, $iProfileId);
-            Note::clearCache();
+        if ((new SecurityToken())->checkUrl()) {
+            $iId = (int)$iId;
+            $iProfileId = (int)$this->session->get('member_id');
+            $oPost = $this->getOwnedPost($iId, $iProfileId);
 
-            $sMsg = t('The thumbnail has been deleted successfully!');
-            $sMsgType = Design::SUCCESS_TYPE;
+            if ($oPost) {
+                $this->deleteThumbFile($oPost);
+                $this->oNoteModel->deleteThumb($iId, $iProfileId);
+                Note::clearCache();
+
+                $sMsg = t('The thumbnail has been deleted successfully!');
+                $sMsgType = Design::SUCCESS_TYPE;
+            } else {
+                $sMsg = t('The thumbnail could not be deleted.');
+                $sMsgType = Design::ERROR_TYPE;
+            }
         } else {
             $sMsg = Form::errorTokenMsg();
             $sMsgType = Design::ERROR_TYPE;
@@ -372,7 +388,6 @@ class MainController extends Controller
 
         $this->view->authors = $this->getAuthorList();
 
-
         $this->view->categories = $this->getCategoryList();
     }
 
@@ -402,7 +417,7 @@ class MainController extends Controller
      */
     private function getCategoryList()
     {
-        $oCache = (new Cache)->start(NoteModel::CACHE_GROUP, 'categorylist', NoteModel::CACHE_LIFETIME);
+        $oCache = (new Cache())->start(NoteModel::CACHE_GROUP, 'categorylist', NoteModel::CACHE_LIFETIME);
 
         if (!$aCategories = $oCache->get()) {
             $aCategoryList = $this->oNoteModel->getCategory(null, 0, self::MAX_CATEGORIES);
@@ -419,7 +434,7 @@ class MainController extends Controller
                 );
 
                 if ($iTotalPostsPerCat > 0 && count($aCategories) <= self::ITEMS_MENU_CATEGORIES) {
-                    $oData = new stdClass();
+                    $oData = new \stdClass();
                     $oData->totalNotes = $iTotalPostsPerCat;
                     $oData->name = $oCategory->name;
                     $aCategories[] = $oData;
@@ -437,7 +452,7 @@ class MainController extends Controller
      */
     private function getAuthorList()
     {
-        $oCache = (new Cache)->start(NoteModel::CACHE_GROUP, 'authorlist', NoteModel::CACHE_LIFETIME);
+        $oCache = (new Cache())->start(NoteModel::CACHE_GROUP, 'authorlist', NoteModel::CACHE_LIFETIME);
 
         if (!$aAuthors = $oCache->get()) {
             $aAuthorList = $this->oNoteModel->getAuthor(0, self::ITEMS_MENU_AUTHORS);
@@ -454,7 +469,7 @@ class MainController extends Controller
                 );
 
                 if ($iTotalPostsPerAuthor > 0) {
-                    $oData = new stdClass();
+                    $oData = new \stdClass();
                     $oData->totalNotes = $iTotalPostsPerAuthor;
                     $oData->username = $oAuthor->username;
                     $aAuthors[] = $oData;
@@ -468,35 +483,44 @@ class MainController extends Controller
     }
 
     /**
-     * @internal Warning! Thumbnail must be removed before the note post in the database.
-     *
-     * @param int $iId
-     * @param int $iProfileId
-     *
-     * @return bool
+     * @internal the thumbnail must be removed before the note post in the database
      */
-    private function deleteThumbFile($iId, $iProfileId)
+    private function deleteThumbFile(\stdClass $oPost): bool
     {
-        $oFile = $this->oNoteModel->readPost(
-            $this->oNoteModel->getPostId($iId),
-            $iProfileId,
-            null
-        );
+        $sThumb = (string)$oPost->thumb;
+        if ($sThumb === '') {
+            return true;
+        }
 
-        return (new Note)->deleteThumb(
-            $this->session->get('member_username') . PH7_DS . $oFile->thumb,
+        $sUsername = (string)$this->session->get('member_username');
+        $sSafeUsername = File::getFileBasename($sUsername);
+        $sSafeThumb = File::getFileBasename($sThumb);
+        if ($sSafeUsername !== $sUsername || $sSafeThumb !== $sThumb) {
+            return false;
+        }
+
+        return (new Note())->deleteThumb(
+            $sSafeUsername . PH7_DS . $sSafeThumb,
             'note',
             $this->file
         );
     }
 
+    private function getOwnedPost(int $iId, int $iProfileId): \stdClass|false
+    {
+        $sPostId = $this->oNoteModel->getPostId($iId);
+
+        return $sPostId ?
+            $this->oNoteModel->readPost($sPostId, $iProfileId, null) :
+            false;
+    }
+
     /**
      * @param string $sPostId
-     * @param stdClass $oPost
      *
      * @return bool
      */
-    private function doesPostExist($sPostId, stdClass $oPost)
+    private function doesPostExist($sPostId, \stdClass $oPost)
     {
         return !empty($oPost->postId) && $this->str->equals($sPostId, $oPost->postId);
     }

--- a/_protected/app/system/modules/payment/views/base/tpl/admin/membershiplist.tpl
+++ b/_protected/app/system/modules/payment/views/base/tpl/admin/membershiplist.tpl
@@ -11,7 +11,7 @@
     {each $membership in $memberships}
         <tr>
             <td>{% $membership->groupId %}</td>
-            <td>{% $membership->name %}</td>
+            <td>{% escape($membership->name) %}</td>
             <td>{% $membership->price %}</td>
             <td>
                 {if $membership->expirationDays == 0}

--- a/_protected/app/system/modules/payment/views/base/tpl/main/membership.tpl
+++ b/_protected/app/system/modules/payment/views/base/tpl/main/membership.tpl
@@ -13,7 +13,7 @@
                             {{ $num_enabled_membership++ }}
                             <li class="list-group-item clearfix">
                                 <div class="pull-left">
-                                    <h4 class="underline">{% $membership->name %}</h4>
+                                    <h4 class="underline">{% escape($membership->name) %}</h4>
                                     <h5>
                                         {% $config->values['module.setting']['currency_sign'] %}{% $membership->price %}
                                         <span class="small">
@@ -28,7 +28,7 @@
                                             {/if}
                                         </span>
                                     </h5>
-                                    <p class="italic">{% $membership->description %}</p>
+                                    <p class="italic">{% nl2br(escape($membership->description)) %}</p>
                                 </div>
                                 <p class="pull-right">
                                     <a

--- a/_protected/app/system/modules/picture/controllers/MainController.php
+++ b/_protected/app/system/modules/picture/controllers/MainController.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2020, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Picture / Controller
  */
 
 namespace PH7;
@@ -17,14 +17,13 @@ use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Url\Header;
 use PH7\JustHttp\StatusCode;
-use stdClass;
 
 class MainController extends Controller
 {
     use ImageTaggable;
 
-    const ALBUMS_PER_PAGE = 16;
-    const PHOTOS_PER_PAGE = 10;
+    public const ALBUMS_PER_PAGE = 16;
+    public const PHOTOS_PER_PAGE = 10;
 
     /** @var PictureModel */
     private $oPictureModel;
@@ -48,13 +47,13 @@ class MainController extends Controller
     {
         parent::__construct();
 
-        $this->oPictureModel = new PictureModel;
-        $this->oPage = new Page;
+        $this->oPictureModel = new PictureModel();
+        $this->oPage = new Page();
 
         $this->sUsername = $this->httpRequest->get('username');
 
         $this->view->member_id = $this->session->get('member_id');
-        $this->iProfileId = (new UserCoreModel)->getId(null, $this->sUsername);
+        $this->iProfileId = (new UserCoreModel())->getId(null, $this->sUsername);
 
         // Predefined meta_keywords tags
         $this->view->meta_keywords = t('picture,photo,pictures,photos,album,albums,photo album,picture album,gallery,picture dating');
@@ -152,7 +151,7 @@ class MainController extends Controller
             $this->view->meta_description = t("Browse %0%'s Photos | Photo Album Social Community - %site_name%", $this->sUsername);
             $this->view->album = $oAlbum;
 
-            /**
+            /*
              * @internal FYI, we don't call `Statistic::setView()`, because it needs a foreach loop,
              * and it is unnecessary to do both, that's why it is located in the album.tpl view instead.
              */
@@ -194,7 +193,7 @@ class MainController extends Controller
 
     public function deletePhoto()
     {
-        if (!(new Token)->check($this->getActionTokenName('deletephoto'))) {
+        if (!(new Token())->check($this->getActionTokenName('deletephoto'))) {
             Header::redirect(
                 Uri::get('picture', 'main', 'albums'),
                 Form::errorTokenMsg()
@@ -202,17 +201,26 @@ class MainController extends Controller
         }
 
         $iPictureId = $this->httpRequest->post('picture_id', Type::INTEGER);
+        $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
+        $iProfileId = (int)$this->session->get('member_id');
+
+        if (!$this->oPictureModel->isPhotoOwnedBy($iPictureId, $iAlbumId, $iProfileId)) {
+            Header::redirect(
+                Uri::get('picture', 'main', 'albums'),
+                t('The photo could not be removed.')
+            );
+        }
 
         CommentCoreModel::deleteRecipient($iPictureId, 'picture');
 
         $this->oPictureModel->deletePhoto(
-            $this->session->get('member_id'),
-            $this->httpRequest->post('album_id', Type::INTEGER),
+            $iProfileId,
+            $iAlbumId,
             $iPictureId
         );
 
-        (new Picture)->deletePhoto(
-            $this->httpRequest->post('album_id'),
+        (new Picture())->deletePhoto(
+            $iAlbumId,
             $this->session->get('member_username'),
             $this->httpRequest->post('picture_link')
         );
@@ -224,7 +232,7 @@ class MainController extends Controller
                 'picture',
                 'main',
                 'album',
-                $this->session->get('member_username') . ',' . $this->httpRequest->post('album_title') . ',' . $this->httpRequest->post('album_id')
+                $this->session->get('member_username') . ',' . $this->httpRequest->post('album_title') . ',' . $iAlbumId
             ),
             t('Your photo has been removed.')
         );
@@ -232,17 +240,21 @@ class MainController extends Controller
 
     public function deleteAlbum()
     {
-        if (!(new Token)->check($this->getActionTokenName('deletealbum'))) {
+        if (!(new Token())->check($this->getActionTokenName('deletealbum'))) {
             Header::redirect(
                 Uri::get('picture', 'main', 'albums'),
                 Form::errorTokenMsg()
             );
         }
 
-        $this->oPictureModel->deletePhoto($this->session->get('member_id'), $this->httpRequest->post('album_id', Type::INTEGER));
-        $this->oPictureModel->deleteAlbum($this->session->get('member_id'), $this->httpRequest->post('album_id', Type::INTEGER));
-        $sDir = PH7_PATH_PUBLIC_DATA_SYS_MOD . 'picture/img/' . $this->session->get('member_username') . PH7_DS . $this->httpRequest->post('album_id') . PH7_DS;
-        $this->file->deleteDir($sDir);
+        $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
+        $this->oPictureModel->deletePhoto($this->session->get('member_id'), $iAlbumId);
+        $this->oPictureModel->deleteAlbum($this->session->get('member_id'), $iAlbumId);
+        (new Picture())->deleteAlbum(
+            $iAlbumId,
+            $this->session->get('member_username'),
+            $this->file
+        );
 
         Picture::clearCache();
 
@@ -303,7 +315,7 @@ class MainController extends Controller
         $this->output();
     }
 
-    protected function imageToSocialMetaTags(stdClass $oPicture): void
+    protected function imageToSocialMetaTags(\stdClass $oPicture): void
     {
         $sFilename = str_replace('original', '600', $oPicture->file);
         $sImageUrl = PH7_URL_DATA_SYS_MOD . 'picture/img/' . $oPicture->username . '/' . $oPicture->albumId . '/' . $sFilename;

--- a/_protected/app/system/modules/picture/controllers/MainController.php
+++ b/_protected/app/system/modules/picture/controllers/MainController.php
@@ -203,8 +203,13 @@ class MainController extends Controller
         $iPictureId = $this->httpRequest->post('picture_id', Type::INTEGER);
         $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
         $iProfileId = (int)$this->session->get('member_id');
+        $sPictureLink = $this->oPictureModel->getOwnedPhotoFile(
+            $iPictureId,
+            $iAlbumId,
+            $iProfileId
+        );
 
-        if (!$this->oPictureModel->isPhotoOwnedBy($iPictureId, $iAlbumId, $iProfileId)) {
+        if ($sPictureLink === false) {
             Header::redirect(
                 Uri::get('picture', 'main', 'albums'),
                 t('The photo could not be removed.')
@@ -222,7 +227,7 @@ class MainController extends Controller
         (new Picture())->deletePhoto(
             $iAlbumId,
             $this->session->get('member_username'),
-            $this->httpRequest->post('picture_link')
+            $sPictureLink
         );
 
         Picture::clearCache();

--- a/_protected/app/system/modules/picture/views/base/tpl/main/album.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/album.tpl
@@ -5,7 +5,7 @@
         <div class="m_photo center">
             {{ $absolute_url = Framework\Mvc\Router\Uri::get('picture','main','photo',"$a->username,$a->albumId,$a->title,$a->pictureId") }}
 
-            <h4><a href="{absolute_url}">{% substr(Framework\Security\Ban\Ban::filterWord($a->title),0,25) %}</a></h4>
+            <h4><a href="{absolute_url}">{% substr(escape(Framework\Security\Ban\Ban::filterWord($a->title)),0,25) %}</a></h4>
             <p>
                 <a href="{url_data_sys_mod}picture/img/{% $a->username %}/{% $a->albumId %}/{% str_replace('original', 1000, $a->file) %}" title="{% $str->escapeAttribute($a->title) %}" data-popup="slideshow">
                     <img src="{url_data_sys_mod}picture/img/{% $a->username %}/{% $a->albumId %}/{% str_replace('original', '400', $a->file) %}" alt="{% $str->escapeAttribute($a->title) %}" title="{% $str->escapeAttribute($a->title) %}" loading="lazy" decoding="async" />

--- a/_protected/app/system/modules/picture/views/base/tpl/main/album.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/album.tpl
@@ -15,7 +15,7 @@
             {if $is_user_auth AND $member_id == $a->profileId}
                 <div class="small">
                     <a href="{{ $design->url('picture', 'main', 'editphoto', "$a->albumId,$a->title,$a->pictureId") }}">{lang 'Edit'}</a> |
-                    {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$a->name, 'album_id'=>$a->albumId, 'picture_id'=>$a->pictureId, 'picture_link'=>$a->file)) }}
+                    {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$a->name, 'album_id'=>$a->albumId, 'picture_id'=>$a->pictureId)) }}
                 </div>
             {/if}
             <p>

--- a/_protected/app/system/modules/picture/views/base/tpl/main/albums.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/albums.tpl
@@ -3,13 +3,13 @@
         {each $album in $albums}
             {{ $absolute_url = Framework\Mvc\Router\Uri::get('picture','main','album',"$album->username,$album->name,$album->albumId") }}
             <div class="thumb_photo">
-                <h4>{% Framework\Security\Ban\Ban::filterWord($album->name) %}</h4>
+                <h4>{% escape(Framework\Security\Ban\Ban::filterWord($album->name)) %}</h4>
                 <p>
                     <a href="{absolute_url}">
                         <img src="{url_data_sys_mod}picture/img/{% $album->username %}/{% $album->albumId %}/{% $album->thumb %}" alt="{% $str->escapeAttribute($album->name) %}" title="{% $str->escapeAttribute($album->name) %}" loading="lazy" decoding="async" />
                     </a>
                 </p>
-                <p>{% nl2br(Framework\Security\Ban\Ban::filterWord($album->description)) %}</p>
+                <p>{% nl2br(escape(Framework\Security\Ban\Ban::filterWord($album->description))) %}</p>
                 <p class="italic">{lang 'Views:'} {% Framework\Mvc\Model\Statistic::getView($album->albumId,DbTableName::ALBUM_PICTURE) %}</p>
 
                 {if $is_user_auth AND $member_id == $album->profileId}

--- a/_protected/app/system/modules/picture/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/index.tpl
@@ -9,7 +9,7 @@
                 </p>
 
                 <p>
-                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('picture', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br /> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% $album->name %}</a>
+                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('picture', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br /> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% escape($album->name) %}</a>
                 </p>
             </div>
         {/each}

--- a/_protected/app/system/modules/picture/views/base/tpl/main/photo.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/photo.tpl
@@ -23,7 +23,7 @@
         {if $is_user_auth AND $member_id == $picture->profileId}
             <div class="small">
                 <a href="{{ $design->url('picture', 'main', 'editphoto', "$picture->albumId,$picture->title,$picture->pictureId") }}">{lang 'Edit'}</a> |
-                {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$picture->name, 'album_id'=>$picture->albumId, 'picture_id'=>$picture->pictureId, 'picture_link'=>$picture->file)) }}
+                {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$picture->name, 'album_id'=>$picture->albumId, 'picture_id'=>$picture->pictureId)) }}
             </div>
         {/if}
 

--- a/_protected/app/system/modules/picture/views/base/tpl/main/photo.tpl
+++ b/_protected/app/system/modules/picture/views/base/tpl/main/photo.tpl
@@ -1,6 +1,6 @@
 <div class="center">
     {if empty($error)}
-        <h2>{% Framework\Security\Ban\Ban::filterWord($picture->title) %}</h2>
+        <h2>{% escape(Framework\Security\Ban\Ban::filterWord($picture->title)) %}</h2>
         <div class="picture_block">
             <a href="{url_data_sys_mod}picture/img/{% $picture->username %}/{% $picture->albumId %}/{% str_replace('original', 1200, $picture->file) %}" title="{% $str->escapeAttribute($picture->title) %}" data-popup="image">
                 <img src="{url_data_sys_mod}picture/img/{% $picture->username %}/{% $picture->albumId %}/{% str_replace('original', '600', $picture->file) %}" alt="{% $str->escapeAttribute($picture->title) %}" title="{% $str->escapeAttribute($picture->title) %}" class="thumb" />
@@ -8,7 +8,7 @@
         </div>
 
         <p>
-            {% nl2br(Framework\Parse\Emoticon::init(Framework\Security\Ban\Ban::filterWord($picture->description))) %}
+            {% nl2br(Framework\Parse\Emoticon::init(escape(Framework\Security\Ban\Ban::filterWord($picture->description)))) %}
         </p>
         <p class="italic">
             {lang 'Album created %0%', Framework\Date\Various::textTimeStamp($picture->createdDate)}

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/album.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/album.tpl
@@ -5,7 +5,7 @@
         <div class="m_photo center">
             {{ $absolute_url = Framework\Mvc\Router\Uri::get('picture','main','photo',"$a->username,$a->albumId,$a->title,$a->pictureId") }}
 
-            <h4><a href="{absolute_url}">{% substr(Framework\Security\Ban\Ban::filterWord($a->title),0,25) %}</a></h4>
+            <h4><a href="{absolute_url}">{% substr(escape(Framework\Security\Ban\Ban::filterWord($a->title)),0,25) %}</a></h4>
             <p>
                 <a href="{url_data_sys_mod}picture/img/{% $a->username %}/{% $a->albumId %}/{% str_replace('original', 1000, $a->file) %}" title="{% $str->escapeAttribute($a->title) %}" data-popup="slideshow">
                     <img src="{url_data_sys_mod}picture/img/{% $a->username %}/{% $a->albumId %}/{% str_replace('original', '400', $a->file) %}" alt="{% $str->escapeAttribute($a->title) %}" title="{% $str->escapeAttribute($a->title) %}" loading="lazy" decoding="async" />

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/album.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/album.tpl
@@ -15,7 +15,7 @@
             {if $is_user_auth AND $member_id == $a->profileId}
                 <div class="small">
                     <a href="{{ $design->url('picture', 'main', 'editphoto', "$a->albumId,$a->title,$a->pictureId") }}">{lang 'Edit'}</a> |
-                    {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$a->name, 'album_id'=>$a->albumId, 'picture_id'=>$a->pictureId, 'picture_link'=>$a->file)) }}
+                    {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$a->name, 'album_id'=>$a->albumId, 'picture_id'=>$a->pictureId)) }}
                 </div>
             {/if}
             <p>

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/albums.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/albums.tpl
@@ -3,13 +3,13 @@
         {each $album in $albums}
             {{ $absolute_url = Framework\Mvc\Router\Uri::get('picture','main','album',"$album->username,$album->name,$album->albumId") }}
             <div class="thumb_photo">
-                <h4>{% Framework\Security\Ban\Ban::filterWord($album->name) %}</h4>
+                <h4>{% escape(Framework\Security\Ban\Ban::filterWord($album->name)) %}</h4>
                 <p>
                     <a href="{absolute_url}">
                         <img src="{url_data_sys_mod}picture/img/{% $album->username %}/{% $album->albumId %}/{% $album->thumb %}" alt="{% $str->escapeAttribute($album->name) %}" title="{% $str->escapeAttribute($album->name) %}" loading="lazy" decoding="async" />
                     </a>
                 </p>
-                <p>{% nl2br(Framework\Security\Ban\Ban::filterWord($album->description)) %}</p>
+                <p>{% nl2br(escape(Framework\Security\Ban\Ban::filterWord($album->description))) %}</p>
                 <p class="italic">{lang 'Views:'} {% Framework\Mvc\Model\Statistic::getView($album->albumId,DbTableName::ALBUM_PICTURE) %}</p>
 
                 {if $is_user_auth AND $member_id == $album->profileId}

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/index.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/index.tpl
@@ -9,7 +9,7 @@
                 </p>
 
                 <p>
-                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('picture', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br /> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% $album->name %}</a>
+                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('picture', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br /> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% escape($album->name) %}</a>
                 </p>
             </div>
         {/each}

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/photo.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/photo.tpl
@@ -23,7 +23,7 @@
         {if $is_user_auth AND $member_id == $picture->profileId}
             <div class="small">
                 <a href="{{ $design->url('picture', 'main', 'editphoto', "$picture->albumId,$picture->title,$picture->pictureId") }}">{lang 'Edit'}</a> |
-                {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$picture->name, 'album_id'=>$picture->albumId, 'picture_id'=>$picture->pictureId, 'picture_link'=>$picture->file)) }}
+                {{ LinkCoreForm::display(t('Delete'), 'picture', 'main', 'deletephoto', array('album_title'=>$picture->name, 'album_id'=>$picture->albumId, 'picture_id'=>$picture->pictureId)) }}
             </div>
         {/if}
 

--- a/_protected/app/system/modules/picture/views/premium/tpl/main/photo.tpl
+++ b/_protected/app/system/modules/picture/views/premium/tpl/main/photo.tpl
@@ -1,6 +1,6 @@
 <div class="center">
     {if empty($error)}
-        <h2>{% Framework\Security\Ban\Ban::filterWord($picture->title) %}</h2>
+        <h2>{% escape(Framework\Security\Ban\Ban::filterWord($picture->title)) %}</h2>
         <div class="picture_block">
             <a href="{url_data_sys_mod}picture/img/{% $picture->username %}/{% $picture->albumId %}/{% str_replace('original', 1200, $picture->file) %}" title="{% $str->escapeAttribute($picture->title) %}" data-popup="image">
                 <img src="{url_data_sys_mod}picture/img/{% $picture->username %}/{% $picture->albumId %}/{% str_replace('original', '600', $picture->file) %}" alt="{% $str->escapeAttribute($picture->title) %}" title="{% $str->escapeAttribute($picture->title) %}" class="thumb" />
@@ -8,7 +8,7 @@
         </div>
 
         <p>
-            {% nl2br(Framework\Parse\Emoticon::init(Framework\Security\Ban\Ban::filterWord($picture->description))) %}
+            {% nl2br(Framework\Parse\Emoticon::init(escape(Framework\Security\Ban\Ban::filterWord($picture->description)))) %}
         </p>
         <p class="italic">
             {lang 'Album created %0%', Framework\Date\Various::textTimeStamp($picture->createdDate)}

--- a/_protected/app/system/modules/report/controllers/AdminController.php
+++ b/_protected/app/system/modules/report/controllers/AdminController.php
@@ -15,6 +15,7 @@ use PH7\Framework\Layout\Html\Security;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\CSRF\Token;
+use PH7\Framework\Security\Validate\Validate;
 use PH7\Framework\Url\Header;
 
 class AdminController extends Controller
@@ -87,7 +88,11 @@ class AdminController extends Controller
         $this->view->page_title = $this->sTitle;
         $this->view->h1_title = $this->sTitle;
         $this->view->dateTime = $this->dateTime;
-        $this->view->report = $this->oReportModel->get($iId, 0, 1);
+        $oReport = $this->oReportModel->get($iId, 0, 1);
+        $this->view->report = $oReport;
+        $this->view->report_url = $oReport && (new Validate)->url((string)$oReport->url)
+            ? $oReport->url
+            : '';
 
         $this->output();
     }

--- a/_protected/app/system/modules/report/views/base/tpl/admin/report.tpl
+++ b/_protected/app/system/modules/report/views/base/tpl/admin/report.tpl
@@ -7,18 +7,18 @@
             <span class="bold">{lang 'Spammer:'}</span> {{ $avatarDesign->get($oUserModel->getUsername($report->spammerId), $oUserModel->getFirstName($report->spammerId) ,null, 64) }}
         </p>
         <p>
-            <span class="bold">{lang 'Contant Type:'}</span> <span class="italic">{% $report->contentType %}</span>
+            <span class="bold">{lang 'Content Type:'}</span> <span class="italic">{% escape($report->contentType) %}</span>
         </p>
         <p>
             <span class="bold">{lang 'URL:'}</span>
-            {if !empty($report->url)}
-                <span class="italic"><a href="{% $report->url %}" target="_blank" rel="noopener noreferrer nofollow">{% $report->url %}</a></span>
+            {if !empty($report_url)}
+                <span class="italic"><a href="{% $str->escapeAttribute($report_url) %}" target="_blank" rel="noopener noreferrer nofollow">{% escape($report_url) %}</a></span>
             {else}
                 <span class="italic underline">{lang 'URL Unavailable'}</span>
             {/if}
         </p>
         <p>
-            <span class="bold">{lang 'Description of report'}</span> <span class="italic">{% $report->description %}</span>
+            <span class="bold">{lang 'Description of report'}</span> <span class="italic">{% nl2br(escape($report->description)) %}</span>
         </p>
         <p>
             <span class="bold">{lang 'Date:'}</span><span class="italic">{% $dateTime->get($report->dateTime)->dateTime() %}</span>

--- a/_protected/app/system/modules/user/assets/ajax/WallAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/WallAjax.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / User / Asset / Ajax
  */
 
 namespace PH7;
@@ -15,12 +15,13 @@ use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Parse\Emoticon;
 use PH7\Framework\Parse\User as UserParser;
 use PH7\Framework\Security\Ban\Ban;
+use PH7\Framework\Security\CSRF\Token;
 use PH7\JustHttp\StatusCode;
 
 class WallAjax extends Core
 {
-    const MAX_ITEMS_SHOWN = 20;
-    const MAX_STRING_LENGTH_SHOWN = 80;
+    public const MAX_ITEMS_SHOWN = 20;
+    public const MAX_STRING_LENGTH_SHOWN = 80;
 
     /** @var WallModel */
     private $oWallModel;
@@ -31,7 +32,6 @@ class WallAjax extends Core
     /** @var string */
     private $sMsg;
 
-    /** @var mixed */
     private $mContents;
 
     /** @var bool */
@@ -41,30 +41,34 @@ class WallAjax extends Core
     {
         parent::__construct();
 
-        $this->oWallModel = new WallModel;
-        $this->oAvatarDesign = new AvatarDesignCore; // Avatar Design Class
+        $sAction = $this->httpRequest->post('type');
+        if (
+            in_array($sAction, ['add', 'edit', 'delete'], true)
+            && !(new Token())->checkUrl()
+        ) {
+            Http::setHeadersByCode(StatusCode::FORBIDDEN);
+            exit(jsonMsg(0, Form::errorTokenMsg()));
+        }
 
-        switch ($this->httpRequest->post('type')) {
+        $this->oWallModel = new WallModel();
+        $this->oAvatarDesign = new AvatarDesignCore(); // Avatar Design Class
+
+        switch ($sAction) {
             case 'show':
                 $this->show();
                 break;
-
             case 'showCommentProfile':
                 $this->showCommentProfile();
                 break;
-
             case 'add':
                 $this->add();
                 break;
-
             case 'edit':
                 $this->edit();
                 break;
-
             case 'delete':
                 $this->delete();
                 break;
-
             default:
                 $this->badRequest();
         }
@@ -127,7 +131,8 @@ class WallAjax extends Core
     {
         $this->bStatus = $this->oWallModel->add(
             $this->session->get('member_id'),
-            $this->httpRequest->post('post')
+            $this->httpRequest->post('post'),
+            $this->dateTime->get()->dateTime('Y-m-d H:i:s')
         );
 
         if (!$this->bStatus) {
@@ -143,7 +148,8 @@ class WallAjax extends Core
     {
         $this->bStatus = $this->oWallModel->edit(
             $this->session->get('member_id'),
-            $this->httpRequest->post('post')
+            $this->httpRequest->post('post'),
+            $this->dateTime->get()->dateTime('Y-m-d H:i:s')
         );
 
         if (!$this->bStatus) {
@@ -180,5 +186,5 @@ class WallAjax extends Core
 
 // Only for the members
 if (User::auth()) {
-    new WallAjax;
+    new WallAjax();
 }

--- a/_protected/app/system/modules/user/assets/ajax/setActivityAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/setActivityAjax.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @title          Set User Last Activity
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / User / Asset / Ajax
+ *
  * @version        1.0
  */
 
@@ -13,9 +14,17 @@ namespace PH7;
 
 defined('PH7') or exit('Restricted access');
 
+use PH7\Framework\Http\Http;
+use PH7\Framework\Security\CSRF\Token;
 use PH7\Framework\Session\Session;
+use PH7\JustHttp\StatusCode;
 
 // Only for members
 if (UserCore::auth()) {
-    (new UserCoreModel)->setLastActivity((new Session)->get('member_id'));
+    if (!(new Token())->checkUrl()) {
+        Http::setHeadersByCode(StatusCode::FORBIDDEN);
+        exit;
+    }
+
+    (new UserCoreModel())->setLastActivity((new Session())->get('member_id'));
 }

--- a/_protected/app/system/modules/user/models/WallModel.php
+++ b/_protected/app/system/modules/user/models/WallModel.php
@@ -1,23 +1,22 @@
 <?php
+
 /**
  * @title          Wall Model
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7/ App / System / Module / User / Model
  */
 
 namespace PH7;
 
-use PDO;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PH7\Framework\Mvc\Model\Engine\Model;
 
 class WallModel extends Model
 {
     /**
-     * @param int $iProfileId
+     * @param int    $iProfileId
      * @param string $sPost
      * @param string $sCreatedDate
      *
@@ -26,15 +25,15 @@ class WallModel extends Model
     public function add($iProfileId, $sPost, $sCreatedDate)
     {
         $rStmt = Db::getInstance()->prepare('INSERT INTO' . Db::prefix(DbTableName::MEMBER_WALL) . '(profileId, post, createdDate) VALUES (:profileId, :post, :createdDate)');
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':post', $sPost, PDO::PARAM_STR);
-        $rStmt->bindValue(':dateTime', $sCreatedDate, PDO::PARAM_STR);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':post', $sPost, \PDO::PARAM_STR);
+        $rStmt->bindValue(':createdDate', $sCreatedDate, \PDO::PARAM_STR);
 
         return $rStmt->execute();
     }
 
     /**
-     * @param int $iProfileId
+     * @param int    $iProfileId
      * @param string $sPost
      * @param string $sUpdatedDate
      *
@@ -43,9 +42,9 @@ class WallModel extends Model
     public function edit($iProfileId, $sPost, $sUpdatedDate)
     {
         $rStmt = Db::getInstance()->prepare('UPDATE' . Db::prefix(DbTableName::MEMBER_WALL) . 'SET post = :post, updatedDate = :updatedDate WHERE profileId = :profileId');
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':post', $sPost, PDO::PARAM_STR);
-        $rStmt->bindValue(':updatedDate', $sUpdatedDate, PDO::PARAM_STR);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':post', $sPost, \PDO::PARAM_STR);
+        $rStmt->bindValue(':updatedDate', $sUpdatedDate, \PDO::PARAM_STR);
 
         return $rStmt->execute();
     }
@@ -58,18 +57,21 @@ class WallModel extends Model
      */
     public function delete($iProfileId, $iWallId)
     {
-        $rStmt = Db::getInstance()->prepare('DELETE FROM' . Db::prefix(DbTableName::MEMBER_WALL) . 'WHERE :profileId=:profileId AND wallId=:wallId');
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
-        $rStmt->bindValue(':wallId', $iWallId, PDO::PARAM_INT);
+        $rStmt = Db::getInstance()->prepare(
+            'DELETE FROM' . Db::prefix(DbTableName::MEMBER_WALL) .
+            'WHERE profileId = :profileId AND wallId = :wallId'
+        );
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':wallId', $iWallId, \PDO::PARAM_INT);
 
         return $rStmt->execute();
     }
 
     /**
-     * @param int $iProfileId
+     * @param int      $iProfileId
      * @param int|null $iWallId
-     * @param int $iOffset
-     * @param int $iLimit
+     * @param int      $iOffset
+     * @param int      $iLimit
      *
      * @return array
      */
@@ -80,18 +82,18 @@ class WallModel extends Model
 
         $sSqlWallId = !empty($iWallId) ? ' AND wallId=:wallId ' : '';
         $sSqlQuery = 'SELECT * FROM' . Db::prefix(DbTableName::MEMBER_WALL) . ' AS w LEFT JOIN' .
-            Db::prefix(DbTableName::MEMBER) . 'AS m ON w.profileId = m.profileId WHERE :profileId=:profileId ' .
-            $sSqlWallId . ' ORDER BY dateTime DESC LIMIT :offset, :limit';
+            Db::prefix(DbTableName::MEMBER) . 'AS m ON w.profileId = m.profileId WHERE w.profileId = :profileId ' .
+            $sSqlWallId . ' ORDER BY w.createdDate DESC LIMIT :offset, :limit';
 
         $rStmt = Db::getInstance()->prepare($sSqlQuery);
-        $rStmt->bindValue(':profileId', $iProfileId, PDO::PARAM_INT);
+        $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
         if (!empty($iWallId)) {
-            $rStmt->bindValue(':wallId', $iWallId, PDO::PARAM_INT);
+            $rStmt->bindValue(':wallId', $iWallId, \PDO::PARAM_INT);
         }
-        $rStmt->bindParam(':offset', $iOffset, PDO::PARAM_INT);
-        $rStmt->bindParam(':limit', $iLimit, PDO::PARAM_INT);
+        $rStmt->bindParam(':offset', $iOffset, \PDO::PARAM_INT);
+        $rStmt->bindParam(':limit', $iLimit, \PDO::PARAM_INT);
         $rStmt->execute();
-        $aRow = $rStmt->fetchAll(PDO::FETCH_OBJ);
+        $aRow = $rStmt->fetchAll(\PDO::FETCH_OBJ);
         Db::free($rStmt);
 
         return $aRow;
@@ -106,7 +108,7 @@ class WallModel extends Model
      */
     public function getCommentProfile($iProfileId, $iOffset, $iLimit)
     {
-        return (new CommentCoreModel)->read(
+        return (new CommentCoreModel())->read(
             $iProfileId,
             '1',
             $iOffset,

--- a/_protected/app/system/modules/video/controllers/MainController.php
+++ b/_protected/app/system/modules/video/controllers/MainController.php
@@ -204,8 +204,13 @@ class MainController extends Controller
         $iVideoId = $this->httpRequest->post('video_id', Type::INTEGER);
         $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
         $iProfileId = (int)$this->session->get('member_id');
+        $sVideoLink = $this->oVideoModel->getOwnedVideoFile(
+            $iVideoId,
+            $iAlbumId,
+            $iProfileId
+        );
 
-        if (!$this->oVideoModel->isVideoOwnedBy($iVideoId, $iAlbumId, $iProfileId)) {
+        if ($sVideoLink === false) {
             Header::redirect(
                 Uri::get('video', 'main', 'albums'),
                 t('The video could not be removed.')
@@ -223,7 +228,7 @@ class MainController extends Controller
         (new Video())->deleteVideo(
             $iAlbumId,
             $this->session->get('member_username'),
-            $this->httpRequest->post('video_link')
+            $sVideoLink
         );
 
         Video::clearCache();

--- a/_protected/app/system/modules/video/controllers/MainController.php
+++ b/_protected/app/system/modules/video/controllers/MainController.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Video / Controller
  */
 
 namespace PH7;
@@ -16,14 +16,13 @@ use PH7\Framework\Navigation\Page;
 use PH7\Framework\Security\Ban\Ban;
 use PH7\Framework\Url\Header;
 use PH7\JustHttp\StatusCode;
-use stdClass;
 
 class MainController extends Controller
 {
     use ImageTaggable;
 
-    const ALBUMS_PER_PAGE = 14;
-    const VIDEOS_PER_PAGE = 10;
+    public const ALBUMS_PER_PAGE = 14;
+    public const VIDEOS_PER_PAGE = 10;
 
     /** @var VideoModel */
     private $oVideoModel;
@@ -47,12 +46,12 @@ class MainController extends Controller
     {
         parent::__construct();
 
-        $this->oVideoModel = new VideoModel;
-        $this->oPage = new Page;
+        $this->oVideoModel = new VideoModel();
+        $this->oPage = new Page();
         $this->sUsername = $this->httpRequest->get('username');
 
         $this->view->member_id = $this->session->get('member_id');
-        $this->iProfileId = (new UserCoreModel)->getId(null, $this->sUsername);
+        $this->iProfileId = (new UserCoreModel())->getId(null, $this->sUsername);
 
         // Predefined meta_keywords tags
         $this->view->meta_keywords = t('video,videos,free,free videos,music,online,watch,dating,video dating,social,community,social network,people video,flirt');
@@ -155,7 +154,7 @@ class MainController extends Controller
             $this->view->meta_description = t('Browse Videos From %0% | Video Album Social Community - %site_name%', $this->sUsername);
             $this->view->album = $oAlbum;
 
-            /**
+            /*
              * @internal FYI, we don't call `Statistic::setView()`, because it needs a foreach loop,
              * and it is unnecessary to do both, that's why it is located in the album.tpl view instead.
              */
@@ -203,30 +202,38 @@ class MainController extends Controller
         $this->requireActionToken('video', 'main', 'deletevideo');
 
         $iVideoId = $this->httpRequest->post('video_id', Type::INTEGER);
+        $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
+        $iProfileId = (int)$this->session->get('member_id');
+
+        if (!$this->oVideoModel->isVideoOwnedBy($iVideoId, $iAlbumId, $iProfileId)) {
+            Header::redirect(
+                Uri::get('video', 'main', 'albums'),
+                t('The video could not be removed.')
+            );
+        }
 
         CommentCoreModel::deleteRecipient($iVideoId, 'video');
 
         $this->oVideoModel->deleteVideo(
-            $this->session->get('member_id'),
-            $this->httpRequest->post('album_id', Type::INTEGER),
+            $iProfileId,
+            $iAlbumId,
             $iVideoId
         );
 
-        (new Video)->deleteVideo(
-            $this->httpRequest->post('album_id'),
+        (new Video())->deleteVideo(
+            $iAlbumId,
             $this->session->get('member_username'),
             $this->httpRequest->post('video_link')
         );
 
         Video::clearCache();
 
-
         Header::redirect(
             Uri::get(
                 'video',
                 'main',
                 'album',
-                $this->session->get('member_username') . ',' . $this->httpRequest->post('album_title') . ',' . $this->httpRequest->post('album_id')
+                $this->session->get('member_username') . ',' . $this->httpRequest->post('album_title') . ',' . $iAlbumId
             ),
             t('Your video has been removed.')
         );
@@ -236,10 +243,14 @@ class MainController extends Controller
     {
         $this->requireActionToken('video', 'main', 'deletealbum');
 
-        $this->oVideoModel->deleteVideo($this->session->get('member_id'), $this->httpRequest->post('album_id', Type::INTEGER));
-        $this->oVideoModel->deleteAlbum($this->session->get('member_id'), $this->httpRequest->post('album_id', Type::INTEGER));
-        $sDir = PH7_PATH_PUBLIC_DATA_SYS_MOD . 'video/file/' . $this->session->get('member_username') . PH7_DS . $this->httpRequest->post('album_id') . PH7_DS;
-        $this->file->deleteDir($sDir);
+        $iAlbumId = $this->httpRequest->post('album_id', Type::INTEGER);
+        $this->oVideoModel->deleteVideo($this->session->get('member_id'), $iAlbumId);
+        $this->oVideoModel->deleteAlbum($this->session->get('member_id'), $iAlbumId);
+        (new Video())->deleteAlbum(
+            $iAlbumId,
+            $this->session->get('member_username'),
+            $this->file
+        );
 
         Video::clearCache();
 
@@ -299,7 +310,7 @@ class MainController extends Controller
         $this->output();
     }
 
-    protected function imageToSocialMetaTags(stdClass $oVideo): void
+    protected function imageToSocialMetaTags(\stdClass $oVideo): void
     {
         $sImageUrl = PH7_URL_DATA_SYS_MOD . 'video/file/' . $oVideo->username . '/' . $oVideo->albumId . '/' . $oVideo->thumb;
         $this->view->image_social_meta_tag = $sImageUrl;

--- a/_protected/app/system/modules/video/views/base/tpl/main/album.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/album.tpl
@@ -11,7 +11,7 @@
             {if $is_user_auth AND $member_id == $a->profileId}
                 <div class="small">
                     <a href="{{ $design->url('video', 'main', 'editvideo', "$a->albumId,$a->title,$a->videoId") }}">{lang 'Edit'}</a> |
-                    {{ LinkCoreForm::display(t('Delete'), 'video', 'main', 'deletevideo', array('album_title'=>$a->name,'album_id'=>$a->albumId,'video_id'=>$a->videoId,'video_link'=>$a->file)) }}
+                    {{ LinkCoreForm::display(t('Delete'), 'video', 'main', 'deletevideo', array('album_title'=>$a->name,'album_id'=>$a->albumId,'video_id'=>$a->videoId)) }}
                 </div>
             {/if}
             <p>

--- a/_protected/app/system/modules/video/views/base/tpl/main/albums.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/albums.tpl
@@ -4,14 +4,14 @@
             {{ $absolute_url = Framework\Mvc\Router\Uri::get('video','main','album',"$album->username,$album->name,$album->albumId") }}
 
             <div class="thumb_photo">
-                <h4>{% Framework\Security\Ban\Ban::filterWord($album->name) %}</h4>
+                <h4>{% escape(Framework\Security\Ban\Ban::filterWord($album->name)) %}</h4>
                 <p>
                     <a href="{absolute_url}">
                         <img src="{url_data_sys_mod}video/file/{% $album->username %}/{% $album->albumId %}/{% $album->thumb %}" alt="{% $str->escapeAttribute($album->name) %}" title="{% $str->escapeAttribute($album->name) %}" loading="lazy" decoding="async" />
                     </a>
                 </p>
 
-                <p>{% nl2br(Framework\Security\Ban\Ban::filterWord($album->description)) %}</p>
+                <p>{% nl2br(escape(Framework\Security\Ban\Ban::filterWord($album->description))) %}</p>
                 <p class="italic">{lang 'Views:'} {% Framework\Mvc\Model\Statistic::getView($album->albumId,DbTableName::ALBUM_VIDEO) %}</p>
 
                 {if $is_user_auth AND $member_id == $album->profileId}

--- a/_protected/app/system/modules/video/views/base/tpl/main/index.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/index.tpl
@@ -9,7 +9,7 @@
                 </p>
 
                 <p>
-                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('video', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% $album->name %}</a>
+                    {lang 'by'} {{ $design->getProfileLink($album->username) }} {lang 'in'} <a href="{{ $design->url('video', 'main', 'album', "$album->username,$album->name,$album->albumId") }}" title="{lang 'Album created on %0%', $album->createdDate}{if !empty($album->updatedDate)}<br> {lang 'Modified on %0%', $album->updatedDate}{/if}">{% escape($album->name) %}</a>
                 </p>
             </div>
         {/each}

--- a/_protected/app/system/modules/video/views/base/tpl/main/video.tpl
+++ b/_protected/app/system/modules/video/views/base/tpl/main/video.tpl
@@ -19,7 +19,7 @@
         {if $is_user_auth AND $member_id == $video->profileId}
             <div class="small">
                 <a href="{{ $design->url('video', 'main', 'editvideo', "$video->albumId,$video->title,$video->videoId") }}">{lang 'Edit'}</a> |
-                {{ LinkCoreForm::display(t('Delete'), 'video', 'main', 'deletevideo', array('album_title'=>$video->name, 'album_id'=>$video->albumId, 'video_id'=>$video->videoId, 'video_link'=>$video->file)) }}
+                {{ LinkCoreForm::display(t('Delete'), 'video', 'main', 'deletevideo', array('album_title'=>$video->name, 'album_id'=>$video->albumId, 'video_id'=>$video->videoId)) }}
             </div>
         {/if}
 

--- a/_protected/framework/Ajax/Ajax.class.php
+++ b/_protected/framework/Ajax/Ajax.class.php
@@ -1,11 +1,11 @@
 <?php
+
 /**
  * @title            Ajax Helper Class
  *
  * @author           Pierre-Henry SORIA <hello@ph7builder.com>
  * @copyright        (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / Framework / Ajax
  */
 
 declare(strict_types=1);
@@ -17,13 +17,18 @@ namespace PH7\Framework\Ajax {
     {
         /**
          * @param int $iStatus 1 = success | 0 = error
-         * @param string $sTxt
          *
          * @return string JSON Format
          */
         public static function jsonMsg(int $iStatus, string $sTxt): string
         {
-            return '{"status":' . $iStatus . ',"txt":"' . $sTxt . '"}';
+            return json_encode(
+                [
+                    'status' => $iStatus,
+                    'txt' => $sTxt
+                ],
+                JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+            );
         }
     }
 }

--- a/_protected/framework/Api/Api.trait.php
+++ b/_protected/framework/Api/Api.trait.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author           Pierre-Henry SORIA <hello@ph7builder.com>
  * @copyright        (c) 2015-2023, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / Framework / Api
  */
 
 namespace PH7\Framework\Api;
@@ -12,19 +12,56 @@ defined('PH7') or exit('Restricted access');
 
 trait Api
 {
+    private const SENSITIVE_FIELDS = [
+        'password',
+        'hashValidation',
+        'twoFactorAuthSecret'
+    ];
+
     /**
-     * Encode the data to JSON
+     * Encode the data to JSON.
      *
-     * @param mixed $mData
-     *
-     * @return string|bool Returns the data encoded to JSON or FALSE if the data is invalid.
+     * @return string|bool returns the data encoded to JSON or FALSE if the data is invalid
      */
     public function set($mData): string|bool
     {
         if (is_array($mData)) {
-            return json_encode($mData);
+            return json_encode($this->filterSensitiveFields($mData));
         }
 
         return false;
+    }
+
+    private function filterSensitiveFields(mixed $mData): mixed
+    {
+        if (is_array($mData)) {
+            foreach ($mData as $sField => $mValue) {
+                if (is_string($sField) && in_array($sField, self::SENSITIVE_FIELDS, true)) {
+                    unset($mData[$sField]);
+                    continue;
+                }
+
+                $mData[$sField] = $this->filterSensitiveFields($mValue);
+            }
+
+            return $mData;
+        }
+
+        if (is_object($mData)) {
+            $oFilteredData = clone $mData;
+
+            foreach (get_object_vars($oFilteredData) as $sField => $mValue) {
+                if (in_array($sField, self::SENSITIVE_FIELDS, true)) {
+                    unset($oFilteredData->{$sField});
+                    continue;
+                }
+
+                $oFilteredData->{$sField} = $this->filterSensitiveFields($mValue);
+            }
+
+            return $oFilteredData;
+        }
+
+        return $mData;
     }
 }

--- a/_protected/framework/Error/CException/ErrException.class.php
+++ b/_protected/framework/Error/CException/ErrException.class.php
@@ -1,12 +1,14 @@
 <?php
+
 /**
  * @title          Error Exception Class
+ *
  * @desc           Management error messages for the Exceptions.
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7/ Framework / Error / CException
+ *
  * @version        1.1
  */
 
@@ -21,21 +23,18 @@ namespace PH7\Framework\Error\CException {
         public function __toString()
         {
             switch ($this->severity) {
-                case E_USER_ERROR : // If the user issues a fatal error
+                case E_USER_ERROR: // If the user issues a fatal error
                     $sType = 'Fatal error ';
                     break;
-
-                case E_WARNING : // If PHP issues a warning
-                case E_USER_WARNING : // If the user issues a warning
+                case E_WARNING: // If PHP issues a warning
+                case E_USER_WARNING: // If the user issues a warning
                     $sType = 'Warning error';
                     break;
-
-                case E_NOTICE : // If PHP issues a notice
-                case E_USER_NOTICE : // If the user issues a notice
+                case E_NOTICE: // If PHP issues a notice
+                case E_USER_NOTICE: // If the user issues a notice
                     $sType = 'Notice error';
                     break;
-
-                default : // Unknown error
+                default: // Unknown error
                     $sType = 'Unknown error';
                     break;
             }
@@ -47,12 +46,13 @@ namespace PH7\Framework\Error\CException {
 
 namespace {
     use PH7\Framework\Error\CException\ErrException;
+    use PH7\Framework\Error\CException\PH7Exception;
 
     /**
      * The code serves as severity
-     * Refer to the predefined constants for more information: http://php.net/manual/errorfunc.constants.php
+     * Refer to the predefined constants for more information: http://php.net/manual/errorfunc.constants.php.
      *
-     * @param integer $iCode
+     * @param int    $iCode
      * @param string $sMessage
      * @param string $sFile
      * @param string $sLine
@@ -64,13 +64,9 @@ namespace {
         throw new ErrException($sMessage, 0, $iCode, $sFile, $sLine);
     }
 
-    /**
-     * @param ErrException $oExcept
-     */
     function customExcept(ErrException $oExcept)
     {
-        //header('HTTP/1.1 500 Internal Server Error');
-        echo '<b>ERROR:</b><br /> Message: ', $oExcept->getMessage(), '<br />File: ', $oExcept->getFile(), 'Line: ', $oExcept->getLine(), '<br />';
+        PH7Exception::launch($oExcept);
     }
 
     set_error_handler('errExcept');

--- a/_protected/framework/Layout/Form/Engine/PFBC/Element/Token.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Element/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file has been made by pH7 (Pierre-Henry SORIA).
  */
@@ -6,7 +7,6 @@
 namespace PFBC\Element;
 
 use PFBC\Validation\Token as ValidationToken;
-use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Security\CSRF\Token as SecurityToken;
 
 class Token extends Hidden
@@ -15,32 +15,13 @@ class Token extends Hidden
 
     public function __construct(string $sName)
     {
-        if (!$this->isEnabled()) {
-            return; // If it's disabled, we stop the execution of the class
-        }
-
         $this->sName = $sName;
-        parent::__construct('security_token', (new SecurityToken)->generate($this->sName));
+        parent::__construct('security_token', (new SecurityToken())->generate($this->sName));
     }
 
     public function render()
     {
-        if (!$this->isEnabled()) {
-            return; // If it's disabled, we stop the execution of the class
-        }
-
         $this->validation[] = new ValidationToken($this->sName);
         parent::render();
-    }
-
-    /**
-     * Check if the CSRF security token for forms is enabled.
-     *
-     * @return bool Returns TRUE if the security token is enabled, FALSE otherwise.
-     */
-    private function isEnabled(): bool
-    {
-        // Check if the CSRF security token for forms is enabled
-        return (bool)DbConfig::getSetting('securityToken');
     }
 }

--- a/_protected/framework/Mvc/Request/Http.class.php
+++ b/_protected/framework/Mvc/Request/Http.class.php
@@ -396,7 +396,9 @@ class Http extends \PH7\Framework\Http\Http
         }
 
         if (!empty($sParam) && $sParam === self::ONLY_XSS_CLEAN) {
-            return (new Secty\Validate\Filter)->xssClean($aType[$sKey]);
+            // Use the dedicated rich-text sanitizer directly. Filter::xssClean()
+            // delegates to the same Purifier and remains a compatibility entry point.
+            return (new Secty\Validate\Purifier)->xssClean($aType[$sKey]);
         }
 
         return escape($aType[$sKey], $this->bStrip);

--- a/_tests/Unit/Framework/Ajax/AjaxTest.php
+++ b/_tests/Unit/Framework/Ajax/AjaxTest.php
@@ -26,4 +26,18 @@ final class AjaxTest extends TestCase
         $sActualResult = Ajax::jsonMsg(0, 'Noooo! :(');
         $this->assertSame('{"status":0,"txt":"Noooo! :("}', $sActualResult);
     }
+
+    public function testJsonMsgEscapesUntrustedSyntax(): void
+    {
+        $sActualResult = Ajax::jsonMsg(0, '"},"injected":true,"txt":"');
+
+        $this->assertSame(
+            '{"status":0,"txt":"\\"},\\"injected\\":true,\\"txt\\":\\""}',
+            $sActualResult
+        );
+        $this->assertSame(
+            ['status' => 0, 'txt' => '"},"injected":true,"txt":"'],
+            json_decode($sActualResult, true, 512, JSON_THROW_ON_ERROR)
+        );
+    }
 }

--- a/_tests/Unit/Framework/Api/ApiTest.php
+++ b/_tests/Unit/Framework/Api/ApiTest.php
@@ -24,8 +24,40 @@ final class ApiTest extends TestCase
 
     public function testSetWithValidData(): void
     {
-        $aData = json_decode('{"status":1,"msg":"Hello World!"}', true);
+        $sJsonData = $this->set(['status' => 1, 'msg' => 'Hello World!']);
 
-        $this->assertSame(['status' => 1, 'msg' => 'Hello World!'], $aData);
+        $this->assertSame(
+            ['status' => 1, 'msg' => 'Hello World!'],
+            json_decode($sJsonData, true, 512, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function testSetOmitsCredentialFieldsRecursively(): void
+    {
+        $oProfile = (object) [
+            'username' => 'alice',
+            'password' => 'password-hash',
+            'hashValidation' => 'validation-secret',
+            'twoFactorAuthSecret' => 'two-factor-secret'
+        ];
+
+        $sJsonData = $this->set([
+            'profile' => $oProfile,
+            'related' => [
+                [
+                    'username' => 'bob',
+                    'password' => 'plaintext-password'
+                ]
+            ]
+        ]);
+        $aData = json_decode($sJsonData, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('alice', $aData['profile']['username']);
+        $this->assertSame('bob', $aData['related'][0]['username']);
+        $this->assertArrayNotHasKey('password', $aData['profile']);
+        $this->assertArrayNotHasKey('hashValidation', $aData['profile']);
+        $this->assertArrayNotHasKey('twoFactorAuthSecret', $aData['profile']);
+        $this->assertArrayNotHasKey('password', $aData['related'][0]);
+        $this->assertSame('password-hash', $oProfile->password);
     }
 }

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TokenTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TokenTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Layout / Form / Engine / PFBC / Element
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout\Form\Engine\PFBC\Element;
+
+// PFBC registers its own spl_autoload_register in Form.class.php
+require_once PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+
+use PFBC\Element\Token;
+use PFBC\Form;
+use PHPUnit\Framework\TestCase;
+
+final class TokenTest extends TestCase
+{
+    public function testTokenAlwaysRendersAHiddenField(): void
+    {
+        new Form('csrf_token_test');
+        $oToken = new Token('csrf_token_test');
+
+        ob_start();
+        $oToken->render();
+        $sHtml = ob_get_clean();
+
+        $this->assertStringContainsString('name="security_token"', $sHtml);
+        $this->assertMatchesRegularExpression('/value="[^"]+"/', $sHtml);
+    }
+}

--- a/static/js/Like.js
+++ b/static/js/Like.js
@@ -46,7 +46,7 @@ var Like = {
             context: oElement,
             type: 'POST',
             dataType: 'json',
-            url: pH7Url.base + 'asset/ajax/Like/',
+            url: pH7Url.base + 'asset/ajax/Like/' + pH7Url.csrf,
             data: 'vote=1&key=' + encodeURIComponent($(oElement).data('key')),
             success: function (oData) {
                 $(this).css({'opacity': 0});

--- a/static/js/Wall.js
+++ b/static/js/Wall.js
@@ -63,7 +63,7 @@ function Wall() {
     this.add = function () {
         var sPost = $('.wall_post').val();
 
-        $.post(pH7Url.base + this.sUrl, {type: 'add', 'post': sPost}, function (oData) {
+        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'add', 'post': sPost}, function (oData) {
             oMe._output(oData);
         }, 'json');
     };
@@ -77,7 +77,7 @@ function Wall() {
     this.edit = function () {
         var sPost = $('.wall_post').val();
 
-        $.post(pH7Url.base + this.sUrl, {type: 'edit', 'post': sPost}, function (oData) {
+        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'edit', 'post': sPost}, function (oData) {
             oMe._output(oData);
         }, 'json');
     };
@@ -91,7 +91,7 @@ function Wall() {
     this.del = function () {
         var sPost = $('.wall_id').val();
 
-        $.post(pH7Url.base + this.sUrl, {type: 'delete', 'post': sPost}, function (oData) {
+        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'delete', 'post': sPost}, function (oData) {
             oMe._output(oData);
         }, 'json');
     };

--- a/static/js/jquery/rating.js
+++ b/static/js/jquery/rating.js
@@ -15,7 +15,7 @@
     $.fn.pHRating = function (op) {
         var defaults = {
             /** String vars **/
-            url: pH7Url.base + 'asset/ajax/Rating/',
+            url: pH7Url.base + 'asset/ajax/Rating/' + pH7Url.csrf,
             bigStarUrl: pH7Url.stic + 'img/icon/m-star.png',
             smallStarUrl: pH7Url.stic + 'img/icon/s-star.png',
             type: 'big', // can be set to 'small' or 'big'

--- a/static/js/setUserActivity.js
+++ b/static/js/setUserActivity.js
@@ -5,7 +5,7 @@
  */
 
 function sendUserActivityHeartbeat() {
-    $.get(pH7Url.base + 'user/asset/ajax/setActivity');
+    $.get(pH7Url.base + 'user/asset/ajax/setActivity' + pH7Url.csrf);
 }
 
 function startUserActivityTracking() {

--- a/templates/system/modules/im/themes/base/js/Messenger.js
+++ b/templates/system/modules/im/themes/base/js/Messenger.js
@@ -42,6 +42,12 @@ var Messenger = {
         return this;
     },
 
+    getEndpointUrl: function (sAction) {
+        var sQuerySeparator = pH7Url.csrf === '' ? '?' : '&';
+
+        return pH7Url.base + 'im/asset/ajax/Messenger/' + pH7Url.csrf + sQuerySeparator + 'act=' + sAction;
+    },
+
     scheduleHeartbeat: function () {
         if (this.iHeartbeatTimer !== null) {
             clearTimeout(this.iHeartbeatTimer);
@@ -213,7 +219,7 @@ var Messenger = {
 
         $.ajax(
             {
-                url: pH7Url.base + "im/asset/ajax/Messenger/?act=heartbeat",
+                url: this.getEndpointUrl('heartbeat'),
                 type: 'POST',
                 cache: false,
                 dataType: "json",
@@ -272,7 +278,7 @@ var Messenger = {
         $('#chatbox_' + sBoxTitle).css('display', 'none');
         this.restructureBoxes();
 
-        $.post(pH7Url.base + "im/asset/ajax/Messenger/?act=close", {box: sBoxTitle});
+        $.post(this.getEndpointUrl('close'), {box: sBoxTitle});
     },
 
     toggleBoxGrowth: function (sBoxTitle) {
@@ -318,7 +324,7 @@ var Messenger = {
             $(oBoxTextarea).focus();
             $(oBoxTextarea).css('height', '44px');
             if (this.sMessage != '') {
-                $.post(pH7Url.base + "im/asset/ajax/Messenger/?act=send", {
+                $.post(this.getEndpointUrl('send'), {
                     to: sBoxTitle,
                     message: this.sMessage
                 }, function (oData) {
@@ -350,7 +356,7 @@ var Messenger = {
     startSession: function () {
         $.ajax(
             {
-                url: pH7Url.base + "im/asset/ajax/Messenger/?act=startsession",
+                url: this.getEndpointUrl('startsession'),
                 type: 'POST',
                 cache: false,
                 dataType: "json",

--- a/templates/themes/base/js/global.js
+++ b/templates/themes/base/js/global.js
@@ -78,6 +78,14 @@ $goBox();
 // Setup tooltips
 // Title of the links
 
+function encodeTooltipText(oElement) {
+    const sTitle = oElement.attr('title');
+
+    if (typeof sTitle === 'string') {
+        oElement.attr('title', $('<div>').text(sTitle).html());
+    }
+}
+
 $('a[title],img[title],abbr[title]').each(function () {
     // "bIsDataPopup" checks that only for links that do not possess the attribute "data-popup", otherwise not the title of the popup (colorbox) cannot appear because of the plugin (tipTip).
     const bIsDataPopup = $(this).data('popup');
@@ -85,6 +93,8 @@ $('a[title],img[title],abbr[title]').each(function () {
     if (!bIsDataPopup) {
         const oE = $(this);
         let pos = "top";
+
+        encodeTooltipText(oE);
 
         if (oE.hasClass("tttop")) {
             pos = "top";
@@ -114,6 +124,8 @@ $('a[title],img[title],abbr[title]').each(function () {
 
 // Title of the Forms
 $('form input[title],textarea[title],select[title]').each(function () {
+    encodeTooltipText($(this));
+
     $(this).tipTip({
         activation: 'focus',
         edgeOffset: 5,

--- a/templates/themes/base/tpl/layout.tpl
+++ b/templates/themes/base/tpl/layout.tpl
@@ -84,7 +84,7 @@
     <!-- End CSS -->
 
     <!-- Begin Header JavaScript -->
-    <script>var pH7Url={base:'{url_root}',relative:'{url_relative}',tpl:'{url_tpl}',stic:'{url_static}',tplImg:'{url_tpl_img}',tplJs:'{url_tpl_js}',tplMod:'{url_tpl_mod}',data:'{url_data}'};</script>
+    <script>var pH7Url={base:'{url_root}',relative:'{url_relative}',tpl:'{url_tpl}',stic:'{url_static}',tplImg:'{url_tpl_img}',tplJs:'{url_tpl_js}',tplMod:'{url_tpl_mod}',data:'{url_data}',csrf:{% json_encode((new Framework\Security\CSRF\Token)->url(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) %}};</script>
     {if $is_admin_auth}<script>pH7Url.admin_mod = '{url_admin_mod}';</script>{/if}
     {{ $design->externalJsFile(PH7_URL_STATIC . PH7_JS . 'jquery/jquery.js') }}
     <!-- End Header JavaScript -->

--- a/templates/themes/premium/tpl/layout.tpl
+++ b/templates/themes/premium/tpl/layout.tpl
@@ -75,7 +75,7 @@
     <!-- End CSS -->
 
     <!-- Begin Header JavaScript -->
-    <script>var pH7Url={base:'{url_root}',relative:'{url_relative}',tpl:'{url_tpl}',stic:'{url_static}',tplImg:'{url_tpl_img}',tplJs:'{url_tpl_js}',tplMod:'{url_tpl_mod}',data:'{url_data}'};</script>
+    <script>var pH7Url={base:'{url_root}',relative:'{url_relative}',tpl:'{url_tpl}',stic:'{url_static}',tplImg:'{url_tpl_img}',tplJs:'{url_tpl_js}',tplMod:'{url_tpl_mod}',data:'{url_data}',csrf:{% json_encode((new Framework\Security\CSRF\Token)->url(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) %}};</script>
     {if $is_admin_auth}<script>pH7Url.admin_mod = '{url_admin_mod}';</script>{/if}
     {{ $design->externalJsFile(PH7_URL_STATIC . PH7_JS . 'jquery/jquery.js') }}
     <!-- End Header JavaScript -->


### PR DESCRIPTION
## Summary

- sanitize forum rich-text output to block stored XSS while preserving supported formatting
- encode untrusted values at HTML, attribute, tooltip, and JSON output boundaries
- enforce CSRF validation on state-changing forms and AJAX requests
- scope media, note, wall, mail, rating, and backup mutations to authorized resources
- remove credential fields from nested API responses and contain exception details
- bind photo and video deletion targets to their ownership-scoped database rows

## Moderator token review

`Permission.php` authenticates and authorizes administrators, but it does not verify request intent. `requireModeratorActionToken()` therefore remains necessary as a separate CSRF control. Every one of the 18 state-changing moderator actions validates the exact token generated by its `LinkCoreForm`; the seven read-only moderator actions intentionally remain token-free. No duplicate sanitizer or authorization check is introduced.

## Compatibility

Normal moderation links continue to work because their token field and controller validator derive the same token name from the same route. Only missing, stale, or forged mutation requests are rejected. The security-token setting remains present for configuration compatibility, while token generation is now mandatory at runtime so a legacy setting cannot silently disable CSRF protection.

Media deletion no longer trusts a separate posted filename. The server resolves the filename from the already-authorized photo or video row, preserving normal deletion behavior while preventing record/file target substitution.

## Verification

- 502 PHPUnit tests, 600 assertions
- focused API credential-filter regression tests: 3 tests, 9 assertions
- PHP syntax checks for all non-vendor PHP files
- JavaScript syntax checks for all non-vendor JavaScript files
- PHPStan: no errors
- Composer validation: valid
- root and installer Composer audits: no advisories
- PHP CS Fixer and `git diff --check`
- GitHub Actions: 41/41 checks pass on the head commit
