### PR TITLE
Prepare v18.5 for release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
-.git
-_tests
-*.md
-!README.md
+*
+!Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Validate Docker
+
+on:
+  push:
+    branches:
+      - 18.x
+  pull_request:
+    branches:
+      - 18.x
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Compose configuration
+        run: docker compose config --quiet
+
+      - name: Build development image
+        run: docker compose build
+
+      - name: Start development stack
+        run: docker compose up --detach --wait
+
+      - name: Verify installer responds
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --location --silent --show-error http://localhost:8080/ > /dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker compose logs
+          exit 1
+
+      - name: Stop development stack
+        if: always()
+        run: docker compose down --volumes

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,9 +17,8 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 35
           add-issue-labels: 'locked, outdated'
           exclude-any-issue-labels: 'help wanted'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,12 @@ Without Docker: any PHP >= 8.2 with the extensions listed in `composer.json`, My
    ```
 3. **Run the tests and static analysis** — both must stay green:
    ```console
-   composer test      # PHPUnit
+   composer test      # deterministic PHPUnit suite
    composer analyse   # PHPStan
    ```
+   The separate `composer test-integration` suite requires an installed local
+   application and the external services or API credentials exercised by those
+   tests.
 4. Keep commits focused and their messages descriptive. Small, reviewable pull requests get merged faster.
 
 Theme/CSS contributions: `_tools/theme-preview.html` renders the base theme's CSS chain against sample markup without a full install — serve the repo root (e.g. `python3 -m http.server 8642`) and open it to check your changes, in both light and dark mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,15 @@ Thank you for helping to make pH7Builder the best free dating/social web app bui
 ```console
 git clone https://github.com/pH7Software/pH7-Social-Dating-CMS.git
 cd pH7-Social-Dating-CMS
