### PR TITLE
Fix PH7Tpl compilation to prevent installation failures

### DIFF
--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/PH7Tpl.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/PH7Tpl.class.php
@@ -332,8 +332,12 @@ class PH7Tpl extends Kernel implements Templatable, GenerableFile
             $this->sCompileDir2 = $this->sCompileDir . $this->registry->module . '_' . md5($this->registry->path_module) . PH7_DS . PH7_TPL_MOD_NAME . PH7_DS . $sCurrentController . PH7_DS;
         }
 
-        $this->sCompileDirFile = ($bIsMainDir ? $this->sCompileDir2 . $sTplFileName . static::COMPILE_FILE_EXT : $this->sCompileDir2) .
-            str_replace($sCurrentController, '', $sTplFileName) . static::COMPILE_FILE_EXT;
+        $this->sCompileDirFile = self::buildCompileFilePath(
+            $this->sCompileDir2,
+            $bIsMainDir,
+            $sTplFileName,
+            $sCurrentController
+        );
 
         if (!$this->file->existFile($this->sTemplateDirFile)) {
             throw new TplException(
@@ -631,6 +635,19 @@ Template Engine: ' . self::NAME . ' version ' . self::VERSION . ' by ' . self::A
     protected function getCurrentController()
     {
         return $this->httpRequest->currentController();
+    }
+
+    private static function buildCompileFilePath(
+        string $sCompileDir,
+        bool $bIsMainDir,
+        string $sTplFileName,
+        string $sCurrentController
+    ): string {
+        $sCompileFileName = $bIsMainDir
+            ? $sTplFileName
+            : str_replace($sCurrentController, '', $sTplFileName);
+
+        return $sCompileDir . $sCompileFileName . static::COMPILE_FILE_EXT;
     }
 
     /**

--- a/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Curly.class.php
+++ b/_protected/framework/Layout/Tpl/Engine/PH7Tpl/Syntax/Curly.class.php
@@ -105,14 +105,14 @@ class Curly extends Syntax implements Parsable
     {
         if (!preg_match('#(;(?:\s+)?}}|;(?:\s+)?%})#', $this->sCode)) {
             $this->sCode = str_replace(
-                ['}}', '%}'],
+                ['%}', '}}'],
                 ';?>',
                 $this->sCode
             );
         } else {
             // Don't put a semicolon if there is already one
             $this->sCode = str_replace(
-                ['}}', '%}'],
+                ['%}', '}}'],
                 '?>',
                 $this->sCode
             );

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/PH7TplTest.php
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/PH7TplTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Layout / Tpl / Engine / PH7Tpl
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout\Tpl\Engine\PH7Tpl;
+
+use PH7\Framework\Layout\Tpl\Engine\PH7Tpl\PH7Tpl;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class PH7TplTest extends TestCase
+{
+    public function testMainTemplateCompilePathContainsFilenameOnce(): void
+    {
+        $oMethod = new ReflectionMethod(PH7Tpl::class, 'buildCompileFilePath');
+        $sCompileDir = PH7_PATH_CACHE . 'pH7tpl_compile/public_main/base/';
+
+        $this->assertSame(
+            $sCompileDir . 'layout.cpl.php',
+            $oMethod->invoke(null, $sCompileDir, true, 'layout', 'main')
+        );
+    }
+
+    public function testModuleTemplateCompilePathRemovesControllerPrefix(): void
+    {
+        $oMethod = new ReflectionMethod(PH7Tpl::class, 'buildCompileFilePath');
+        $sCompileDir = PH7_PATH_CACHE . 'pH7tpl_compile/user/base/main/';
+
+        $this->assertSame(
+            $sCompileDir . 'index.cpl.php',
+            $oMethod->invoke(null, $sCompileDir, false, 'mainindex', 'main')
+        );
+    }
+}

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/CurlyTest.php
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/CurlyTest.php
@@ -87,6 +87,11 @@ class CurlyTest extends SyntaxTestCase
         $this->assertFile('echo-semicolon', $this->oCurlySyntax);
     }
 
+    public function testEchoBeforeLiteralClosingBrace(): void
+    {
+        $this->assertFile('echo-before-literal-closing-brace', $this->oCurlySyntax);
+    }
+
     public function testIfStatement(): void
     {
         $this->assertFile('if', $this->oCurlySyntax);

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/curly/echo-before-literal-closing-brace.curly.tpl
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/input/curly/echo-before-literal-closing-brace.curly.tpl
@@ -1,0 +1,1 @@
+var object={value:{% json_encode($value) %}};

--- a/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/curly/echo-before-literal-closing-brace.curly.output
+++ b/_tests/Unit/Framework/Layout/Tpl/Engine/PH7Tpl/Syntax/fixtures/output/curly/echo-before-literal-closing-brace.curly.output
@@ -1,0 +1,1 @@
+var object={value:<?php echo  json_encode($value) ;?>};


### PR DESCRIPTION
## What changed

- Parses `{% … %}` before `{{ … }}` so an echoed value followed by a literal closing brace no longer compiles into invalid `%;?>` PHP.
- Builds the main-theme compile filename once, producing `layout.cpl.php` instead of `layout.cpl.phplayout.cpl.php`.
- Adds regression coverage for both compile defects.

## Why

Fresh 18.5.0 installations could return HTTP 500 on PHP 8.2 because the base layout generated syntactically invalid compiled PHP. This reproduces and fixes the failure reported in #1222.

## Validation

- Recompiled the real base `layout.tpl` and verified it with `php -l`.
- PH7Tpl suite: 92 tests, 128 assertions.
- Deterministic suite: 505 tests, 603 assertions.
- PHPStan: no errors.
- `git diff --check`: clean.

Fixes #1222