### PR TITLE
Restore compatibility across bundled themes

### DIFF
--- a/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/layout.xsl.tpl
@@ -12,7 +12,7 @@
         <head>
             <meta charset="utf-8" />
             <title>{lang 'XML Sitemap - %site_name%'}</title>
-            <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
             <link rel="stylesheet" href="{url_tpl_mod_css}style.css" />
         </head>
         <body>

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Root
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use FilesystemIterator;
+
+final class ThemeAssetTest extends TestCase
+{
+    private const SHARED_LAYOUT_ASSETS = [
+        'design_system.css',
+        'menu.css',
+        'menu_inverse.css'
+    ];
+
+    public function testEveryThemeProvidesSharedLayoutAssets(): void
+    {
+        $sThemesDirectory = dirname(__DIR__, 3) . '/templates/themes';
+        $aThemeDirectories = glob($sThemesDirectory . '/*', GLOB_ONLYDIR);
+
+        $this->assertIsArray($aThemeDirectories);
+        $this->assertNotEmpty($aThemeDirectories);
+
+        foreach ($aThemeDirectories as $sThemeDirectory) {
+            foreach (self::SHARED_LAYOUT_ASSETS as $sAsset) {
+                $this->assertFileExists(
+                    $sThemeDirectory . '/css/' . $sAsset,
+                    sprintf('%s must provide css/%s for the shared layout', basename($sThemeDirectory), $sAsset)
+                );
+            }
+        }
+    }
+
+    public function testEveryLocalCssImportResolves(): void
+    {
+        $sThemesDirectory = dirname(__DIR__, 3) . '/templates/themes';
+        $aThemeDirectories = glob($sThemesDirectory . '/*', GLOB_ONLYDIR);
+
+        foreach ($aThemeDirectories as $sThemeDirectory) {
+            $aCssFiles = $this->findFiles($sThemeDirectory . '/css', '.css');
+
+            foreach ($aCssFiles as $sCssFile) {
+                $sCss = file_get_contents($sCssFile);
+                preg_match_all('/@import\s+url\(([^)]+)\)/i', $sCss, $aImports);
+
+                foreach ($aImports[1] as $sImport) {
+                    $sImport = trim($sImport, " \t\n\r\0\x0B\"'");
+                    $sImportPath = str_replace(
+                        [
+                            '[$url_def_tpl_css]',
+                            '[$url_theme][$current_tpl_name]/css/'
+                        ],
+                        [
+                            $sThemesDirectory . '/base/css/',
+                            $sThemeDirectory . '/css/'
+                        ],
+                        $sImport
+                    );
+
+                    $this->assertFileExists(
+                        $sImportPath,
+                        sprintf('%s imports the missing file %s', $sCssFile, $sImport)
+                    );
+                }
+            }
+        }
+    }
+
+    public function testTemplatesDoNotDisableBrowserZoom(): void
+    {
+        $sProjectRoot = dirname(__DIR__, 3);
+        $aTemplateFiles = array_merge(
+            $this->findFiles($sProjectRoot . '/templates', '.tpl'),
+            $this->findFiles($sProjectRoot . '/_protected/app/system/modules', '.tpl')
+        );
+
+        foreach ($aTemplateFiles as $sTemplateFile) {
+            $sTemplate = file_get_contents($sTemplateFile);
+
+            $this->assertIsString($sTemplate);
+            $this->assertDoesNotMatchRegularExpression(
+                '/(?:maximum-scale\s*=\s*1|user-scalable\s*=\s*no)/i',
+                $sTemplate,
+                sprintf('%s must allow users to zoom', $sTemplateFile)
+            );
+        }
+    }
+
+    private function findFiles(string $sDirectory, string $sSuffix): array
+    {
+        $aFiles = [];
+        $oIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sDirectory, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($oIterator as $oFile) {
+            if ($oFile->isFile() && str_ends_with($oFile->getFilename(), $sSuffix)) {
+                $aFiles[] = $oFile->getPathname();
+            }
+        }
+
+        sort($aFiles);
+
+        return $aFiles;
+    }
+}

--- a/_tools/theme-preview.html
+++ b/_tools/theme-preview.html
@@ -90,7 +90,7 @@
 
     <h2>Apprise dialog & tipTip tooltip (forced visible)</h2>
     <div style="position: relative; height: 220px;">
