### PR TITLE
Upgrade GitHub actions for Node 24

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -31,7 +31,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Validate Compose configuration
         run: docker compose config --quiet

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -29,7 +29,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/validate-installer.yml
+++ b/.github/workflows/validate-installer.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate installer composer.json
         run: composer validate --strict --working-dir _install


### PR DESCRIPTION
## What changed

- upgrades `actions/checkout` from v4 to the current v7 major
- upgrades `actions/cache` from v4 to the current v6 major

## Why

GitHub’s post-merge v18.5 checks warned that the previous action majors still
target Node 20 and were only succeeding because the runner forced them onto
Node 24. The current official majors natively use Node 24 while preserving the
inputs used by these workflows.

## Validation

- verified the current official release majors through the GitHub API
- verified both tagged `action.yml` files declare `node24`
- parsed every repository workflow as YAML
- reviewed the complete eight-line action-version diff
- `git diff --check`

The PR workflow run provides the final compatibility proof across the complete
PHP, Composer, installer, static-analysis, and Docker matrices.