-composer install          # installs into _protected/vendor
-docker compose up         # PHP + MySQL; then open http://localhost to run the installer
+docker compose up --build
 ```
 
-Without Docker: any PHP >= 8.2 with the extensions listed in `composer.json`, MySQL/MariaDB, and Apache/nginx (see `nginx.conf` / `sample.htaccess`).
+Open http://localhost:8080 to run the installer. The development database uses
+host `db`, database and username `ph7builder`, and password `ph7builder`.
+
+Without Docker: install dependencies with `composer install`, then use any PHP
+>= 8.2 installation with the extensions listed in `composer.json`,
+MySQL/MariaDB, and Apache/nginx (see `nginx.conf` / `sample.htaccess`).
 
 ## Before you open a pull request
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,23 @@
-# Set the wanted Ubuntu & PHP versions
-ARG UBUNTU_VERSION=22.04
-ARG PHP_VERSION=8.2.0
-ARG PHP_BASE_IMAGE=fpm
+# syntax=docker/dockerfile:1
 
+ARG PHP_VERSION=8.2
 
-# Set the base image to Ubuntu
-FROM ubuntu:${UBUNTU_VERSION}
+FROM composer:2 AS composer
 
-# Install Nginx
+FROM php:${PHP_VERSION}-fpm-bookworm
 
-# Add application repository URL to the default sources
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ raring main universe" >> /etc/apt/sources.list
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libonig-dev \
+        libpng-dev \
+        libzip-dev \
+        unzip \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" exif gd mbstring pdo_mysql zip \
+    && rm -rf /var/lib/apt/lists/*
 
-# Update the repository & upgrade
-RUN apt update && apt upgrade -y
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
-# Install locale for Gettext
-RUN apt -y install apt-utils
-RUN apt -y install locales
-
-# Set the locale
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-RUN apt install -y software-properties-common
-
-# Install dependencies
-RUN apt install -y && \
-    bzip2 curl git less mysql-client sudo unzip zip \
-    libbz2-dev libfontconfig1 libfontconfig1-dev \
-    libfreetype6-dev libjpeg62-turbo-dev libpng12-dev libzip-dev
-
-# Download and Install Nginx
-RUN apt install -y nginx
-
-# Remove the default Nginx configuration file
-RUN rm -v /etc/nginx/ph7builder.conf
-
-# Copy a configuration file from the current directory
-COPY ph7builder.conf /etc/nginx/
-
-# Append "daemon off;" to the beginning of the configuration
-RUN echo "daemon off;" >> /etc/nginx/ph7builder.conf
-
-# Get PHP with its Docker image
-FROM php:${PHP_VERSION}-${PHP_BASE_IMAGE}
-
-RUN docker-php-ext-install bz2 && \
-    docker-php-ext-configure gd \
-        --with-freetype-dir=/usr/include/ \
-        --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-install gd && \
-    docker-php-ext-install iconv && \
-    docker-php-ext-install opcache && \
-    docker-php-ext-install pdo && \
-    docker-php-ext-install pdo_mysql && \
-    docker-php-ext-install zip
-
-
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/ \
-    && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
-ENV PATH="~/.composer/vendor/bin:./vendor/bin:${PATH}"
-
-# Expose ports
-EXPOSE 80
-EXPOSE 443
-
-# Set the default command to execute
-# when creating a new container
-CMD service nginx start
+WORKDIR /var/www

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -32,7 +32,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = '© (c) 2012-%s, Pierre-Henry Soria. All Rights Reserved.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '18.4.0';
+    public const SOFTWARE_VERSION = '18.5.0';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/framework/Analytics/StoreStats.class.php
+++ b/_protected/framework/Analytics/StoreStats.class.php
@@ -55,7 +55,7 @@ class StoreStats
     {
         $sFullPath = PH7_PATH_TMP . static::DIR . $sFileName . static::EXT;
         $aData = [];
-        $iFlag = FILE_TEXT;
+        $iFlag = 0;
 
         if (is_file($sFullPath)) {
             $aLine = file($sFullPath);

--- a/_protected/framework/File/File.class.php
+++ b/_protected/framework/File/File.class.php
@@ -157,7 +157,7 @@ class File
      *
      * @return int|bool Returns the number of bytes that were written to the file, or FALSE on failure.
      */
-    public function putFile(string $sFile, string $sContents, int $iFlag = FILE_TEXT): int|bool
+    public function putFile(string $sFile, string $sContents, int $iFlag = 0): int|bool
     {
         return @file_put_contents($sFile, $sContents, $iFlag);
     }

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '18.4.0';
+    public const KERNEL_VERSION = '18.5.0';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-07-11';
+    public const KERNEL_RELEASE_DATE = '2026-07-29';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/composer.json
+++ b/composer.json
@@ -105,8 +105,9 @@
     }
   },
   "scripts": {
-    "test": "_protected/vendor/bin/phpunit",
-    "test-ci": "_protected/vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml",
+    "test": "_protected/vendor/bin/phpunit --testsuite \"pH7Builder Protected CI\" --no-coverage",
+    "test-ci": "_protected/vendor/bin/phpunit --testsuite \"pH7Builder Protected CI\" --coverage-text --coverage-clover=build/coverage.xml",
+    "test-integration": "_protected/vendor/bin/phpunit --testsuite \"pH7Builder Integration\" --no-coverage",
     "analyse": "_protected/vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=1G",
     "post-cmd": [
       "cp -R _protected/vendor/twbs/bootstrap/dist/css/bootstrap.min.css static/css/bootstrap.css",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,43 @@
 services:
   web:
-    image: nginx:latest
+    image: nginx:1.28-alpine
     ports:
       - "8080:80"
     volumes:
-      - .:/var/www/
-      - ./sites:/etc/nginx/conf.d
-      - ./nginx.conf:/etc/nginx/ph7builder.conf
+      - .:/var/www:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
-      - php
-    links:
-      - php
+      php:
+        condition: service_started
+
   php:
-    image: php:8.2.0-fpm
+    build:
+      context: .
+    working_dir: /var/www
+    command: sh -c "composer install --no-interaction && exec php-fpm"
     volumes:
-      - .:/var/www/
-    command: bash -c "composer install"
-    working_dir: /var/www/
+      - .:/var/www
+    depends_on:
+      db:
+        condition: service_healthy
+
   db:
-    # Pinned so a "latest" pull can't jump to a new MySQL major (e.g. 9's auth/SQL-mode changes) and break the dev DB
     image: mysql:8.4
     ports:
       - "8001:3306"
+    environment:
+      MYSQL_DATABASE: ph7builder
+      MYSQL_USER: ph7builder
+      MYSQL_PASSWORD: ph7builder
+      MYSQL_ROOT_PASSWORD: ph7builder-root
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    volumes:
+      - ph7builder-db:/var/lib/mysql
+
+volumes:
+  ph7builder-db:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,32 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    root /var/www;
+    index index.php;
+    client_max_body_size 50M;
+
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location ~ ^/(?:_protected|_repository|_tests|_tools|\.git|\.github)(?:/|$) {
+        deny all;
+    }
+
+    location ~ ^/_install/(?:data|vendor)(?:/|$) {
+        deny all;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_pass php:9000;
+    }
+}


### PR DESCRIPTION
## What changed

- identifies the runtime and installer as v18.5.0 with the release date
- removes the obsolete `FILE_TEXT` flag that emits PHP 8.4+ deprecations
- makes the default Composer test command run the deterministic suite while preserving integration tests separately
- repairs the documented Docker development stack and adds a build/smoke workflow
- upgrades the scheduled lock workflow to the maintained Node 24 action

## Why

The final release audit found stale product metadata, avoidable deprecation
noise, an advertised test command that mixed environment-dependent suites, a
nonfunctional Docker quick start, and a repeatedly failing
repository-maintenance action. These changes address those concrete
release-readiness gaps without altering the reviewed application security
boundaries.

## Validation

- `composer test -- --display-deprecations` — 502 tests, 600 assertions
- focused purifier, CSRF token, and attribute-escaping tests — 14 tests, 18 assertions
- `composer analyse -- --debug` — no errors
- PHP syntax checks on every changed PHP file
- `composer validate --strict`
- root and installer `composer audit --locked` — no advisories
- `git diff --check`

The new Docker workflow provides the authoritative Compose build and installer
smoke test on this PR.