-        <div class="apprise" style="display:block; position:absolute; top:10px; left:10px; width:280px;">
+        <div class="apprise" style="display:block; position:absolute; top:10px; left:10px; width:calc(100% - 20px); max-width:280px; box-sizing:border-box;">
             <div class="apprise-inner">
                 <p>Are you sure you want to unmatch Alex?</p>
                 <div class="apprise-buttons">
@@ -99,7 +99,7 @@
                 </div>
             </div>
         </div>
-        <div id="tiptip_holder" class="tip_top" style="display:block; position:absolute; top:40px; left:340px;">
+        <div id="tiptip_holder" class="tip_top" style="display:block; position:absolute; top:150px; right:10px; left:auto;">
             <div id="tiptip_content">Online 5 minutes ago</div>
         </div>
     </div>

--- a/composer.lock
+++ b/composer.lock
@@ -108,16 +108,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.388.6",
+            "version": "3.390.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b89b2b0e0741900c9e25d12302ed8300fa50f22b"
+                "reference": "a09e95bf062e15b7343f9c1362fd45c7a0dec39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b89b2b0e0741900c9e25d12302ed8300fa50f22b",
-                "reference": "b89b2b0e0741900c9e25d12302ed8300fa50f22b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a09e95bf062e15b7343f9c1362fd45c7a0dec39b",
+                "reference": "a09e95bf062e15b7343f9c1362fd45c7a0dec39b",
                 "shasum": ""
             },
             "require": {
@@ -125,9 +125,9 @@
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/promises": "^2.0",
-                "guzzlehttp/psr7": "^2.4.5",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
                 "mtdowling/jmespath.php": "^2.9.1",
                 "php": ">=8.1",
                 "psr/http-message": "^1.0 || ^2.0",
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.6"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.390.2"
             },
-            "time": "2026-07-14T18:07:03+00:00"
+            "time": "2026-07-31T18:06:07+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -309,16 +309,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.11",
+            "version": "1.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6"
+                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
-                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/c008272789979f709f7fcb32c2ecf1d2db5e84e5",
+                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5",
                 "shasum": ""
             },
             "require": {
@@ -365,7 +365,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.11"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.13"
             },
             "funding": [
                 {
@@ -377,7 +377,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-30T09:16:10+00:00"
+            "time": "2026-07-18T12:35:13+00:00"
         },
         {
             "name": "dasprid/enum",
@@ -699,16 +699,16 @@
         },
         {
             "name": "geoip2/geoip2",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maxmind/GeoIP2-php.git",
-                "reference": "49fceddd694295e76e970a32848e03bb19e56b42"
+                "reference": "257a350e5e0cae57ac95417f32bb0aba285b2c0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maxmind/GeoIP2-php/zipball/49fceddd694295e76e970a32848e03bb19e56b42",
-                "reference": "49fceddd694295e76e970a32848e03bb19e56b42",
+                "url": "https://api.github.com/repos/maxmind/GeoIP2-php/zipball/257a350e5e0cae57ac95417f32bb0aba285b2c0d",
+                "reference": "257a350e5e0cae57ac95417f32bb0aba285b2c0d",
                 "shasum": ""
             },
             "require": {
@@ -737,10 +737,10 @@
                 {
                     "name": "Gregory J. Oschwald",
                     "email": "goschwald@maxmind.com",
-                    "homepage": "https://www.maxmind.com/"
+                    "homepage": "https://www.maxmind.com/en/home"
                 }
             ],
-            "description": "MaxMind GeoIP2 PHP API",
+            "description": "MaxMind GeoIP PHP API",
             "homepage": "https://github.com/maxmind/GeoIP2-php",
             "keywords": [
                 "IP",
@@ -751,22 +751,22 @@
             ],
             "support": {
                 "issues": "https://github.com/maxmind/GeoIP2-php/issues",
-                "source": "https://github.com/maxmind/GeoIP2-php/tree/v3.3.0"
+                "source": "https://github.com/maxmind/GeoIP2-php/tree/v3.4.0"
             },
-            "time": "2025-11-20T18:50:15+00:00"
+            "time": "2026-07-16T22:11:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -865,7 +865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -881,7 +881,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2157,16 +2157,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.14",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
+                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
-                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
                 "shasum": ""
             },
             "require": {
@@ -2231,7 +2231,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.14"
+                "source": "https://github.com/symfony/console/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -2251,7 +2251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T11:50:14+00:00"
+            "time": "2026-07-27T13:51:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2326,16 +2326,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.14",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff"
+                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/51fe3d170227be8d1772214b82ae506e15ed78ff",
-                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/336e7f3b9e95aba04f93ea9143920c2186abfbb9",
+                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9",
                 "shasum": ""
             },
             "require": {
@@ -2387,7 +2387,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.14"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -2407,7 +2407,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-06T11:10:32+00:00"
+            "time": "2026-07-21T15:13:06+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2491,16 +2491,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.11",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79",
                 "shasum": ""
             },
             "require": {
@@ -2537,7 +2537,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -2557,20 +2557,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:38:44+00:00"
+            "time": "2026-07-22T07:36:05+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.14",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
+                "reference": "68c1f27c97edd0222eb8d440a6c8c4da5354ab46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
-                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/68c1f27c97edd0222eb8d440a6c8c4da5354ab46",
+                "reference": "68c1f27c97edd0222eb8d440a6c8c4da5354ab46",
                 "shasum": ""
             },
             "require": {
@@ -2621,7 +2621,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -2641,20 +2641,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-13T08:51:35+00:00"
+            "time": "2026-07-28T07:33:02+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
+                "reference": "0c1daf58bc931628df0bea26840d1fc8b9a3d34b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
-                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/0c1daf58bc931628df0bea26840d1fc8b9a3d34b",
+                "reference": "0c1daf58bc931628df0bea26840d1fc8b9a3d34b",
                 "shasum": ""
             },
             "require": {
@@ -2710,7 +2710,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.13"
+                "source": "https://github.com/symfony/mime/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -2730,7 +2730,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T16:22:37+00:00"
+            "time": "2026-07-29T07:59:49+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2817,16 +2817,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.38.1",
+            "version": "v1.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
-                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
                 "shasum": ""
             },
             "require": {
@@ -2875,7 +2875,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
             },
             "funding": [
                 {
@@ -2895,7 +2895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T05:58:03+00:00"
+            "time": "2026-07-28T08:25:59+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -3327,16 +3327,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.13",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
-                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e394af32256bf9e7bf80849d95e589167c10097b",
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b",
                 "shasum": ""
             },
             "require": {
@@ -3394,7 +3394,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.13"
+                "source": "https://github.com/symfony/string/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -3414,7 +3414,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T15:23:29+00:00"
+            "time": "2026-07-28T07:33:02+00:00"
         },
         {
             "name": "twbs/bootstrap",
@@ -4151,16 +4151,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.13",
+            "version": "v3.95.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "ea941114a002eb5e5876f190223deec1066c482c"
+                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/ea941114a002eb5e5876f190223deec1066c482c",
-                "reference": "ea941114a002eb5e5876f190223deec1066c482c",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a8b4e4216faabf67f4e96110ee99a48c96e4e683",
+                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683",
                 "shasum": ""
             },
             "require": {
@@ -4200,10 +4200,10 @@
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
-                "phpunit/phpunit": "^9.6.35 || ^10.5.64 || ^11.5.56",
+                "phpunit/phpunit": "^9.6.35 || ^10.5.64 || ^11.5.56 || ^12.5.31 || ^13.0.6",
                 "symfony/polyfill-php85": "^1.38",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.36 || ^7.4.8 || ^8.1.0",
-                "symfony/yaml": "^5.4.53 || ^6.4.41 || ^7.4.13 || ^8.1.0"
+                "symfony/var-dumper": "^5.4.48 || ^6.4.36 || ^7.4.8 || ^8.1.1",
+                "symfony/yaml": "^5.4.53 || ^6.4.41 || ^7.4.13 || ^8.1.1"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -4244,7 +4244,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.13"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.18"
             },
             "funding": [
                 {
@@ -4252,7 +4252,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-10T09:23:21+00:00"
+            "time": "2026-07-30T15:46:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4562,11 +4562,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.5",
+            "version": "2.2.7",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
+                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
                 "shasum": ""
             },
             "require": {
@@ -4622,7 +4622,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-05T06:31:06+00:00"
+            "time": "2026-07-29T17:39:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/templates/themes/base/css/design_system.css
+++ b/templates/themes/base/css/design_system.css
@@ -11,11 +11,13 @@
 
 :root {
     /* Brand */
-    --ph7-primary: #e8467c;
+    --ph7-primary: #d6336c;
     --ph7-primary-dark: #c92e63;
     --ph7-primary-soft: #fde8ef;
-    --ph7-accent: #7c5cff;
+    --ph7-accent: #7048e8;
     --ph7-gradient: linear-gradient(135deg, var(--ph7-primary) 0%, var(--ph7-accent) 100%);
+    --ph7-link: var(--ph7-primary);
+    --ph7-link-hover: var(--ph7-primary-dark);
 
     /* Surfaces & text */
     --ph7-bg: #ffffff;
@@ -43,6 +45,8 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
+        --ph7-link: #ff7aa8;
+        --ph7-link-hover: #ff9fbd;
         --ph7-primary-soft: #3a2030;
         --ph7-bg: #15151c;
         --ph7-surface: #1e1e28;
@@ -78,12 +82,12 @@ label, .control-label, legend {
 }
 
 a {
-    color: var(--ph7-primary);
+    color: var(--ph7-link);
     transition: color var(--ph7-transition);
 }
 
 a:hover, a:focus {
-    color: var(--ph7-primary-dark);
+    color: var(--ph7-link-hover);
     text-decoration: none;
 }
 
@@ -120,7 +124,7 @@ a:hover, a:focus {
 .btn-primary:hover, .btn-primary:focus,
 .btn-success:hover, .btn-success:focus {
     background: var(--ph7-gradient);
-    filter: brightness(1.08);
+    filter: brightness(.92);
     color: #fff;
 }
 
@@ -133,7 +137,7 @@ a:hover, a:focus {
 .btn-default:hover, .btn-default:focus {
     background-color: var(--ph7-primary-soft);
     border-color: var(--ph7-primary);
-    color: var(--ph7-primary-dark);
+    color: var(--ph7-link-hover);
 }
 
 /** FORMS **/
@@ -274,7 +278,7 @@ input[type=color]::-moz-color-swatch {
 
 .dropdown-menu > li > a:hover {
     background-color: var(--ph7-primary-soft);
-    color: var(--ph7-primary-dark);
+    color: var(--ph7-link-hover);
 }
 
 /** TABLES **/
@@ -344,7 +348,7 @@ input[type=color]::-moz-color-swatch {
 }
 
 .char_counter_low {
-    color: var(--ph7-primary-dark);
+    color: var(--ph7-link-hover);
     font-weight: 600;
 }
 

--- a/templates/themes/cartoon/css/_inc/keyframes.css
+++ b/templates/themes/cartoon/css/_inc/keyframes.css
@@ -1,1 +1,1 @@
-@import url([$url_def_tpl_css]keyframes.css);
+@import url([$url_def_tpl_css]_inc/keyframes.css);

--- a/templates/themes/cartoon/css/design_system.css
+++ b/templates/themes/cartoon/css/design_system.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]design_system.css);

--- a/templates/themes/cartoon/css/menu_inverse.css
+++ b/templates/themes/cartoon/css/menu_inverse.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]menu_inverse.css);

--- a/templates/themes/datelove/css/_inc/keyframes.css
+++ b/templates/themes/datelove/css/_inc/keyframes.css
@@ -1,1 +1,1 @@
-@import url([$url_def_tpl_css]keyframes.css);
+@import url([$url_def_tpl_css]_inc/keyframes.css);

--- a/templates/themes/datelove/css/design_system.css
+++ b/templates/themes/datelove/css/design_system.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]design_system.css);

--- a/templates/themes/datelove/css/menu_inverse.css
+++ b/templates/themes/datelove/css/menu_inverse.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]menu_inverse.css);

--- a/templates/themes/premium/css/_inc/keyframes.css
+++ b/templates/themes/premium/css/_inc/keyframes.css
@@ -1,1 +1,1 @@
-@import url([$url_def_tpl_css]keyframes.css);
+@import url([$url_def_tpl_css]_inc/keyframes.css);

--- a/templates/themes/premium/css/common.css
+++ b/templates/themes/premium/css/common.css
@@ -9,8 +9,8 @@
 }
 
 body, td, pre {
-    font-family: 'Open Sans', Verdana, Arial, sans-serif;
-    font-size: 13px;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
     color: #666;
 }
 

--- a/templates/themes/premium/css/design_system.css
+++ b/templates/themes/premium/css/design_system.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]design_system.css);

--- a/templates/themes/premium/css/menu_inverse.css
+++ b/templates/themes/premium/css/menu_inverse.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]menu_inverse.css);

--- a/templates/themes/premium/css/style.css
+++ b/templates/themes/premium/css/style.css
@@ -133,7 +133,7 @@ table {
     text-decoration: none;
     text-align: center;
     line-height: 20px;
-    font-family: 'Helvetica Neue', 'Open Sans', Helvetica, sans-serif;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     border-color: #a8a8a8 #888 #888 #a8a8a8;
     border-style: solid;
     border-width: 1px;

--- a/templates/themes/premium/tpl/layout.tpl
+++ b/templates/themes/premium/tpl/layout.tpl
@@ -3,7 +3,7 @@
 <html lang="{% $config->values['language']['lang'] %}">
   <head>
     <meta charset="{% $config->values['language']['charset'] %}" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     <!-- Begin Title and Meta info -->
@@ -11,6 +11,18 @@
     <meta name="description" content="{% $str->escapeAttribute($str->upperFirst($meta_description)) %}" />
     <meta name="keywords" content="{% $str->escapeAttribute($meta_keywords) %}" />
     {main_include 'social-meta-tags.inc.tpl'}
+
+    {{
+      $aJsonLdWebsite = [
+        '@context' => 'https://schema.org',
+        '@type' => ['WebSite', 'SocialNetworkingSite', 'DatingService'],
+        'name' => $site_name,
+        'url' => PH7_URL_ROOT,
+        'logo' => PH7_URL_ROOT . 'favicon.ico',
+        'publishingPrinciples' => \PH7\Framework\Mvc\Router\Uri::get('page', 'main', 'aipolicy')
+      ]
+    }}
+    <script type="application/ld+json">{% json_encode($aJsonLdWebsite, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) %}</script>
     <meta name="robots" content="{% $str->escapeAttribute($meta_robots) %}" />
     <link rel="icon" href="{url_relative}favicon.ico" />
     <link rel="canonical" href="{current_url}" />
@@ -21,34 +33,22 @@
     <meta name="category" content="{% $str->escapeAttribute($meta_category) %}" />
     <meta name="rating" content="{% $str->escapeAttribute($meta_rating) %}" />
     <meta name="distribution" content="{% $str->escapeAttribute($meta_distribution) %}" />
-    <meta name="theme-color" content="#ffffff" />
     {if $header}{header}{/if}
 
     {if $is_pwa_enabled}
-       <link rel="manifest" href="{{ $design->url('pwa','main','manifest') }}" />
-       {{ $design->staticFiles('js', PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_JS, 'sw-register.js') }}
-       <link rel="apple-touch-icon" sizes="57x57" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-57x57.png">
-       <link rel="apple-touch-icon" sizes="60x60" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-60x60.png">
-       <link rel="apple-touch-icon" sizes="72x72" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-72x72.png">
-       <link rel="apple-touch-icon" sizes="76x76" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-76x76.png">
-       <link rel="apple-touch-icon" sizes="114x114" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-114x114.png">
-       <link rel="apple-touch-icon" sizes="144x144" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-144x144.png">
-       <link rel="apple-touch-icon" sizes="152x152" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-152x152.png">
-       <link rel="apple-touch-icon" sizes="180x180" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}apple-icon-180x180.png">
-       <link rel="icon" type="image/png" sizes="32x32" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}favicon-32x32.png">
-       <link rel="icon" type="image/png" sizes="96x96" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}favicon-96x96.png">
-       <link rel="icon" type="image/png" sizes="16x16" href="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}favicon-16x16.png">
-       <meta name="apple-mobile-web-app-capable" content="yes">
-       <meta name="apple-mobile-web-app-title" content="{site_name}">
-       <meta name="msapplication-TileColor" content="#ffffff">
-       <meta name="msapplication-TileImage" content="{{ PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_IMG }}ms-icon-144x144.png">
+      <link rel="manifest" href="{{ $design->url('pwa','main','manifest') }}" />
+      <meta name="msapplication-config" content="{{ $design->url('pwa','main','browserconfig') }}" />
+      <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+      <meta name="theme-color" content="#15151c" media="(prefers-color-scheme: dark)" />
+      {{ $design->staticFiles('js', PH7_LAYOUT . PH7_SYS . PH7_MOD . 'pwa/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_JS, 'sw-register.js') }}
+      {def_main_include 'pwa-icon-tags.inc.tpl'}
     {/if}
 
     <!-- Begin Copyright pH7 Dating/Social CMS by Pierre-Henry SORIA, All Rights Reserved -->
     <!-- Do not modify or remove this code! Think of those who spend a lot of time to develop this CMS & Framework for you -->
     <meta name="creator" content="pH7Builder, Pierre-Henry Soria - {software_url}" />
     <meta name="designer" content="pH7Builder, Pierre-Henry Soria - {software_url}" />
-    <meta name="generator" content="{software_name}, {software_version}" />
+    <meta name="generator" content="{software_name}, v{software_version}" />
     <!-- End Copyright -->
 
     <!-- End Title and Meta -->
@@ -56,10 +56,15 @@
     <!-- Begin Sheet CSS -->
     {{ $design->externalCssFile(PH7_URL_STATIC. PH7_CSS . 'js/jquery/smoothness/jquery-ui.css') }}
     {{ $design->externalCssFile(PH7_URL_STATIC. PH7_CSS . 'font-awesome.css') }}
-    {{ $design->staticFiles('css', PH7_STATIC . PH7_CSS . 'js/jquery/box/', 'box.css') }} {* We have to include box CSS alone because it includes images in its folder *}
+    {{ $design->staticFiles('css', PH7_STATIC . PH7_CSS . 'js/jquery/box', 'box.css') }} {* We have to include box CSS alone because it includes images in its folder *}
     {{ $design->staticFiles('css', PH7_STATIC . PH7_CSS, 'bootstrap.css,bootstrap_customize.css,animate.css') }}
-    {{ $design->staticFiles('css', PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_CSS, 'common.css,style.css,layout.css,menu.css,like.css,color.css,form.css,js/jquery/rating.css,js/jquery/apprise.css,js/jquery/tipTip.css') }}
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans" />
+    {{ $design->staticFiles('css', PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_CSS, 'common.css,style.css,layout.css,like.css,color.css,form.css,js/jquery/rating.css,js/jquery/apprise.css,js/jquery/tipTip.css,design_system.css') }}
+    {if $top_navbar_type === 'inverse'}
+      {{ $design->staticFiles('css', PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_CSS, 'menu_inverse.css') }}
+    {else}
+      {{ $design->staticFiles('css', PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_CSS, 'menu.css') }}
+    {/if}
+    {* System font stack is defined in design_system.css — no external font request (better privacy/performance) *}
 
     {* Custom CSS code *}
     {{ $design->externalCssFile(PH7_RELATIVE.'asset/css/color.css') }}
@@ -67,6 +72,10 @@
 
     {if $is_user_auth AND $is_im_enabled}
       {{ $design->staticFiles('css', PH7_LAYOUT . PH7_SYS . PH7_MOD . 'im/' . PH7_TPL . PH7_DEFAULT_THEME . PH7_SH . PH7_CSS, 'messenger.css') }}
+    {/if}
+
+    {if $is_disclaimer}
+      {{ $design->staticFiles('css', PH7_STATIC . PH7_CSS . PH7_JS, 'disclaimer.css') }}
     {/if}
 
     <!-- Other sheet CSS for modules etc. -->
@@ -192,7 +201,7 @@
     <!-- End Footer -->
 
     <!-- Begin Footer JavaScript -->
-    {{ $design->staticFiles('js', PH7_STATIC . PH7_JS, 'jquery/box.js,jquery/tipTip.js,bootstrap.js,common.js,str.js,holder.js') }}
+    {{ $design->staticFiles('js', PH7_STATIC . PH7_JS, 'jquery/box.js,jquery/tipTip.js,bootstrap.js,common.js,str.js,holder.js,password_toggle.js') }}
     {{ $design->staticFiles('js', PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_JS, 'global.js') }}
     {{ $design->externalJsFile(PH7_URL_STATIC . PH7_JS . 'jquery/jquery-ui.js') }} {* UI must be the last here, otherwise the jQueryUI buttons won't work *}
 
@@ -208,7 +217,7 @@
 
     {* Cookie info bar *}
     {if $is_cookie_consent_bar}
-      {{ $design->staticFiles('js', PH7_STATIC . PH7_JS, 'cookie_consent/eu-states.js') }}
+      <script src="https://cdn.jsdelivr.net/npm/cookie-bar/cookiebar-latest.min.js?always=1"></script>
     {/if}
 
     {* JS code Injection *}
@@ -225,7 +234,8 @@
     <!-- Common Dialogs -->
     {{ $design->message() }}
     {{ $design->error() }}
-    {if $is_disclaimer AND !$is_admin_auth AND !AdminCore::isAdminPanel()}
+    {if $is_disclaimer AND !AdminCore::isAdminPanel()}
+      {{ $design->staticFiles('js', PH7_STATIC . PH7_JS . 'disclaimer', 'Disclaimer.js,common.js') }}
       {main_include 'disclaimer-dialog.inc.tpl'}
     {/if}
     <!-- End Footer JavaScript -->

--- a/templates/themes/premium/tpl/top_menu.inc.tpl
+++ b/templates/themes/premium/tpl/top_menu.inc.tpl
@@ -12,7 +12,11 @@
 
 
     {* Menu for all *}
-      <nav class="navbar navbar-inverse navbar-fixed-top">
+      {if $top_navbar_type === 'inverse'}
+        <nav class="navbar navbar-inverse navbar-fixed-top">
+      {else}
+        <nav class="navbar navbar-default navbar-fixed-top">
+      {/if}
         <div class="container">
         <!-- Brand and toggle get grouped for better mobile display -->
           <div class="navbar-header">

--- a/templates/themes/zendate/css/_inc/keyframes.css
+++ b/templates/themes/zendate/css/_inc/keyframes.css
@@ -1,1 +1,1 @@
-@import url([$url_def_tpl_css]keyframes.css);
+@import url([$url_def_tpl_css]_inc/keyframes.css);

--- a/templates/themes/zendate/css/design_system.css
+++ b/templates/themes/zendate/css/design_system.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]design_system.css);

--- a/templates/themes/zendate/css/menu_inverse.css
+++ b/templates/themes/zendate/css/menu_inverse.css
@@ -1,0 +1,1 @@
+@import url([$url_def_tpl_css]menu_inverse.css);


### PR DESCRIPTION
## What changed

- Restore the shared design-system and inverse-navbar assets for Cartoon, Date Love, Premium, and Zen Date, preventing the combined CSS endpoint from rejecting those theme bundles.
- Bring the standalone Premium layout back in sync with current PWA, structured-data, disclaimer, cookie-consent, password-toggle, navbar, privacy, and mobile-accessibility behavior while preserving its theme-specific markup and styling.
- Correct every bundled theme's broken keyframe import.
- Improve light/dark link and button contrast without changing the established pink/purple identity.
- Remove the forced horizontal overflow from the responsive theme preview and allow browser zoom on Premium and XML pages.
- Refresh 13 dependencies within their existing supported major-version constraints; no Bootstrap, Stripe, Guzzle, or Smarty major migration is included.
- Add regression coverage for shared theme assets, local CSS imports, and zoom accessibility.

## Root cause

The shared base layout had evolved to request new CSS assets, but derivative themes did not provide the required import wrappers. Because the static asset combiner rejects the entire request when one listed file is absent, selecting those themes could lose the complete theme CSS bundle. Premium also owns a standalone layout and had missed several base-layout fixes over time.

## Verification

- `composer test` — 508 tests, 1,349 assertions
- Full deterministic suite with deprecations forcibly enabled on PHP 8.5.1 — clean
- `composer analyse` — 754 files, no errors
- 349 PH7Tpl templates compiled and every generated PHP file passed `php -l`
- Project-owned JavaScript passed `node --check`; XML files passed `xmllint`
- `composer validate --strict`, `composer check-platform-reqs`, and `composer audit` — clean
- Browser audit at 1440px and 320px — zero horizontal overflow; no duplicate IDs or missing image alt text in the preview
- Focused theme regression test — 746 assertions
