### PR TITLE
Prepare pH7Builder 18.5.1 for stable release

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         shell: bash
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Verify installer responds
         run: |
-          for attempt in {1..30}; do
+          for _ in {1..30}; do
             if curl --fail --location --silent --show-error http://localhost:8080/ > /dev/null; then
               exit 0
             fi

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         shell: bash
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         shell: bash
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v6

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -32,7 +32,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = '© (c) 2012-%s, Pierre-Henry Soria. All Rights Reserved.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '18.5.0';
+    public const SOFTWARE_VERSION = '18.5.1';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/app/langs/en_US/LC_MESSAGES/global.po
+++ b/_protected/app/langs/en_US/LC_MESSAGES/global.po
@@ -151,6 +151,8 @@ msgid "Email already used. Yours? <a href=\"%0%\">Password forgotten?</a>"
 msgstr ""
 
 #: _protected/app/system/core/assets/ajax/ValidateCoreAjax.php:155
+#: _protected/app/system/modules/affiliate/forms/processing/LoginFormProcess.php:64
+#: _protected/app/system/modules/user/forms/processing/LoginFormProcess.php:65
 msgid "Oops! \"%0%\" is not associated with any %site_name% accounts."
 msgstr ""
 
@@ -172,6 +174,7 @@ msgid "Your must enter a valid date (Month-Day-Year)."
 msgstr ""
 
 #: _protected/app/system/core/assets/ajax/ValidateCoreAjax.php:200
+#: _protected/app/system/modules/api/controllers/UserController.php:85
 #, php-format
 msgid "You must be %0% to %1% years to register on the site."
 msgstr ""
@@ -4311,11 +4314,6 @@ msgstr ""
 msgid "Your affiliate account has been created! %0%"
 msgstr ""
 
-#: _protected/app/system/modules/affiliate/forms/processing/LoginFormProcess.php:64
-#: _protected/app/system/modules/user/forms/processing/LoginFormProcess.php:65
-msgid "Oops! \"%0%\" is not associated with any %site_name% accounts."
-msgstr ""
-
 #: _protected/app/system/modules/affiliate/forms/processing/LoginFormProcess.php:88
 #: _protected/app/system/modules/user/forms/processing/LoginFormProcess.php:87
 msgid "Please try again (make sure your caps lock is off)."
@@ -4364,10 +4362,6 @@ msgstr ""
 
 #: _protected/app/system/modules/api/controllers/UserController.php:82
 msgid "The Password must contain from %0% to %1% characters."
-msgstr ""
-
-#: _protected/app/system/modules/api/controllers/UserController.php:85
-msgid "You must be %0% to %1% years to register on the site."
 msgstr ""
 
 #: _protected/app/system/modules/api/controllers/UserController.php:125
@@ -5661,6 +5655,7 @@ msgid "Compose a new message"
 msgstr ""
 
 #: _protected/app/system/modules/mail/controllers/MainController.php:86
+#: _protected/app/system/modules/user/forms/NotificationForm.php:36
 msgid "Messages"
 msgstr ""
 
@@ -6601,6 +6596,15 @@ msgstr ""
 
 #: _protected/app/system/modules/payment/controllers/MainController.php:346
 msgid "Amount: %1%%0%"
+msgstr ""
+
+#: _protected/app/system/modules/payment/views/base/tpl/main/pay.tpl:26
+msgid "Total:"
+msgstr ""
+
+#: _protected/app/system/modules/payment/views/base/tpl/main/membership.tpl:21
+#: _protected/app/system/modules/payment/views/base/tpl/main/pay.tpl:29
+msgid "including %0%% VAT"
 msgstr ""
 
 #: _protected/app/system/modules/payment/controllers/MainController.php:347
@@ -7608,10 +7612,6 @@ msgstr ""
 
 #: _protected/app/system/modules/user/forms/NotificationForm.php:35
 msgid "By enabling this option, you would be likely to receive occasional news on our website and our services and offers, promotions and other benefits to our partners."
-msgstr ""
-
-#: _protected/app/system/modules/user/forms/NotificationForm.php:36
-msgid "Messages"
 msgstr ""
 
 #: _protected/app/system/modules/user/forms/NotificationForm.php:37
@@ -12833,6 +12833,7 @@ msgid "Your logged IP is:"
 msgstr ""
 
 #: _protected/data/cache/pH7tpl_compile/admin123_4afd58a4d127bb00dfafed41a3407e91/base/main/news.inc.cpl.php:19
+#: _protected/app/system/modules/admin123/views/base/tpl/main/news.inc.tpl:2
 msgid "Latest <a href=\"%software_website%\" title=\"%software_name%\">pH7Builder Software</a>'s News"
 msgstr ""
 
@@ -15392,10 +15393,6 @@ msgstr ""
 msgid "Turn Off Two-Factor Authentication"
 msgstr ""
 
-#: _protected/app/system/modules/user/forms/PrivacyForm.php:74
-msgid "No, don't display members who viewed my profile. (Selecting this option will prevent you from seeing who visited your profile)."
-msgstr ""
-
 #: _protected/app/system/modules/user/views/base/tpl/main/accountdeleted.tpl:3
 msgid "Your account has been removed successfully!"
 msgstr ""
@@ -15691,10 +15688,6 @@ msgstr ""
 
 #: _protected/app/system/core/forms/DeleteUserCoreForm.php:42
 msgid "My email address has changed."
-msgstr ""
-
-#: _protected/app/system/modules/admin123/views/base/tpl/main/news.inc.tpl:2
-msgid "Latest <a href=\"%software_website%\" title=\"%software_name%\">pH7Builder Software</a>'s News"
 msgstr ""
 
 #: _protected/app/system/modules/two-factor-auth/controllers/MainController.php:121

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/stat.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/stat.tpl
@@ -1,30 +1,31 @@
-<script src="https://www.google.com/jsapi"></script>
+<script src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
-    google.load("visualization", "1", {packages:["corechart"]});
-    google.setOnLoadCallback(showUserChart);
+    google.charts.load('current', {packages: ['corechart']});
+    google.charts.setOnLoadCallback(showUserChart);
 
     function showUserChart() {
         $('#user_chart').html('');
 
-        var oDate = new Date;
+        var oToday = new Date;
+        var oWeekAgo = new Date(oToday);
+        var oMonthAgo = new Date(oToday);
+        var oYearAgo = new Date(oToday);
         var oDateOptions = {
-           day: "numeric", month: "short", year: "numeric"
+            day: 'numeric', month: 'short', year: 'numeric'
         };
+        var sLocale = {% json_encode($config->values['language']['lang']) %};
 
-        oDate.setFullYear(oDate.getFullYear());
-        var sYear = oDate.toLocaleDateString('{% $config->values['language']['lang'] %}', oDateOptions);
+        oWeekAgo.setDate(oWeekAgo.getDate() - 7);
+        oMonthAgo.setDate(oMonthAgo.getDate() - 31);
+        oYearAgo.setDate(oYearAgo.getDate() - 365);
 
-        oDate.setMonth(oDate.getMonth()-1);
-        var sMonth = oDate.toLocaleDateString('{% $config->values['language']['lang'] %}', oDateOptions);
-
-        oDate.setDate(oDate.getDay()-7);
-        var sWeek = oDate.toLocaleDateString('{% $config->values['language']['lang'] %}', oDateOptions);
-
-        oDate.setDate(oDate.getDay());
-        var sDay = oDate.toLocaleDateString('{% $config->values['language']['lang'] %}', oDateOptions);
+        var sDay = oToday.toLocaleDateString(sLocale, oDateOptions);
+        var sWeek = oWeekAgo.toLocaleDateString(sLocale, oDateOptions);
+        var sMonth = oMonthAgo.toLocaleDateString(sLocale, oDateOptions);
+        var sYear = oYearAgo.toLocaleDateString(sLocale, oDateOptions);
 
         var aData = google.visualization.arrayToDataTable([
-          ['{lang 'Time'}', '{lang 'All'}', '{lang 'Man'}', '{lang 'Women'}', '{lang 'Couples'}'],
+          [{% json_encode(t('Time')) %}, {% json_encode(t('All')) %}, {% json_encode(t('Man')) %}, {% json_encode(t('Women')) %}, {% json_encode(t('Couples')) %}],
           [sDay, {today_total_members}, {today_total_male_members}, {today_total_female_members}, {today_total_couple_members}],
           [sWeek, {week_total_members}, {week_total_male_members}, {week_total_female_members}, {week_total_couple_members}],
           [sMonth, {month_total_members}, {month_total_male_members}, {month_total_female_members}, {month_total_couple_members}],
@@ -32,7 +33,7 @@
         ]);
 
         var aOptions = {
-          title: '{lang 'User Statistics'}'
+          title: {% json_encode(t('User Statistics')) %}
         };
 
         new google.visualization.LineChart($('#user_chart')[0]).draw(aData, aOptions);

--- a/_protected/app/system/modules/admin123/views/base/tpl/tool/cache.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/tool/cache.tpl
@@ -8,20 +8,20 @@
     </div>
 
     <div class="s_marg">
-        <script src="https://www.google.com/jsapi"></script>
+        <script src="https://www.gstatic.com/charts/loader.js"></script>
         <script>
-            google.load("visualization", "1", {packages:["corechart"]});
-            google.setOnLoadCallback(showCacheChart);
+            google.charts.load('current', {packages: ['corechart']});
+            google.charts.setOnLoadCallback(showCacheChart);
 
             function showCacheChart() {
                 $('#cache_chart').html('');
 
                 var oDataTable = new google.visualization.DataTable();
-                oDataTable.addColumn('string', '{lang 'Cache'}');
-                oDataTable.addColumn('number', '{lang 'Size'}');
+                oDataTable.addColumn('string', {% json_encode(t('Cache')) %});
+                oDataTable.addColumn('number', {% json_encode(t('Size')) %});
                 var aData = [
                     {each $aData in $aChartData}
-                        ["{% $aData['title'] %}", {v:{% $aData['size'] %}, f:"{% Framework\File\Various::bytesToSize($aData['size']) %}"}],
+                        [{% json_encode($aData['title']) %}, {v: {% $aData['size'] %}, f: {% json_encode(Framework\File\Various::bytesToSize($aData['size'])) %}}],
                     {/each}
                 ];
                 oDataTable.addRows(aData);

--- a/_protected/app/system/modules/admin123/views/base/tpl/tool/freespace.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/tool/freespace.tpl
@@ -1,19 +1,19 @@
 <div class="center">
     <div class="s_marg">
-        <script src="https://www.google.com/jsapi"></script>
+        <script src="https://www.gstatic.com/charts/loader.js"></script>
         <script>
-            google.load("visualization", "1", {packages:["corechart"]});
-            google.setOnLoadCallback(showFreeSpaceChart);
+            google.charts.load('current', {packages: ['corechart']});
+            google.charts.setOnLoadCallback(showFreeSpaceChart);
 
             function showFreeSpaceChart () {
                 $('#free_space_chart').html('');
 
                 var oDataTable = new google.visualization.DataTable();
-                oDataTable.addColumn('string', '{lang 'Free Space'}');
-                oDataTable.addColumn('number', '{lang 'Size'}');
+                oDataTable.addColumn('string', {% json_encode(t('Free Space')) %});
+                oDataTable.addColumn('number', {% json_encode(t('Size')) %});
                 var aData = [
                     {each $aData in $aChartData}
-                        ["{% $aData['title'] %}", {v:{% $aData['size'] %}, f:"{% Framework\File\Various::bytesToSize($aData['size']) %}"}],
+                        [{% json_encode($aData['title']) %}, {v: {% $aData['size'] %}, f: {% json_encode(Framework\File\Various::bytesToSize($aData['size'])) %}}],
                     {/each}
                 ];
                 oDataTable.addRows(aData);

--- a/_protected/app/system/modules/payment/config/config.ini
+++ b/_protected/app/system/modules/payment/config/config.ini
@@ -47,7 +47,7 @@ stripe.secret_key = "sk_test_d8e8fca2dc0f896fd7cb4cb0031ba249"
 braintree.enabled = 0
 braintree.merchant_id = "cbqd3ncztsszwbrh"
 braintree.public_key = "7mr28wc74trf2xp4"
-braintree.private_ke = "3a21c73d4c362d0bf38080e9d87a5854"
+braintree.private_key = "3a21c73d4c362d0bf38080e9d87a5854"
 
 ; 2Checkout
 2co.enabled = 0

--- a/_protected/app/system/modules/payment/controllers/MainController.php
+++ b/_protected/app/system/modules/payment/controllers/MainController.php
@@ -1,16 +1,13 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2020, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Payment / Controller
  */
 
 namespace PH7;
 
-use DateInterval;
-use DateTime;
-use Throwable;
 use PH7\Framework\Cache\Cache;
 use PH7\Framework\Core\Kernel;
 use PH7\Framework\File\File;
@@ -18,24 +15,40 @@ use PH7\Framework\Layout\Tpl\Engine\PH7Tpl\PH7Tpl;
 use PH7\Framework\Mail\Mail;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Payment\Gateway\Api\Api as ApiInterface;
-use stdClass;
+use PH7\Framework\Security\CSRF\Token;
 use Stripe\Charge as StripeCharge;
 
 class MainController extends Controller
 {
-    const PAYPAL_GATEWAY_NAME = 'paypal';
-    const STRIPE_GATEWAY_NAME = 'stripe';
-    const BRAINTREE_GATEWAY_NAME = 'braintree';
-    const TWO_CHECKOUT_GATEWAY_NAME = '2co';
-    const CCBILL_GATEWAY_NAME = 'ccbill';
+    public const PAYPAL_GATEWAY_NAME = 'paypal';
+    public const STRIPE_GATEWAY_NAME = 'stripe';
+    public const BRAINTREE_GATEWAY_NAME = 'braintree';
+    public const TWO_CHECKOUT_GATEWAY_NAME = '2co';
+    public const CCBILL_GATEWAY_NAME = 'ccbill';
 
-    const REDIRECTION_DELAY = 4; // In seconds
+    public const REDIRECTION_DELAY = 4; // In seconds
 
-    const PAYMENT_GATEWAYS = [
+    public const PAYMENT_GATEWAYS = [
         PayPal::class,
         Braintree::class,
         Stripe::class,
         TwoCO::class
+    ];
+
+    private const CHECKOUT_TOKEN_LIFETIME = 7200;
+
+    private const GATEWAY_ENABLE_SETTINGS = [
+        self::PAYPAL_GATEWAY_NAME => 'paypal.enabled',
+        self::STRIPE_GATEWAY_NAME => 'stripe.enabled',
+        self::BRAINTREE_GATEWAY_NAME => 'braintree.enabled',
+        self::TWO_CHECKOUT_GATEWAY_NAME => '2co.enabled'
+    ];
+
+    private const SENSITIVE_PAYMENT_FIELDS = [
+        'checkout_reference',
+        'custom',
+        'payment_method_nonce',
+        'stripeToken'
     ];
 
     /** @var AffiliateCoreModel */
@@ -57,8 +70,8 @@ class MainController extends Controller
     {
         parent::__construct();
 
-        $this->oUserModel = new AffiliateCoreModel;
-        $this->oPayModel = new PaymentModel;
+        $this->oUserModel = new AffiliateCoreModel();
+        $this->oPayModel = new PaymentModel();
         $this->iProfileId = $this->session->get('member_id');
     }
 
@@ -75,6 +88,13 @@ class MainController extends Controller
         if (empty($oMembershipData)) {
             $this->displayPageNotFound(t('No membership found!'));
         } else {
+            foreach ($oMembershipData as $oMembership) {
+                $oMembership->isPurchasable = PaymentCheckout::isPurchasableMembership($oMembership);
+                if ($oMembership->isPurchasable) {
+                    $oMembership->totalPrice = $this->getTotalAmount($oMembership);
+                }
+            }
+
             $this->view->page_title = $this->view->h1_title = t('Memberships Plans');
             $this->view->memberships = $oMembershipData;
             $this->output();
@@ -82,7 +102,7 @@ class MainController extends Controller
     }
 
     /**
-     * @param null|int $iMembershipId
+     * @param int|null $iMembershipId
      *
      * @return void
      */
@@ -106,6 +126,17 @@ class MainController extends Controller
 
             $this->view->page_title = $this->view->h1_title = t('Payment Option');
             $this->view->membership = $oMembershipData;
+            $this->view->is_purchasable_membership = PaymentCheckout::isPurchasableMembership($oMembershipData);
+            if ($this->view->is_purchasable_membership) {
+                $this->view->checkout_token = (new Token())->generate(
+                    PaymentCheckout::getTokenName($iMembershipId)
+                );
+                $this->view->total_price = $this->getTotalAmount($oMembershipData);
+                $this->session->set(
+                    PaymentCheckout::getContextName($iMembershipId),
+                    $this->getCheckoutContext($oMembershipData)
+                );
+            }
             $this->output();
         }
     }
@@ -117,30 +148,29 @@ class MainController extends Controller
      */
     public function process($sProvider = '')
     {
+        if (!$this->isPaymentProviderEnabled($sProvider)) {
+            $sProvider = '';
+        }
+
         switch ($sProvider) {
             case self::PAYPAL_GATEWAY_NAME:
                 $this->paypalHandler();
                 break;
-
             case self::STRIPE_GATEWAY_NAME:
                 $this->stripeHandler();
                 break;
-
             case self::BRAINTREE_GATEWAY_NAME:
                 $this->braintreeHandler();
                 break;
-
             case self::TWO_CHECKOUT_GATEWAY_NAME:
                 $this->twoCheckOutHandler();
                 break;
-
             case self::CCBILL_GATEWAY_NAME:
                 // Still in developing...
                 // You are more than welcome to contribute on GitHub: https://github.com/pH7Software/pH7-Social-Dating-CMS
                 break;
-
             default:
-                $this->defaultHandler();
+                break;
         }
 
         // Set the page titles
@@ -162,31 +192,6 @@ class MainController extends Controller
         $this->output();
     }
 
-    /**
-     * @param string $sGatewayName
-     * @param int $iItemNumber
-     *
-     * @return void
-     *
-     * @throws Framework\Layout\Tpl\Engine\PH7Tpl\Exception
-     */
-    public function notification($sGatewayName = '', $iItemNumber = 0)
-    {
-        // Save buyer information to a log file
-        if ($this->isValidPaymentGateway($sGatewayName)) {
-            // Add payment info into the log file
-            $this->log(
-                new $sGatewayName(false),
-                t('%0% payment was made with the following information:', $sGatewayName)
-            );
-        }
-
-        // Send a notification email
-        if (!empty($iItemNumber)) {
-            $this->sendNotifyMail($iItemNumber);
-        }
-    }
-
     public function info()
     {
         $this->sTitle = t('Membership Details');
@@ -194,8 +199,8 @@ class MainController extends Controller
 
         $oInfo = $this->oUserModel->getMembershipDetails($this->iProfileId);
         if ($this->isMembershipExpirable($oInfo)) {
-            $oDate = new DateTime($oInfo->membershipDate);
-            $oDate->add(new DateInterval(sprintf('P%dD', $oInfo->expirationDays)));
+            $oDate = new \DateTime($oInfo->membershipDate);
+            $oDate->add(new \DateInterval(sprintf('P%dD', $oInfo->expirationDays)));
             $this->view->expirationDate = $oDate->format($this->config->values['language.application']['textual_date_format']);
             unset($oDate);
         } else {
@@ -250,7 +255,11 @@ class MainController extends Controller
         $this->view->intro = t('Hello!') . '<br />' . t('Congratulations! You received a new payment from %0%', $sBuyer);
         $this->view->date = t('Date of the payment: %0%', $this->dateTime->get()->date());
         $this->view->membership_name = t('Membership name: %0%', $oMembershipData->name);
-        $this->view->membership_price = t('Amount: %1%%0%', $oMembershipData->price, $this->config->values['module.setting']['currency_sign']);
+        $this->view->membership_price = t(
+            'Amount: %1%%0%',
+            $this->getTotalAmount($oMembershipData),
+            $this->config->values['module.setting']['currency_sign']
+        );
         $this->view->membership_duration = nt('Membership duration: %n% day', 'Membership duration: %n% days', $oMembershipData->expirationDays);
         $this->view->browser_info = t('User Web browser info: %0%', $this->browser->getUserAgent());
         $this->view->ip = t('Buyer IP address: %0%', $this->design->ip(null, false));
@@ -267,32 +276,34 @@ class MainController extends Controller
             'subject' => t('New Payment Received from %0%', $sBuyer)
         ];
 
-        return (new Mail)->send($aInfo, $sMessageHtml);
+        return (new Mail())->send($aInfo, $sMessageHtml);
     }
 
     private function paypalHandler()
     {
         $oPayPal = new PayPal($this->config->values['module.setting']['sandbox.enabled']);
-        if ($oPayPal->valid() && $this->httpRequest->postExists('custom')) {
-            $aData = explode('|', base64_decode($this->httpRequest->post('custom')));
-            $iItemNumber = (int)$aData[0];
-            if ($this->oUserModel->updateMembership(
-                $iItemNumber,
-                $this->iProfileId,
-                $this->dateTime->get()->dateTime(UserCoreModel::DATETIME_FORMAT)
-            )) {
-                $this->bStatus = true; // Status is OK
-                $this->updateUserGroupId($iItemNumber);
-                // PayPal automatically calls the `notification()` method thanks to its IPN feature and "notify_url" form attribute
-            }
+        if (!$this->httpRequest->postExists('custom') || !$oPayPal->valid()) {
+            return;
+        }
+
+        $oMembership = $this->getCheckoutMembership($this->httpRequest->post('custom'));
+        if ($oMembership !== null && $this->isValidPayPalPayment($oMembership)) {
+            $this->completeMembershipPayment($oMembership, PayPal::class);
         }
     }
 
     private function stripeHandler()
     {
-        if ($this->httpRequest->postExists('stripeToken')) {
+        if ($this->httpRequest->postExists(['stripeToken', 'checkout_reference'])) {
+            $oMembership = $this->getCheckoutMembership(
+                $this->httpRequest->post('checkout_reference')
+            );
+            if ($oMembership === null) {
+                return;
+            }
+
             \Stripe\Stripe::setApiKey($this->config->values['module.setting']['stripe.secret_key']);
-            $sAmount = $this->httpRequest->post('amount');
+            $sAmount = $this->getTotalAmount($oMembership);
             $sStripeEmail = $this->httpRequest->post('stripeEmail');
 
             try {
@@ -305,20 +316,16 @@ class MainController extends Controller
                     ]
                 );
 
-                // Make sure the item has been paid
-                if ($oCharge->paid === true) {
-                    $iItemNumber = $this->httpRequest->post('item_number');
-                    if ($this->oUserModel->updateMembership(
-                        $iItemNumber,
-                        $this->iProfileId,
-                        $this->dateTime->get()->dateTime(UserCoreModel::DATETIME_FORMAT)
-                    )) {
-                        $this->bStatus = true; // Status is OK
-                        $this->updateUserGroupId($iItemNumber);
-                        $this->notification(Stripe::class, $iItemNumber);
-                    }
+                if (
+                    $oCharge->paid === true
+                    && (string)$oCharge->amount === Stripe::getAmount($sAmount)
+                    && strtolower((string)$oCharge->currency) === strtolower(
+                        $this->config->values['module.setting']['currency_code']
+                    )
+                ) {
+                    $this->completeMembershipPayment($oMembership, Stripe::class);
                 }
-            } catch (Throwable $oException) {
+            } catch (\Throwable $oException) {
                 // Card declines are handled as payment failures (without exposing exception details).
                 if (!$this->isStripeCardDeclineException($oException)) {
                     $this->design->setMessage($this->str->escape($oException->getMessage(), true));
@@ -329,26 +336,38 @@ class MainController extends Controller
 
     private function braintreeHandler()
     {
-        if ($bNonce = $this->httpRequest->post('payment_method_nonce')) {
+        if (
+            $this->httpRequest->postExists(['payment_method_nonce', 'checkout_reference'])
+            && $sNonce = $this->httpRequest->post('payment_method_nonce')
+        ) {
+            $oMembership = $this->getCheckoutMembership(
+                $this->httpRequest->post('checkout_reference')
+            );
+            if ($oMembership === null) {
+                return;
+            }
+
             Braintree::init($this->config);
 
             $oResult = Braintree::sale([
-                'amount' => $this->httpRequest->post('amount'),
-                'paymentMethodNonce' => $bNonce,
+                'amount' => $this->getTotalAmount($oMembership),
+                'paymentMethodNonce' => $sNonce,
                 'options' => ['submitForSettlement' => true]
             ]);
 
-            if ($oResult->success) {
-                $iItemNumber = $this->httpRequest->post('item_number');
-                if ($this->oUserModel->updateMembership(
-                    $iItemNumber,
-                    $this->iProfileId,
-                    $this->dateTime->get()->dateTime(UserCoreModel::DATETIME_FORMAT)
-                )) {
-                    $this->bStatus = true; // Status is OK
-                    $this->updateUserGroupId($iItemNumber);
-                    $this->notification(Braintree::class, $iItemNumber);
-                }
+            if (
+                $oResult->success
+                && $oResult->transaction
+                && PaymentCheckout::isExpectedAmount(
+                    $oMembership->price,
+                    $this->config->values['module.setting']['vat_rate'],
+                    $oResult->transaction->amount
+                )
+                && strtoupper((string)$oResult->transaction->currencyIsoCode) === strtoupper(
+                    $this->config->values['module.setting']['currency_code']
+                )
+            ) {
+                $this->completeMembershipPayment($oMembership, Braintree::class);
             } elseif ($oResult->transaction) {
                 $sErrMsg = t('Error processing transaction: %0%', $oResult->transaction->processorResponseText);
                 $this->design->setMessage($this->str->escape($sErrMsg, true));
@@ -362,41 +381,136 @@ class MainController extends Controller
         $sVendorId = $this->config->values['module.setting']['2co.vendor_id'];
         $sSecretWord = $this->config->values['module.setting']['2co.secret_word'];
 
-        $iItemNumber = $this->httpRequest->post('cart_order_id');
-        if ($o2CO->valid($sVendorId, $sSecretWord)
-            && $this->httpRequest->postExists('sale_id')
-        ) {
-            if ($this->oUserModel->updateMembership(
-                $iItemNumber,
-                $this->iProfileId,
-                $this->dateTime->get()->dateTime(UserCoreModel::DATETIME_FORMAT)
+        if (!$o2CO->valid($sVendorId, $sSecretWord)) {
+            return;
+        }
+
+        $oMembership = $this->getCheckoutMembership(
+            $this->httpRequest->gets('merchant_order_id')
+        );
+        if (
+            $oMembership !== null
+            && PaymentCheckout::isExpectedAmount(
+                $oMembership->price,
+                $this->config->values['module.setting']['vat_rate'],
+                $this->httpRequest->gets('total')
             )
-            ) {
-                $this->bStatus = true; // Status is OK
-                $this->updateUserGroupId($iItemNumber);
-                $this->notification(TwoCO::class, $iItemNumber);
-            }
+        ) {
+            $this->completeMembershipPayment($oMembership, TwoCO::class);
         }
     }
 
-    private function defaultHandler()
+    private function getCheckoutMembership(mixed $mCheckoutReference): ?\stdClass
     {
-        $this->paypalHandler();
+        if (!is_string($mCheckoutReference)) {
+            return null;
+        }
+
+        $aCheckoutReference = PaymentCheckout::parseReference($mCheckoutReference);
+        if ($aCheckoutReference === null) {
+            return null;
+        }
+
+        $iMembershipId = $aCheckoutReference['membership_id'];
+        $oMembership = $this->oPayModel->getMemberships($iMembershipId);
+        if (!$oMembership instanceof \stdClass || !PaymentCheckout::isPurchasableMembership($oMembership)) {
+            return null;
+        }
+
+        $sContextName = PaymentCheckout::getContextName($iMembershipId);
+        $mCheckoutContext = $this->session->get($sContextName, false);
+        $bValidToken = (new Token())->check(
+            PaymentCheckout::getTokenName($iMembershipId),
+            $aCheckoutReference['token'],
+            self::CHECKOUT_TOKEN_LIFETIME
+        );
+        $this->session->remove($sContextName);
+
+        if (
+            !$bValidToken
+            || !is_string($mCheckoutContext)
+            || !hash_equals($this->getCheckoutContext($oMembership), $mCheckoutContext)
+        ) {
+            return null;
+        }
+
+        return $oMembership;
     }
 
-    private function isStripeCardDeclineException(Throwable $oException): bool
+    private function isValidPayPalPayment(\stdClass $oMembership): bool
+    {
+        return PaymentCheckout::isValidPayPalPayment(
+            $_POST,
+            $oMembership,
+            $this->config->values['module.setting']['paypal.email'],
+            $this->config->values['module.setting']['currency_code'],
+            $this->config->values['module.setting']['vat_rate']
+        );
+    }
+
+    private function completeMembershipPayment(\stdClass $oMembership, string $sGatewayName): void
+    {
+        $iMembershipId = (int)$oMembership->groupId;
+        if (!$this->oUserModel->updateMembership(
+            $iMembershipId,
+            $this->iProfileId,
+            $this->dateTime->get()->dateTime(UserCoreModel::DATETIME_FORMAT)
+        )) {
+            return;
+        }
+
+        $this->bStatus = true;
+        $this->updateUserGroupId($iMembershipId);
+        $this->notifyPayment($sGatewayName, $iMembershipId);
+    }
+
+    private function notifyPayment(string $sGatewayName, int $iMembershipId): void
+    {
+        if ($this->isValidPaymentGateway($sGatewayName)) {
+            $this->log(
+                new $sGatewayName(false),
+                t('%0% payment was made with the following information:', $sGatewayName)
+            );
+        }
+
+        $this->sendNotifyMail($iMembershipId);
+    }
+
+    private function getTotalAmount(\stdClass $oMembership): string
+    {
+        return PaymentCheckout::getTotalAmount(
+            $oMembership->price,
+            $this->config->values['module.setting']['vat_rate']
+        );
+    }
+
+    private function getCheckoutContext(\stdClass $oMembership): string
+    {
+        return $this->getTotalAmount($oMembership) . '|' . strtoupper(
+            $this->config->values['module.setting']['currency_code']
+        );
+    }
+
+    private function isPaymentProviderEnabled(string $sProvider): bool
+    {
+        $sSettingName = self::GATEWAY_ENABLE_SETTINGS[$sProvider] ?? null;
+
+        return $sSettingName !== null && !empty($this->config->values['module.setting'][$sSettingName]);
+    }
+
+    private function isStripeCardDeclineException(\Throwable $oException): bool
     {
         $sLegacyCardExceptionClass = 'Stripe\\Error\\Card';
 
-        return is_a($oException, \Stripe\Exception\CardException::class) ||
-            (class_exists($sLegacyCardExceptionClass, false) && is_a($oException, $sLegacyCardExceptionClass));
+        return is_a($oException, \Stripe\Exception\CardException::class)
+            || (class_exists($sLegacyCardExceptionClass, false) && is_a($oException, $sLegacyCardExceptionClass));
     }
 
     /**
      * Create a Payment Log file.
      *
-     * @param ApiInterface $oProvider A provider class.
-     * @param string $sMsg
+     * @param ApiInterface $oProvider a provider class
+     * @param string       $sMsg
      *
      * @return void
      */
@@ -404,7 +518,13 @@ class MainController extends Controller
     {
         if ($this->config->values['module.setting']['log_file.enabled']) {
             $sLogTxt = $sMsg . File::EOL . File::EOL . File::EOL;
-            $oProvider->saveLog($sLogTxt . print_r($_POST, true), $this->registry);
+            $aLogData = $_POST;
+            foreach (self::SENSITIVE_PAYMENT_FIELDS as $sFieldName) {
+                if (array_key_exists($sFieldName, $aLogData)) {
+                    $aLogData[$sFieldName] = '[redacted]';
+                }
+            }
+            $oProvider->saveLog($sLogTxt . print_r($aLogData, true), $this->registry);
         }
     }
 
@@ -415,7 +535,7 @@ class MainController extends Controller
      */
     private function clearCache()
     {
-        (new Cache)->start(
+        (new Cache())->start(
             UserCoreModel::CACHE_GROUP,
             'membershipDetails' . $this->iProfileId,
             null
@@ -433,13 +553,11 @@ class MainController extends Controller
     }
 
     /**
-     * @param stdClass $oInfo
-     *
      * @return bool
      */
-    private function isMembershipExpirable(stdClass $oInfo)
+    private function isMembershipExpirable(\stdClass $oInfo)
     {
-        return $oInfo->expirationDays != 0 && !empty($oInfo->membershipDate);
+        return $oInfo->expirationDays !== 0 && !empty($oInfo->membershipDate);
     }
 
     /**

--- a/_protected/app/system/modules/payment/inc/class/Braintree.php
+++ b/_protected/app/system/modules/payment/inc/class/Braintree.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hi@ph7.me>
  * @copyright      (c) 2017-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Payment / Inc / Class
  */
 
 namespace PH7;
@@ -15,8 +15,8 @@ class Braintree extends BraintreeGateway
 {
     use Api; // Import the Api trait
 
-    const JS_LIBRARY_URL = 'https://js.braintreegateway.com/web/dropin/1.44.1/js/dropin.min.js';
-    const SANDBOX_MERCHANT_ID = 'cbqd3ncztsszwbrh';
+    public const JS_LIBRARY_URL = 'https://js.braintreegateway.com/web/dropin/1.44.1/js/dropin.min.js';
+    public const SANDBOX_MERCHANT_ID = 'cbqd3ncztsszwbrh';
 
     public static function init(Config $oConfig)
     {
@@ -31,7 +31,9 @@ class Braintree extends BraintreeGateway
 
         $sConfigurationClass::merchantId($oConfig->values['module.setting']['braintree.merchant_id']);
         $sConfigurationClass::publicKey($oConfig->values['module.setting']['braintree.public_key']);
-        $sConfigurationClass::privateKey($oConfig->values['module.setting']['braintree.private_ke']);
+        $sPrivateKey = $oConfig->values['module.setting']['braintree.private_key'] ??
+            $oConfig->values['module.setting']['braintree.private_ke'] ?? '';
+        $sConfigurationClass::privateKey($sPrivateKey);
     }
 
     public static function generateClientToken(): string
@@ -54,8 +56,8 @@ class Braintree extends BraintreeGateway
 
     private static function isSandboxEnabled(Config $oConfig)
     {
-        return (bool)$oConfig->values['module.setting']['sandbox.enabled'] ||
-            $oConfig->values['module.setting']['braintree.merchant_id'] === static::SANDBOX_MERCHANT_ID;
+        return (bool)$oConfig->values['module.setting']['sandbox.enabled']
+            || $oConfig->values['module.setting']['braintree.merchant_id'] === static::SANDBOX_MERCHANT_ID;
     }
 
     private static function getConfigurationClass(): string

--- a/_protected/app/system/modules/payment/inc/class/PaymentCheckout.php
+++ b/_protected/app/system/modules/payment/inc/class/PaymentCheckout.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7;
+
+final class PaymentCheckout
+{
+    private const TOKEN_NAME_PREFIX = 'payment_checkout_';
+    private const CONTEXT_NAME_PREFIX = 'payment_checkout_context_';
+    private const PRICE_SCALE = 100;
+    private const VAT_SCALE = 1000;
+    private const PERCENT_SCALE = 100 * self::VAT_SCALE;
+
+    private function __construct()
+    {
+    }
+
+    public static function getTokenName(int $iMembershipId): string
+    {
+        return self::TOKEN_NAME_PREFIX . $iMembershipId;
+    }
+
+    public static function getContextName(int $iMembershipId): string
+    {
+        return self::CONTEXT_NAME_PREFIX . $iMembershipId;
+    }
+
+    public static function createReference(int $iMembershipId, string $sToken): string
+    {
+        if ($iMembershipId < 1 || !self::isValidToken($sToken)) {
+            throw new \InvalidArgumentException('A valid membership and checkout token are required.');
+        }
+
+        return rtrim(strtr(base64_encode($iMembershipId . '|' . $sToken), '+/', '-_'), '=');
+    }
+
+    /**
+     * @return array{membership_id:int,token:string}|null
+     */
+    public static function parseReference(string $sReference): ?array
+    {
+        if ($sReference === '' || preg_match('/^[A-Za-z0-9_-]+$/', $sReference) !== 1) {
+            return null;
+        }
+
+        $iPadding = (4 - strlen($sReference) % 4) % 4;
+        $sDecodedReference = base64_decode(
+            strtr($sReference, '-_', '+/') . str_repeat('=', $iPadding),
+            true
+        );
+
+        if (!is_string($sDecodedReference)) {
+            return null;
+        }
+
+        $aReferenceParts = explode('|', $sDecodedReference, 2);
+        if (count($aReferenceParts) !== 2 || preg_match('/^[1-9][0-9]*$/', $aReferenceParts[0]) !== 1) {
+            return null;
+        }
+
+        $mMembershipId = filter_var(
+            $aReferenceParts[0],
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]]
+        );
+        $sToken = $aReferenceParts[1];
+        if ($mMembershipId === false || !self::isValidToken($sToken)) {
+            return null;
+        }
+
+        return [
+            'membership_id' => $mMembershipId,
+            'token' => $sToken
+        ];
+    }
+
+    public static function isPurchasableMembership(mixed $mMembership): bool
+    {
+        return $mMembership instanceof \stdClass
+            && (int)($mMembership->enable ?? 0) === 1
+            && self::toMinorUnits($mMembership->price ?? '') > 0;
+    }
+
+    /**
+     * Return the configured membership price including VAT, rounded to the
+     * currency's two-decimal minor unit.
+     */
+    public static function getTotalAmount(string|int|float $mPrice, string|int|float $mVatRate): string
+    {
+        $iPrice = self::toMinorUnits($mPrice);
+        $iVatRate = self::toVatUnits($mVatRate);
+        if ($iPrice === null || $iVatRate === null) {
+            throw new \InvalidArgumentException('The payment amount or VAT rate is invalid.');
+        }
+
+        $iTax = intdiv(($iPrice * $iVatRate) + intdiv(self::PERCENT_SCALE, 2), self::PERCENT_SCALE);
+
+        return self::formatMinorUnits($iPrice + $iTax);
+    }
+
+    public static function getMinorUnits(string|int|float $mAmount): int
+    {
+        $iAmount = self::toMinorUnits($mAmount);
+        if ($iAmount === null) {
+            throw new \InvalidArgumentException('The payment amount is invalid.');
+        }
+
+        return $iAmount;
+    }
+
+    public static function isExpectedAmount(
+        string|int|float $mPrice,
+        string|int|float $mVatRate,
+        string|int|float $mPaidAmount
+    ): bool {
+        $iPaidAmount = self::toMinorUnits($mPaidAmount);
+
+        return $iPaidAmount !== null
+            && self::getTotalAmount($mPrice, $mVatRate) === self::formatMinorUnits($iPaidAmount);
+    }
+
+    public static function isValidPayPalPayment(
+        array $aPayment,
+        \stdClass $oMembership,
+        string $sMerchantEmail,
+        string $sCurrency,
+        string|int|float $mVatRate
+    ): bool {
+        $aRequiredFields = [
+            'payment_status',
+            'txn_id',
+            'receiver_email',
+            'mc_currency',
+            'mc_gross',
+            'item_number'
+        ];
+        foreach ($aRequiredFields as $sFieldName) {
+            if (
+                !isset($aPayment[$sFieldName])
+                || !is_scalar($aPayment[$sFieldName])
+                || is_bool($aPayment[$sFieldName])
+            ) {
+                return false;
+            }
+        }
+
+        $sMembershipId = (string)$aPayment['item_number'];
+
+        return $aPayment['payment_status'] === 'Completed'
+            && preg_match('/^[1-9][0-9]*$/', $sMembershipId) === 1
+            && (int)$sMembershipId === (int)$oMembership->groupId
+            && strcasecmp(trim((string)$aPayment['receiver_email']), trim($sMerchantEmail)) === 0
+            && strtoupper((string)$aPayment['mc_currency']) === strtoupper($sCurrency)
+            && self::isExpectedAmount($oMembership->price, $mVatRate, $aPayment['mc_gross'])
+            && trim((string)$aPayment['txn_id']) !== '';
+    }
+
+    private static function isValidToken(string $sToken): bool
+    {
+        return preg_match('/^[a-f0-9]{40}$/', $sToken) === 1;
+    }
+
+    private static function toMinorUnits(string|int|float $mAmount): ?int
+    {
+        $sAmount = trim((string)$mAmount);
+        if (preg_match('/^(\d{1,10})(?:\.(\d{1,2}))?$/', $sAmount, $aMatches) !== 1) {
+            return null;
+        }
+
+        $sDecimals = str_pad($aMatches[2] ?? '', 2, '0');
+
+        return ((int)$aMatches[1] * self::PRICE_SCALE) + (int)$sDecimals;
+    }
+
+    private static function toVatUnits(string|int|float $mVatRate): ?int
+    {
+        $sVatRate = trim((string)$mVatRate);
+        if (preg_match('/^(\d{1,3})(?:\.(\d{1,3}))?$/', $sVatRate, $aMatches) !== 1) {
+            return null;
+        }
+
+        $iVatRate = ((int)$aMatches[1] * self::VAT_SCALE) +
+            (int)str_pad($aMatches[2] ?? '', 3, '0');
+
+        return $iVatRate <= self::PERCENT_SCALE ? $iVatRate : null;
+    }
+
+    private static function formatMinorUnits(int $iAmount): string
+    {
+        return sprintf('%d.%02d', intdiv($iAmount, self::PRICE_SCALE), $iAmount % self::PRICE_SCALE);
+    }
+}

--- a/_protected/app/system/modules/payment/inc/class/Stripe.php
+++ b/_protected/app/system/modules/payment/inc/class/Stripe.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2015-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Payment / Inc / Class
  */
 
 namespace PH7;
@@ -14,15 +14,15 @@ class Stripe extends StripeGateway
 {
     use Api; // Import the Api trait
 
-    const JS_LIBRARY_URL = 'https://checkout.stripe.com/checkout.js';
+    public const JS_LIBRARY_URL = 'https://checkout.stripe.com/checkout.js';
 
     /**
      * @param string $sPrice Normal price format (e.g., 19.95).
      *
-     * @return int Returns amount in cents (without points) to be validated for Stripe.
+     * @return int returns amount in cents (without points) to be validated for Stripe
      */
     public static function getAmount($sPrice)
     {
-        return str_replace('.', '', $sPrice);
+        return (string)PaymentCheckout::getMinorUnits($sPrice);
     }
 }

--- a/_protected/app/system/modules/payment/inc/class/design/PaymentDesign.php
+++ b/_protected/app/system/modules/payment/inc/class/design/PaymentDesign.php
@@ -1,48 +1,49 @@
 <?php
+
 /**
  * @title          Payment Design
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / Payment / Inc / Class / Design
  */
 
 namespace PH7;
 
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Payment\Gateway\Api\Api as PaymentApi;
-use stdClass;
 
 class PaymentDesign extends Framework\Core\Core
 {
-    const DIV_CONTAINER_NAME = 'payment-form';
+    public const DIV_CONTAINER_NAME = 'payment-form';
+    public const MAX_STRING_FIELD_LENGTH = 127;
     private const BRAINTREE_FORM_ID = 'braintree-payment-form';
-    const MAX_STRING_FIELD_LENGTH = 127;
 
     /**
-     * @param stdClass $oMembership
-     *
      * @return void
      */
-    public function buttonPayPal(stdClass $oMembership)
+    public function buttonPayPal(\stdClass $oMembership, string $sCheckoutToken)
     {
         $oPayPal = new PayPal($this->config->values['module.setting']['sandbox.enabled']);
+        $sCheckoutReference = PaymentCheckout::createReference($oMembership->groupId, $sCheckoutToken);
+        $mVatRate = $this->config->values['module.setting']['vat_rate'];
 
         $oPayPal
             ->param('business', $this->config->values['module.setting']['paypal.email'])
-            ->param('custom', base64_encode($oMembership->groupId . '|' . $oMembership->price))// Use base64_encode() to discourage curious people
+            ->param('custom', $sCheckoutReference)
             ->param('amount', $oMembership->price)
             ->param('item_number', $oMembership->groupId)
             ->param('item_name', $this->setMaxValueLengthToField($this->registry->site_name . ' ' . $oMembership->name))
             ->param('no_note', 1)
             ->param('no_shipping', 1)
             ->param('currency_code', $this->config->values['module.setting']['currency_code'])
-            ->param('tax_cart', $this->config->values['module.setting']['vat_rate'])
             ->param('return', Uri::get('payment', 'main', 'process', 'paypal'))
             ->param('rm', 2)// Auto redirection in POST data
-            ->param('notify_url', Uri::get('payment', 'main', 'notification', 'PH7\PayPal,' . $oMembership->groupId))
             ->param('cancel_return', Uri::get('payment', 'main', 'membership', '?msg=' . t('The payment was aborted. No charge has been taken from your account.'), false));
+
+        if ((float)$mVatRate > 0) {
+            $oPayPal->param('tax_rate', $mVatRate);
+        }
 
         $this->displayGatewayForm($oPayPal, $oMembership->name, 'PayPal');
 
@@ -52,28 +53,31 @@ class PaymentDesign extends Framework\Core\Core
     /**
      * Generates Stripe payment form Stripe API.
      *
-     * @param stdClass $oMembership
-     *
      * @return void
      */
-    public function buttonStripe(stdClass $oMembership)
+    public function buttonStripe(\stdClass $oMembership, string $sCheckoutToken)
     {
-        $oStripe = new Stripe;
+        $oStripe = new Stripe();
+        $sTotalAmount = PaymentCheckout::getTotalAmount(
+            $oMembership->price,
+            $this->config->values['module.setting']['vat_rate']
+        );
 
         $oStripe
-            ->param('item_number', $oMembership->groupId)
-            ->param('amount', $oMembership->price);
+            ->param(
+                'checkout_reference',
+                PaymentCheckout::createReference($oMembership->groupId, $sCheckoutToken)
+            );
 
-        echo
-        '<form action="', $oStripe->getUrl(), '" method="post">',
-            $oStripe->generate(),
-            '<script
-                src="', Stripe::JS_LIBRARY_URL, '" class="stripe-button"
-                data-key="', $this->config->values['module.setting']['stripe.publishable_key'], '"
-                data-name="', $this->registry->site_name, '"
-                data-description="', $oMembership->name, '"
-                data-amount="', Stripe::getAmount($oMembership->price), '"
-                data-currency="', $this->config->values['module.setting']['currency_code'], '"
+        echo '<form action="', $this->str->escapeAttribute($oStripe->getUrl()), '" method="post">',
+        $oStripe->generate(),
+        '<script
+                src="', $this->str->escapeAttribute(Stripe::JS_LIBRARY_URL), '" class="stripe-button"
+                data-key="', $this->str->escapeAttribute($this->config->values['module.setting']['stripe.publishable_key']), '"
+                data-name="', $this->str->escapeAttribute($this->registry->site_name), '"
+                data-description="', $this->str->escapeAttribute($oMembership->name), '"
+                data-amount="', $this->str->escapeAttribute(Stripe::getAmount($sTotalAmount)), '"
+                data-currency="', $this->str->escapeAttribute($this->config->values['module.setting']['currency_code']), '"
                 data-allow-remember-me="true">
             </script>
         </form>';
@@ -84,27 +88,30 @@ class PaymentDesign extends Framework\Core\Core
     /**
      * Generates Braintree payment form Braintree API.
      *
-     * @param stdClass $oMembership
-     *
      * @return void
      */
-    public function buttonBraintree(stdClass $oMembership)
+    public function buttonBraintree(\stdClass $oMembership, string $sCheckoutToken)
     {
-        $fPrice = $oMembership->price;
+        $sTotalAmount = PaymentCheckout::getTotalAmount(
+            $oMembership->price,
+            $this->config->values['module.setting']['vat_rate']
+        );
         $sCurrency = $this->config->values['module.setting']['currency_code'];
         $sLocale = PH7_LANG_NAME;
 
         Braintree::init($this->config);
         $sClientToken = Braintree::generateClientToken();
 
-        echo '<script src="', Braintree::JS_LIBRARY_URL, '"></script>';
+        echo '<script src="', $this->str->escapeAttribute(Braintree::JS_LIBRARY_URL), '"></script>';
 
-        $oBraintree = new Braintree;
+        $oBraintree = new Braintree();
         $oBraintree
-            ->param('item_number', $oMembership->groupId)
-            ->param('amount', $fPrice);
+            ->param(
+                'checkout_reference',
+                PaymentCheckout::createReference($oMembership->groupId, $sCheckoutToken)
+            );
 
-        $this->displayGatewayForm($oBraintree, $oMembership->name, '<u>Braintree</u>');
+        $this->displayGatewayForm($oBraintree, $oMembership->name, 'Braintree');
 
         unset($oBraintree);
 
@@ -115,7 +122,7 @@ class PaymentDesign extends Framework\Core\Core
         echo 'const oDropinOptions = {';
         echo 'authorization: ' . json_encode($sClientToken) . ',';
         echo 'container: ' . json_encode('#' . self::DIV_CONTAINER_NAME) . ',';
-        echo 'paypal: {flow: "checkout", amount: ' . json_encode((string)$fPrice) . ', currency: ' . json_encode($sCurrency) . ', locale: ' . json_encode($sLocale) . '}';
+        echo 'paypal: {flow: "checkout", amount: ' . json_encode($sTotalAmount) . ', currency: ' . json_encode($sCurrency) . ', locale: ' . json_encode($sLocale) . '}';
         echo '};';
         echo 'braintree.dropin.create(oDropinOptions, function (oError, oDropinInstance) {';
         echo 'if (oError || !oDropinInstance) { console.error(oError); return; }';
@@ -140,22 +147,25 @@ class PaymentDesign extends Framework\Core\Core
     }
 
     /**
-     * @param stdClass $oMembership
-     *
      * @return void
      */
-    public function button2CheckOut(stdClass $oMembership)
+    public function button2CheckOut(\stdClass $oMembership, string $sCheckoutToken)
     {
         $o2CO = new TwoCO($this->config->values['module.setting']['sandbox.enabled']);
+        $sCheckoutReference = PaymentCheckout::createReference($oMembership->groupId, $sCheckoutToken);
+        $sTotalAmount = PaymentCheckout::getTotalAmount(
+            $oMembership->price,
+            $this->config->values['module.setting']['vat_rate']
+        );
 
         $o2CO
             ->param('sid', $this->config->values['module.setting']['2co.vendor_id'])
             ->param('id_type', 1)
             ->param('cart_order_id', $oMembership->groupId)
-            ->param('merchant_order_id', $oMembership->groupId)
+            ->param('merchant_order_id', $sCheckoutReference)
             ->param('c_prod', $oMembership->groupId)
-            ->param('c_price', $oMembership->price)
-            ->param('total', $oMembership->price)
+            ->param('c_price', $sTotalAmount)
+            ->param('total', $sTotalAmount)
             ->param('c_name', $this->registry->site_name . ' ' . $oMembership->name)
             ->param('tco_currency', $this->config->values['module.setting']['currency_code'])
             ->param('c_tangible', 'N')
@@ -167,20 +177,17 @@ class PaymentDesign extends Framework\Core\Core
     }
 
     /**
-     * @param stdClass $oMembership
-     *
      * @return void
      */
-    public function buttonCCBill(stdClass $oMembership)
+    public function buttonCCBill(\stdClass $oMembership, string $sCheckoutToken)
     {
         // Not implemented yet.
         // Feel free to contribute: https://github.com/pH7Software/pH7-Social-Dating-CMS
     }
 
     /**
-     * @param PaymentApi $oPaymentProvider
      * @param string $sMembershipName
-     * @param string $sProviderName The payment provider name.
+     * @param string $sProviderName   the payment provider name
      *
      * @return void HTML output,
      */
@@ -190,7 +197,7 @@ class PaymentDesign extends Framework\Core\Core
             ? ' id="' . self::BRAINTREE_FORM_ID . '"'
             : '';
 
-        echo '<form action="', $oPaymentProvider->getUrl(), '" method="post"', $sFormId, '>';
+        echo '<form action="', $this->str->escapeAttribute($oPaymentProvider->getUrl()), '" method="post"', $sFormId, '>';
 
         if ($oPaymentProvider instanceof Braintree) {
             echo $this->getDivFormContainer();
@@ -205,13 +212,17 @@ class PaymentDesign extends Framework\Core\Core
      * Build a "buy text" message.
      *
      * @param string $sMembershipName Membership name (e.g., Platinum, Silver, ...).
-     * @param string $sProviderName Provider name (e.g., PayPal, 2CO, ...).
+     * @param string $sProviderName   Provider name (e.g., PayPal, 2CO, ...).
      *
      * @return string
      */
     private function buyTxt($sMembershipName, $sProviderName)
     {
-        return t('Buy %0% with %1%!', $sMembershipName, '<b>' . $sProviderName . '</b>');
+        return t(
+            'Buy %0% with %1%!',
+            $this->str->escape($sMembershipName),
+            '<b>' . $this->str->escape($sProviderName) . '</b>'
+        );
     }
 
     /**

--- a/_protected/app/system/modules/payment/views/base/tpl/main/membership.tpl
+++ b/_protected/app/system/modules/payment/views/base/tpl/main/membership.tpl
@@ -9,14 +9,17 @@
             <div class="panel-body">
                 <ul class="list-group">
                     {each $membership in $memberships}
-                        {if $membership->enable == 1 AND $membership->price != 0}
+                        {if $membership->isPurchasable}
                             {{ $num_enabled_membership++ }}
                             <li class="list-group-item clearfix">
                                 <div class="pull-left">
                                     <h4 class="underline">{% escape($membership->name) %}</h4>
                                     <h5>
-                                        {% $config->values['module.setting']['currency_sign'] %}{% $membership->price %}
+                                        {% escape($config->values['module.setting']['currency_sign']) %}{% $membership->totalPrice %}
                                         <span class="small">
+                                            {if $config->values['module.setting']['vat_rate'] > 0}
+                                                ({lang 'including %0%% VAT', $config->values['module.setting']['vat_rate']})
+                                            {/if}
                                             {if $membership->expirationDays > 0}
                                                 {if $membership->expirationDays == 1}
                                                     {lang 'per day', $membership->expirationDays}

--- a/_protected/app/system/modules/payment/views/base/tpl/main/pay.tpl
+++ b/_protected/app/system/modules/payment/views/base/tpl/main/pay.tpl
@@ -15,40 +15,48 @@
     {if !$is_paypal AND !$is_stripe AND !$is_braintree AND !$is_2co AND !$is_ccbill}
         <p class="err_msg">{lang 'No Payment System Enabled!'}</p>
     {else}
-        {if $membership->enable == 1 AND $membership->price != 0}
+        {if $is_purchasable_membership}
             {{ $oDesign = new PaymentDesign }}
 
             <div class="paypal_logo left">
                 <img src="{url_tpl_mod_img}payment-icon.png" alt="Payment Gateways" title="{lang 'Purchase your subscription safely!'}" />
             </div>
 
+            <p class="bold">
+                {lang 'Total:'}
+                {% escape($config->values['module.setting']['currency_sign']) %}{% $total_price %}
+                {if $config->values['module.setting']['vat_rate'] > 0}
+                    <span class="small">({lang 'including %0%% VAT', $config->values['module.setting']['vat_rate']})</span>
+                {/if}
+            </p>
+
             {if $is_braintree}
                 <div class="left vs_marg">
-                    {{ $oDesign->buttonBraintree($membership) }}
+                    {{ $oDesign->buttonBraintree($membership, $checkout_token) }}
                 </div>
             {/if}
 
             {if $is_paypal}
                 <div class="left vs_marg">
-                    {{ $oDesign->buttonPayPal($membership) }}
+                    {{ $oDesign->buttonPayPal($membership, $checkout_token) }}
                 </div>
             {/if}
 
             {if $is_stripe}
                 <div class="left vs_marg">
-                    {{ $oDesign->buttonStripe($membership) }}
+                    {{ $oDesign->buttonStripe($membership, $checkout_token) }}
                 </div>
             {/if}
 
             {if $is_2co}
                 <div class="left vs_marg">
-                    {{ $oDesign->button2CheckOut($membership) }}
+                    {{ $oDesign->button2CheckOut($membership, $checkout_token) }}
                 </div>
             {/if}
 
             {if $is_ccbill}
                 <div class="left vs_marg">
-                    {{ $oDesign->buttonCCBill($membership) }}
+                    {{ $oDesign->buttonCCBill($membership, $checkout_token) }}
                 </div>
             {/if}
         {else}

--- a/_protected/framework/Payment/Gateway/Api/PayPal.class.php
+++ b/_protected/framework/Payment/Gateway/Api/PayPal.class.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @title            PayPal Class
  *
  * @author           Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright        (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / Framework / Payment / Gateway / Api
+ *
  * @version          1.4
  */
 
@@ -17,17 +18,17 @@ use PH7\Framework\File\Stream;
 use PH7\Framework\Url\Url;
 
 /**
- * PayPal class using PayPal's API
+ * PayPal class using PayPal's API.
  *
- * @link https://developer.paypal.com/docs/integration/direct/identity/seamless-checkout/
+ * @see https://developer.paypal.com/docs/integration/direct/identity/seamless-checkout/
  */
 class PayPal extends Provider implements Api
 {
-    const SANDBOX_PAYMENT_URL = 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr';
-    const PAYMENT_URL = 'https://ipnpb.paypal.com/cgi-bin/webscr';
+    public const SANDBOX_PAYMENT_URL = 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr';
+    public const PAYMENT_URL = 'https://ipnpb.paypal.com/cgi-bin/webscr';
 
     /* Should we accept valid transactions but hasn't been completed yet? */
-    const ACCEPT_VALID_PAYMENT_NOT_COMPLETED = true;
+    public const ACCEPT_VALID_PAYMENT_NOT_COMPLETED = false;
 
     /** @var string */
     private $sUrl;
@@ -39,8 +40,7 @@ class PayPal extends Provider implements Api
     private $sMsg;
 
     /** @var bool|null */
-    private $bValid = null;
-
+    private $bValid;
 
     /**
      * @param bool $bSandbox Default FALSE
@@ -63,7 +63,7 @@ class PayPal extends Provider implements Api
      *
      * @return string
      *
-     * @internal We added an empty parameter for the method only to be compatible with the API interface.
+     * @internal we added an empty parameter for the method only to be compatible with the API interface
      */
     public function getUrl($sParam = '')
     {
@@ -88,7 +88,7 @@ class PayPal extends Provider implements Api
      *
      * @return bool
      *
-     * @internal We added two empty parameters for the method only to be compatible with the API interface.
+     * @internal we added two empty parameters for the method only to be compatible with the API interface
      */
     public function valid($sParam1 = '', $sParam2 = '')
     {
@@ -99,7 +99,7 @@ class PayPal extends Provider implements Api
         $this->setParams();
 
         $mStatus = $this->getStatus();
-        $mStatus = trim($mStatus);
+        $mStatus = trim((string)$mStatus);
 
         if (0 === strcmp('VERIFIED', $mStatus)) {
             if ($this->isValidPayment()) {
@@ -123,7 +123,7 @@ class PayPal extends Provider implements Api
     /**
      * Connect to PayPal.
      *
-     * @return bool|string Message from the transaction status on success or FALSE on failure.
+     * @return bool|string message from the transaction status on success or FALSE on failure
      */
     protected function getStatus()
     {
@@ -133,6 +133,8 @@ class PayPal extends Provider implements Api
         curl_setopt($rCh, CURLOPT_POSTFIELDS, $this->sRequest);
         curl_setopt($rCh, CURLOPT_SSL_VERIFYPEER, 1);
         curl_setopt($rCh, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($rCh, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($rCh, CURLOPT_TIMEOUT, 30);
         $sHost = (string)parse_url($this->sUrl, PHP_URL_HOST);
         if ($sHost !== '') {
             curl_setopt($rCh, CURLOPT_HTTPHEADER, [sprintf('Host: %s', $sHost)]);
@@ -165,7 +167,7 @@ class PayPal extends Provider implements Api
     }
 
     /**
-     * Set data URL e.g., "&key=value"
+     * Set data URL e.g., "&key=value".
      *
      * @param string $sName
      * @param string $sValue
@@ -186,12 +188,19 @@ class PayPal extends Provider implements Api
      */
     protected function getPostData()
     {
-        $rRawPost = Stream::getInput();
-        $aRawPost = explode('&', $rRawPost);
+        return $this->parsePostData((string)Stream::getInput());
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    protected function parsePostData(string $sRawPost): array
+    {
+        $aRawPost = explode('&', $sRawPost);
         $aPostData = [];
 
         foreach ($aRawPost as $sKeyVal) {
-            $aKeyVal = explode('=', $sKeyVal);
+            $aKeyVal = explode('=', $sKeyVal, 2);
             if (count($aKeyVal) === 2) {
                 $aPostData[$aKeyVal[0]] = Url::decode($aKeyVal[1]);
             }

--- a/_protected/framework/Payment/Gateway/Api/Provider.class.php
+++ b/_protected/framework/Payment/Gateway/Api/Provider.class.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @title            Provider Class
  *
  * @author           Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright        (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / Framework / Payment / Gateway / Api
+ *
  * @version          1.0
  */
 
@@ -33,14 +34,16 @@ abstract class Provider
     /**
      * Generate Output.
      *
-     * @return string HTML tags.
+     * @return string HTML tags
      */
     public function generate()
     {
         $sHtml = ''; // Default Value
 
         foreach ($this->aParams as $sKey => $sVal) {
-            $sHtml .= "<input type=\"hidden\" name=\"$sKey\" value=\"$sVal\" />\n";
+            $sEscapedKey = htmlspecialchars((string)$sKey, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $sEscapedValue = htmlspecialchars((string)$sVal, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $sHtml .= "<input type=\"hidden\" name=\"$sEscapedKey\" value=\"$sEscapedValue\" />\n";
         }
 
         return $sHtml;

--- a/_protected/framework/Payment/Gateway/Api/TwoCheckOut.class.php
+++ b/_protected/framework/Payment/Gateway/Api/TwoCheckOut.class.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @title            2 Check Out Class
  *
  * @author           Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright        (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package          PH7 / Framework / Payment / Gateway / Api
+ *
  * @version          1.0
  */
 
@@ -24,7 +25,6 @@ class TwoCheckOut extends Provider implements Api
     /** @var bool */
     private $bValid = false;
 
-
     /**
      * @param bool $bSandbox
      */
@@ -40,7 +40,7 @@ class TwoCheckOut extends Provider implements Api
     /**
      * Get Checkout URL.
      *
-     * @param bool $bSinglePage TRUE = Single page, FALSE = Standard multi page.
+     * @param bool $bSinglePage TRUE = Single page, FALSE = Standard multi page
      *
      * @return string
      */
@@ -66,53 +66,48 @@ class TwoCheckOut extends Provider implements Api
      *
      * @param string $sVendorId
      * @param string $sSecretWord
+     * @param string $sSecretKey
      *
      * @return bool
      */
-    public function valid($sVendorId = '', $sSecretWord = '')
+    public function valid($sVendorId = '', $sSecretWord = '', $sSecretKey = '')
     {
         // Instant Notification Service Messages
-        $aInsMsg = [];
-
-        foreach ($_POST as $sKey => $sVal) {
-            $aInsMsg[$sKey] = $sVal;
-        }
+        $aInsMsg = $_POST;
+        $aReturnData = $_GET;
 
         if (
-            !empty($_POST['message_type']) &&
-            $_POST['message_type'] == 'FRAUD_STATUS_CHANGED'
+            ($aInsMsg['message_type'] ?? '') === 'FRAUD_STATUS_CHANGED'
+            && $this->hasScalarValues($aInsMsg, ['sale_id', 'invoice_id', 'fraud_status'])
         ) {
             $sHashPayload = $aInsMsg['sale_id'] . $sVendorId . $aInsMsg['invoice_id'] . $sSecretWord;
             $sLegacyHash = strtoupper(md5($sHashPayload));
-            $sReceivedHash = strtoupper((string)($aInsMsg['md5_hash'] ?? $aInsMsg['hash'] ?? $aInsMsg['HASH'] ?? ''));
+            $sLegacyReceivedHash = strtoupper((string)($aInsMsg['md5_hash'] ?? ''));
+            $sModernReceivedHash = (string)($aInsMsg['hash'] ?? $aInsMsg['HASH'] ?? '');
+            $bSignatureValid = (
+                $sLegacyReceivedHash !== ''
+                && hash_equals($sLegacyHash, $sLegacyReceivedHash)
+            ) || (
+                $sModernReceivedHash !== ''
+                && $sSecretKey !== ''
+                && $this->validateHmacSignature($sHashPayload, $sModernReceivedHash, $sSecretKey)
+            );
 
-            if (
-                ($aInsMsg['md5_hash'] ?? '') !== '' &&
-                hash_equals($sLegacyHash, strtoupper((string)$aInsMsg['md5_hash']))
-            ) {
+            if ($bSignatureValid && ($aInsMsg['fraud_status'] ?? '') === 'pass') {
                 $this->bValid = true;
-                $this->sMsg = t('Refund transaction valid.');
-            } elseif (
-                $sReceivedHash !== '' &&
-                $this->validateShaSignature($sHashPayload, $sReceivedHash)
-            ) {
-                $this->bValid = true;
-                $this->sMsg = t('Refund transaction valid.');
+                $this->sMsg = t('Transaction valid and completed.');
             } else {
                 $this->bValid = false;
-                $this->sMsg = t('Invalid refund transaction.');
+                $this->sMsg = t('Invalid transaction.');
             }
         } elseif (
-            !empty($_REQUEST['key']) &&
-            !empty($aInsMsg['order_number']) &&
-            !empty($aInsMsg['total'])
+            $this->hasScalarValues($aReturnData, ['key', 'order_number', 'total'])
         ) {
-            $sHashPayload = $sSecretWord . $sVendorId . $aInsMsg['order_number'] . $aInsMsg['total'];
+            $sHashPayload = $sSecretWord . $sVendorId . $aReturnData['order_number'] . $aReturnData['total'];
             $sLegacyHash = strtoupper(md5($sHashPayload));
-            $sSha2Hash = strtoupper(hash('sha256', $sHashPayload));
-            $sReceivedHash = strtoupper((string)($_REQUEST['key'] ?? ''));
+            $sReceivedHash = strtoupper((string)$aReturnData['key']);
 
-            if ($sReceivedHash !== '' && ($sReceivedHash === $sLegacyHash || $sReceivedHash === $sSha2Hash)) {
+            if ($sReceivedHash !== '' && hash_equals($sLegacyHash, $sReceivedHash)) {
                 $this->bValid = true;
                 $this->sMsg = t('Purchase transaction valid.');
             } else {
@@ -124,22 +119,44 @@ class TwoCheckOut extends Provider implements Api
             $this->sMsg = t('Invalid connection to 2CheckOut.');
         }
 
-        unset($aInsMsg);
+        unset($aInsMsg, $aReturnData);
 
         return $this->bValid;
     }
 
-    private function validateShaSignature(string $sPayload, string $sReceivedHash): bool
-    {
+    private function validateHmacSignature(
+        string $sPayload,
+        string $sReceivedHash,
+        string $sSecretKey
+    ): bool {
         [$sAlgorithm, $sHash] = $this->splitSignatureWithAlgorithm($sReceivedHash);
 
-        if ($sAlgorithm !== null) {
-            return $this->compareHash($sPayload, $sAlgorithm, $sHash);
+        if ($sAlgorithm === null) {
+            return false;
         }
 
-        // If no algorithm prefix is provided, try modern supported SHA variants.
-        return $this->compareHash($sPayload, 'sha256', $sHash) ||
-            $this->compareHash($sPayload, 'sha3-256', $sHash);
+        $sCalculatedHash = strtoupper(hash_hmac($sAlgorithm, $sPayload, $sSecretKey));
+
+        return hash_equals($sCalculatedHash, $sHash);
+    }
+
+    /**
+     * @param string[] $aFieldNames
+     */
+    private function hasScalarValues(array $aData, array $aFieldNames): bool
+    {
+        foreach ($aFieldNames as $sFieldName) {
+            if (
+                !isset($aData[$sFieldName])
+                || !is_scalar($aData[$sFieldName])
+                || is_bool($aData[$sFieldName])
+                || trim((string)$aData[$sFieldName]) === ''
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -163,12 +180,5 @@ class TwoCheckOut extends Provider implements Api
         }
 
         return [$sAlgorithm, $sHash];
-    }
-
-    private function compareHash(string $sPayload, string $sAlgorithm, string $sExpectedHash): bool
-    {
-        $sCalculatedHash = strtoupper(hash($sAlgorithm, $sPayload));
-
-        return hash_equals($sCalculatedHash, $sExpectedHash);
     }
 }

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '18.5.0';
+    public const KERNEL_VERSION = '18.5.1';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-07-29';
+    public const KERNEL_RELEASE_DATE = '2026-08-02';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_tests/Unit/App/System/Module/Payment/Inc/Classes/BraintreeTest.php
+++ b/_tests/Unit/App/System/Module/Payment/Inc/Classes/BraintreeTest.php
@@ -64,6 +64,18 @@ final class BraintreeTest extends TestCase
         $this->assertSame('sandbox', GatewayConfiguration::environment());
     }
 
+    public function testInitSupportsLegacyPrivateKeySetting(): void
+    {
+        $oConfig = $this->createConfig(false, 'merchant_prod');
+        $oConfig->values['module.setting']['braintree.private_ke'] =
+            $oConfig->values['module.setting']['braintree.private_key'];
+        unset($oConfig->values['module.setting']['braintree.private_key']);
+
+        Braintree::init($oConfig);
+
+        $this->assertSame('private_key', GatewayConfiguration::privateKey());
+    }
+
     private function createConfig(bool $bSandboxEnabled, string $sMerchantId): Config
     {
         $oReflection = new ReflectionClass(Config::class);
@@ -75,7 +87,7 @@ final class BraintreeTest extends TestCase
                 'sandbox.enabled' => $bSandboxEnabled,
                 'braintree.merchant_id' => $sMerchantId,
                 'braintree.public_key' => 'public_key',
-                'braintree.private_ke' => 'private_key',
+                'braintree.private_key' => 'private_key',
             ],
         ];
 

--- a/_tests/Unit/App/System/Module/Payment/Inc/Classes/PaymentCheckoutTest.php
+++ b/_tests/Unit/App/System/Module/Payment/Inc/Classes/PaymentCheckoutTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / App / System / Module / Payment / Inc / Classes
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\Payment\Inc\Classes;
+
+require_once PH7_PATH_SYS_MOD . 'payment/inc/class/PaymentCheckout.php';
+
+use InvalidArgumentException;
+use PH7\PaymentCheckout;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class PaymentCheckoutTest extends TestCase
+{
+    private const MEMBERSHIP_ID = 6;
+    private const TOKEN = '0123456789abcdef0123456789abcdef01234567';
+
+    public function testReferenceRoundTrip(): void
+    {
+        $sReference = PaymentCheckout::createReference(self::MEMBERSHIP_ID, self::TOKEN);
+
+        $this->assertSame(
+            [
+                'membership_id' => self::MEMBERSHIP_ID,
+                'token' => self::TOKEN
+            ],
+            PaymentCheckout::parseReference($sReference)
+        );
+    }
+
+    public function testCheckoutSessionNamesAreScopedToMembership(): void
+    {
+        $this->assertSame('payment_checkout_6', PaymentCheckout::getTokenName(self::MEMBERSHIP_ID));
+        $this->assertSame('payment_checkout_context_6', PaymentCheckout::getContextName(self::MEMBERSHIP_ID));
+    }
+
+    #[DataProvider('invalidReferenceProvider')]
+    public function testInvalidReferenceIsRejected(string $sReference): void
+    {
+        $this->assertNull(PaymentCheckout::parseReference($sReference));
+    }
+
+    public static function invalidReferenceProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'not base64url' => ['%%%'],
+            'missing token' => [rtrim(strtr(base64_encode('6|'), '+/', '-_'), '=')],
+            'zero membership' => [rtrim(strtr(base64_encode('0|' . self::TOKEN), '+/', '-_'), '=')],
+            'overflowing membership' => [rtrim(strtr(base64_encode(str_repeat('9', 40) . '|' . self::TOKEN), '+/', '-_'), '=')],
+            'invalid token' => [rtrim(strtr(base64_encode('6|short'), '+/', '-_'), '=')]
+        ];
+    }
+
+    public function testTotalIncludesPercentageVatAndRoundsToMinorUnits(): void
+    {
+        $this->assertSame('23.99', PaymentCheckout::getTotalAmount('19.99', '20'));
+        $this->assertSame('19.99', PaymentCheckout::getTotalAmount('19.99', '0'));
+    }
+
+    public function testAmountComparisonUsesNormalizedMinorUnits(): void
+    {
+        $this->assertTrue(PaymentCheckout::isExpectedAmount('19.99', '20', '23.99'));
+        $this->assertTrue(PaymentCheckout::isExpectedAmount('19.90', '0', '19.9'));
+        $this->assertFalse(PaymentCheckout::isExpectedAmount('19.99', '20', '19.99'));
+        $this->assertFalse(PaymentCheckout::isExpectedAmount('19.99', '20', 'invalid'));
+    }
+
+    public function testMinorUnitsPreserveSingleDecimalPlaces(): void
+    {
+        $this->assertSame(1990, PaymentCheckout::getMinorUnits('19.9'));
+    }
+
+    public function testInvalidAmountIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PaymentCheckout::getTotalAmount('-1.00', '20');
+    }
+
+    public function testOnlyEnabledPaidMembershipIsPurchasable(): void
+    {
+        $oMembership = new stdClass;
+        $oMembership->enable = '1';
+        $oMembership->price = '9.99';
+
+        $this->assertTrue(PaymentCheckout::isPurchasableMembership($oMembership));
+
+        $oMembership->enable = '0';
+        $this->assertFalse(PaymentCheckout::isPurchasableMembership($oMembership));
+
+        $oMembership->enable = '1';
+        $oMembership->price = '0.00';
+        $this->assertFalse(PaymentCheckout::isPurchasableMembership($oMembership));
+
+        $this->assertFalse(PaymentCheckout::isPurchasableMembership(false));
+        $this->assertFalse(PaymentCheckout::isPurchasableMembership([]));
+    }
+
+    public function testValidPayPalPaymentMatchesTrustedCheckoutDetails(): void
+    {
+        $oMembership = $this->createMembership();
+
+        $this->assertTrue(
+            PaymentCheckout::isValidPayPalPayment(
+                $this->createPayPalPayment(),
+                $oMembership,
+                'merchant@example.com',
+                'USD',
+                '20'
+            )
+        );
+    }
+
+    #[DataProvider('invalidPayPalPaymentProvider')]
+    public function testInvalidPayPalPaymentIsRejected(string $sField, string $sValue): void
+    {
+        $aPayment = $this->createPayPalPayment();
+        $aPayment[$sField] = $sValue;
+
+        $this->assertFalse(
+            PaymentCheckout::isValidPayPalPayment(
+                $aPayment,
+                $this->createMembership(),
+                'merchant@example.com',
+                'USD',
+                '20'
+            )
+        );
+    }
+
+    public static function invalidPayPalPaymentProvider(): array
+    {
+        return [
+            'pending' => ['payment_status', 'Pending'],
+            'missing transaction' => ['txn_id', ''],
+            'wrong merchant' => ['receiver_email', 'attacker@example.com'],
+            'wrong currency' => ['mc_currency', 'EUR'],
+            'underpayment' => ['mc_gross', '9.99'],
+            'wrong membership' => ['item_number', '5'],
+            'non-numeric membership' => ['item_number', '6foo']
+        ];
+    }
+
+    public function testPayPalPaymentWithMissingFieldIsRejected(): void
+    {
+        $aPayment = $this->createPayPalPayment();
+        unset($aPayment['txn_id']);
+
+        $this->assertFalse(
+            PaymentCheckout::isValidPayPalPayment(
+                $aPayment,
+                $this->createMembership(),
+                'merchant@example.com',
+                'USD',
+                '20'
+            )
+        );
+    }
+
+    private function createMembership(): stdClass
+    {
+        $oMembership = new stdClass;
+        $oMembership->groupId = self::MEMBERSHIP_ID;
+        $oMembership->enable = '1';
+        $oMembership->price = '19.99';
+
+        return $oMembership;
+    }
+
+    private function createPayPalPayment(): array
+    {
+        return [
+            'payment_status' => 'Completed',
+            'txn_id' => 'PAYPAL-TRANSACTION-1',
+            'receiver_email' => 'merchant@example.com',
+            'mc_currency' => 'USD',
+            'mc_gross' => '23.99',
+            'item_number' => (string)self::MEMBERSHIP_ID
+        ];
+    }
+}

--- a/_tests/Unit/App/System/Module/Payment/Inc/Classes/StripeTest.php
+++ b/_tests/Unit/App/System/Module/Payment/Inc/Classes/StripeTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace PH7\Test\Unit\App\System\Module\Payment\Inc\Classes;
 
 require_once PH7_PATH_SYS_MOD . 'payment/inc/class/Api.php';
+require_once PH7_PATH_SYS_MOD . 'payment/inc/class/PaymentCheckout.php';
 require_once PH7_PATH_SYS_MOD . 'payment/inc/class/Stripe.php';
 
 use PH7\Stripe;
@@ -23,5 +24,10 @@ final class StripeTest extends TestCase
         $iAmount = Stripe::getAmount('19.99');
 
         $this->assertSame('1999', $iAmount);
+    }
+
+    public function testAmountWithOneDecimalPlace(): void
+    {
+        $this->assertSame('1990', Stripe::getAmount('19.9'));
     }
 }

--- a/_tests/Unit/Framework/Payment/Gateway/Api/PayPalTest.php
+++ b/_tests/Unit/Framework/Payment/Gateway/Api/PayPalTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Payment / Gateway / Api
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Payment\Gateway\Api;
+
+use PH7\Framework\Payment\Gateway\Api\PayPal;
+use PHPUnit\Framework\TestCase;
+
+final class PayPalTest extends TestCase
+{
+    private array $aPostBackup = [];
+
+    protected function setUp(): void
+    {
+        $this->aPostBackup = $_POST;
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = $this->aPostBackup;
+    }
+
+    public function testVerifiedCompletedPaymentIsAccepted(): void
+    {
+        $_POST = ['payment_status' => 'Completed'];
+
+        $this->assertTrue($this->createVerifiedGateway()->valid());
+    }
+
+    public function testVerifiedPendingPaymentIsRejected(): void
+    {
+        $_POST = ['payment_status' => 'Pending'];
+
+        $this->assertFalse($this->createVerifiedGateway()->valid());
+    }
+
+    public function testRawPostParserPreservesEqualsCharactersInValues(): void
+    {
+        $oGateway = new class(false) extends PayPal {
+            public function parse(string $sRawPost): array
+            {
+                return $this->parsePostData($sRawPost);
+            }
+        };
+
+        $this->assertSame(
+            ['custom' => 'membership=token', 'payment_status' => 'Completed'],
+            $oGateway->parse('custom=membership%3Dtoken&payment_status=Completed')
+        );
+    }
+
+    private function createVerifiedGateway(): PayPal
+    {
+        return new class(false) extends PayPal {
+            protected function getStatus()
+            {
+                return 'VERIFIED';
+            }
+
+            protected function getPostData()
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/_tests/Unit/Framework/Payment/Gateway/Api/ProviderTest.php
+++ b/_tests/Unit/Framework/Payment/Gateway/Api/ProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Payment / Gateway / Api
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Payment\Gateway\Api;
+
+use PH7\Framework\Payment\Gateway\Api\Provider;
+use PHPUnit\Framework\TestCase;
+
+final class ProviderTest extends TestCase
+{
+    public function testGenerateEscapesHiddenFieldAttributes(): void
+    {
+        $oProvider = new class extends Provider {
+        };
+        $oProvider->param('reference', '"><script>alert(1)</script>&');
+
+        $sHtml = $oProvider->generate();
+
+        $this->assertStringContainsString(
+            'value="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&amp;"',
+            $sHtml
+        );
+        $this->assertStringNotContainsString('<script>', $sHtml);
+    }
+}

--- a/_tests/Unit/Framework/Payment/Gateway/Api/TwoCheckOutTest.php
+++ b/_tests/Unit/Framework/Payment/Gateway/Api/TwoCheckOutTest.php
@@ -16,17 +16,20 @@ use PHPUnit\Framework\TestCase;
 final class TwoCheckOutTest extends TestCase
 {
     private array $aPostBackup = [];
+    private array $aGetBackup = [];
     private array $aRequestBackup = [];
 
     protected function setUp(): void
     {
         $this->aPostBackup = $_POST;
+        $this->aGetBackup = $_GET;
         $this->aRequestBackup = $_REQUEST;
     }
 
     protected function tearDown(): void
     {
         $_POST = $this->aPostBackup;
+        $_GET = $this->aGetBackup;
         $_REQUEST = $this->aRequestBackup;
     }
 
@@ -40,6 +43,7 @@ final class TwoCheckOutTest extends TestCase
 
         $_POST = [
             'message_type' => 'FRAUD_STATUS_CHANGED',
+            'fraud_status' => 'pass',
             'sale_id' => $sSaleId,
             'invoice_id' => $sInvoiceId,
             'md5_hash' => strtoupper(md5($sPayload)),
@@ -51,7 +55,30 @@ final class TwoCheckOutTest extends TestCase
         $this->assertTrue($oGateway->valid($sVendorId, $sSecretWord));
     }
 
-    public function testFraudStatusChangedAcceptsSha256HashWithPrefix(): void
+    public function testFraudStatusChangedAcceptsSha256HmacWithPrefix(): void
+    {
+        $sVendorId = 'vendor123';
+        $sSecretWord = 'secret_word';
+        $sSecretKey = 'secret_key';
+        $sSaleId = '1001';
+        $sInvoiceId = '9001';
+        $sPayload = $sSaleId . $sVendorId . $sInvoiceId . $sSecretWord;
+
+        $_POST = [
+            'message_type' => 'FRAUD_STATUS_CHANGED',
+            'fraud_status' => 'pass',
+            'sale_id' => $sSaleId,
+            'invoice_id' => $sInvoiceId,
+            'hash' => 'SHA256:' . strtoupper(hash_hmac('sha256', $sPayload, $sSecretKey)),
+        ];
+        $_REQUEST = $_POST;
+
+        $oGateway = new TwoCheckOut(false);
+
+        $this->assertTrue($oGateway->valid($sVendorId, $sSecretWord, $sSecretKey));
+    }
+
+    public function testFraudStatusChangedRejectsPendingFraudReview(): void
     {
         $sVendorId = 'vendor123';
         $sSecretWord = 'secret_word';
@@ -61,6 +88,29 @@ final class TwoCheckOutTest extends TestCase
 
         $_POST = [
             'message_type' => 'FRAUD_STATUS_CHANGED',
+            'fraud_status' => 'wait',
+            'sale_id' => $sSaleId,
+            'invoice_id' => $sInvoiceId,
+            'md5_hash' => strtoupper(md5($sPayload)),
+        ];
+        $_REQUEST = $_POST;
+
+        $oGateway = new TwoCheckOut(false);
+
+        $this->assertFalse($oGateway->valid($sVendorId, $sSecretWord));
+    }
+
+    public function testFraudStatusChangedRejectsUnkeyedShaSignature(): void
+    {
+        $sVendorId = 'vendor123';
+        $sSecretWord = 'secret_word';
+        $sSaleId = '1001';
+        $sInvoiceId = '9001';
+        $sPayload = $sSaleId . $sVendorId . $sInvoiceId . $sSecretWord;
+
+        $_POST = [
+            'message_type' => 'FRAUD_STATUS_CHANGED',
+            'fraud_status' => 'pass',
             'sale_id' => $sSaleId,
             'invoice_id' => $sInvoiceId,
             'hash' => 'SHA256:' . strtoupper(hash('sha256', $sPayload)),
@@ -69,7 +119,7 @@ final class TwoCheckOutTest extends TestCase
 
         $oGateway = new TwoCheckOut(false);
 
-        $this->assertTrue($oGateway->valid($sVendorId, $sSecretWord));
+        $this->assertFalse($oGateway->valid($sVendorId, $sSecretWord, 'secret_key'));
     }
 
     public function testPurchaseReturnAcceptsLegacyMd5Key(): void
@@ -80,18 +130,20 @@ final class TwoCheckOutTest extends TestCase
         $sTotal = '39.99';
         $sPayload = $sSecretWord . $sVendorId . $sOrderNumber . $sTotal;
 
-        $_POST = [
+        $_GET = [
             'order_number' => $sOrderNumber,
             'total' => $sTotal,
+            'key' => strtoupper(md5($sPayload)),
         ];
-        $_REQUEST = $_POST + ['key' => strtoupper(md5($sPayload))];
+        $_POST = [];
+        $_REQUEST = $_GET;
 
         $oGateway = new TwoCheckOut(false);
 
         $this->assertTrue($oGateway->valid($sVendorId, $sSecretWord));
     }
 
-    public function testPurchaseReturnAcceptsSha256Key(): void
+    public function testPurchaseReturnRejectsUndocumentedSha256Key(): void
     {
         $sVendorId = 'vendor123';
         $sSecretWord = 'secret_word';
@@ -99,14 +151,31 @@ final class TwoCheckOutTest extends TestCase
         $sTotal = '39.99';
         $sPayload = $sSecretWord . $sVendorId . $sOrderNumber . $sTotal;
 
-        $_POST = [
+        $_GET = [
             'order_number' => $sOrderNumber,
             'total' => $sTotal,
+            'key' => strtoupper(hash('sha256', $sPayload)),
         ];
-        $_REQUEST = $_POST + ['key' => strtoupper(hash('sha256', $sPayload))];
+        $_POST = [];
+        $_REQUEST = $_GET;
 
         $oGateway = new TwoCheckOut(false);
 
-        $this->assertTrue($oGateway->valid($sVendorId, $sSecretWord));
+        $this->assertFalse($oGateway->valid($sVendorId, $sSecretWord));
+    }
+
+    public function testPurchaseReturnRejectsNonScalarFields(): void
+    {
+        $_GET = [
+            'order_number' => ['7001'],
+            'total' => '39.99',
+            'key' => 'INVALID',
+        ];
+        $_POST = [];
+        $_REQUEST = $_GET;
+
+        $oGateway = new TwoCheckOut(false);
+
+        $this->assertFalse($oGateway->valid('vendor123', 'secret_word'));
     }
 }

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -96,6 +96,62 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testCookieBarDependencyIsPinnedAndIntegrityChecked(): void
+    {
+        $sProjectRoot = dirname(__DIR__, 3);
+        $aLayoutFiles = [
+            $sProjectRoot . '/templates/themes/base/tpl/layout.tpl',
+            $sProjectRoot . '/templates/themes/premium/tpl/layout.tpl'
+        ];
+
+        foreach ($aLayoutFiles as $sLayoutFile) {
+            $sLayout = file_get_contents($sLayoutFile);
+
+            $this->assertIsString($sLayout);
+            $this->assertStringContainsString('cookie-bar@1.10.3/', $sLayout);
+            $this->assertStringContainsString('integrity="sha384-', $sLayout);
+            $this->assertStringNotContainsString('cookie-bar/cookiebar-latest', $sLayout);
+        }
+    }
+
+    public function testAdminChartsUseCurrentLoaderApi(): void
+    {
+        $sAdminTemplateDirectory = dirname(__DIR__, 3) .
+            '/_protected/app/system/modules/admin123/views/base/tpl';
+        $aChartTemplates = [
+            $sAdminTemplateDirectory . '/main/stat.tpl',
+            $sAdminTemplateDirectory . '/tool/cache.tpl',
+            $sAdminTemplateDirectory . '/tool/freespace.tpl'
+        ];
+
+        foreach ($aChartTemplates as $sChartTemplate) {
+            $sTemplate = file_get_contents($sChartTemplate);
+
+            $this->assertIsString($sTemplate);
+            $this->assertStringContainsString('https://www.gstatic.com/charts/loader.js', $sTemplate);
+            $this->assertStringContainsString('google.charts.load(', $sTemplate);
+            $this->assertStringNotContainsString('https://www.google.com/jsapi', $sTemplate);
+            $this->assertStringNotContainsString('google.load(', $sTemplate);
+        }
+    }
+
+    public function testThemeFormControlsRetainResponsiveBorderBoxSizing(): void
+    {
+        $sProjectRoot = dirname(__DIR__, 3);
+        $aFormStylesheets = [
+            $sProjectRoot . '/templates/themes/base/css/form.css',
+            $sProjectRoot . '/templates/themes/premium/css/form.css'
+        ];
+
+        foreach ($aFormStylesheets as $sFormStylesheet) {
+            $sCss = file_get_contents($sFormStylesheet);
+
+            $this->assertIsString($sCss);
+            $this->assertStringContainsString('box-sizing: border-box;', $sCss);
+            $this->assertStringNotContainsString('box-sizing: content-box;', $sCss);
+        }
+    }
+
     private function findFiles(string $sDirectory, string $sSuffix): array
     {
         $aFiles = [];

--- a/_tools/pH7.sh
+++ b/_tools/pH7.sh
@@ -32,7 +32,7 @@ function init() {
     echo "18) update geoip db"
 
 
-    read option
+    read -r option
     case $option in
       "clear cache") clear-cache;;
       "remove tmp file") remove-tmp-file;;
@@ -115,19 +115,18 @@ function clean-code() {
         eval "$exec 's/\s+$/\n/'"
         eval "$exec 's/\t/    /g'"
 
-        #_clean-indent
         echo "Code has been cleaned!"
     fi
 }
 
 # Count all line of code in all files
 function count-line-code() {
-    find . -type f | xargs wc -l
+    find . -type f -exec wc -l {} +
 }
 
 # Count all line of code in PHP files
 function count-php-line-code() {
-    find . -type f -name '*.php' | xargs wc -l
+    find . -type f -name '*.php' -exec wc -l {} +
 }
 
 # Count all files
@@ -192,7 +191,7 @@ function save-code() {
 # Backup. Create a compressed archive of the project
 function backup() {
     echo "Specify the full path ending with a SLASH where you want the archive will be stored"
-    read path
+    read -r path
     if [ ! -d "$path" ]; then
         echo "The path is not a valid directory."
         exit 1
@@ -202,7 +201,7 @@ function backup() {
     if [ -e "$full_path" ]; then
         _confirm "A backup already exists in this directory, do you want to delete it?"
         if [ $? -eq 1 ]; then
-            rm $full_path
+            rm "$full_path"
         else
             echo "Backup canceled. Please choose a different backup directory or delete the old one."
             exit 2
@@ -214,7 +213,7 @@ function backup() {
     remove-tmp-file
     remove-log-file
 
-    tar -jcvf $full_path .
+    tar -jcvf "$full_path" .
     echo "Backup project successfully created into: $full_path"
 }
 
@@ -275,11 +274,11 @@ function update-geoip-db() {
 # Clear caches to avoid wrong data when checking out to another git branch
 function git-checkout() {
     echo "Give the name of the git branch you want to checkout"
-    read branch_name
-    if [ ! -z "$branch_name" ]; then
+    read -r branch_name
+    if [ -n "$branch_name" ]; then
         echo "Removing cache files before checking out the branch. Please answer 'Y'"
         clear-cache
-        git checkout $branch_name
+        git checkout "$branch_name"
     else
         echo "You need to enter the git branch name."
     fi
@@ -288,22 +287,10 @@ function git-checkout() {
 
 #### Private functions ####
 
-# Clean coding-style. Set PSR-* Ident Style (http://cs.sensiolabs.org)
-function _clean-indent() {
-    indents=indentation,function_declaration,function_typehint_space,
-method_argument_space,line_after_namespace,empty_return,linefeed,trailing_spaces,eof_ending,php_closing_tag,multiple_use,parenthesis,extra_empty_lines,short_tag,php4_constructor,phpdoc_scalar,
-lowercase_keywords,lowercase_constants,array_element_no_space_before_comma,array_element_white_space_after_comma,
-extra_empty_lines,encoding
-
-    cs_script="./_tools/php-cs-fixer.phar"
-
-    find . -type f -name "*.php" -exec php $cs_script fix {} --fixers=$indents \;
-}
-
 # Change permissions of the folders/files (CHMOD)
 function _permissions() {
-    find . -type f -print0 | sudo xargs -0 chmod $1 # First parameter for Files
-    find . -type d -print0 | sudo xargs -0 chmod $2 # Second parameter for Folders
+    find . -type f -print0 | sudo xargs -0 chmod "$1" # First parameter for Files
+    find . -type d -print0 | sudo xargs -0 chmod "$2" # Second parameter for Folders
 
     sudo chmod -R 777 ./_install/data/logs/
     sudo chmod -R 777 ./data/system/modules/*
@@ -323,23 +310,23 @@ function _cache-permissions() {
 
 # Save a git project to the specified repo (e.g. github, bitbucket)
 function _save-project-to-repo() {
-    git remote rm  $1 # Remove remote name if it already exists
-    git remote add $1 $2
-    git push $1
+    git remote rm "$1" # Remove remote name if it already exists
+    git remote add "$1" "$2"
+    git push "$1"
 }
 
 # Save repo on Internet Archive
 function _save-project-to-ia() {
     ia_saver_url="https://web.archive.org/save/"
 
-    curl -s $ia_saver_url$1 > /dev/null
+    curl -s "$ia_saver_url$1" > /dev/null
 }
 
 # Confirmation of orders entered
 function _confirm() {
-    echo $1 "(Y/N)"
-    read input
-    input=$(_to-lower $input) # Case-insensitive
+    echo "$1" "(Y/N)"
+    read -r input
+    input=$(_to-lower "$input") # Case-insensitive
     if [ "$input" == "y" ]; then
         return 1
     else
@@ -349,7 +336,7 @@ function _confirm() {
 
 # To lower
 function _to-lower() {
-    echo $1 | tr '[:upper:]' '[:lower:]'
+    echo "$1" | tr '[:upper:]' '[:lower:]'
 }
 
 function _error() {

--- a/_tools/packaging.sh
+++ b/_tools/packaging.sh
@@ -121,9 +121,9 @@ function run() {
 
 # Confirmation of orders entered
 function _confirm() {
-    echo $1 "(Y/N)"
-    read input
-    input=$(_to-lower $input) # Case-insensitive
+    echo "$1" "(Y/N)"
+    read -r input
+    input=$(_to-lower "$input") # Case-insensitive
     if [ "$input" == "y" ]; then
         return 1
     else
@@ -133,7 +133,7 @@ function _confirm() {
 
 # To lower
 function _to-lower() {
-    echo $1 | tr '[:upper:]' '[:lower:]'
+    echo "$1" | tr '[:upper:]' '[:lower:]'
 }
 
 run

--- a/_tools/theme-preview.html
+++ b/_tools/theme-preview.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>pH7Builder — Base Theme Style Guide</title>
+<title>pH7Builder — Theme Style Guide</title>
 <!--
-  Developer tool: previews the base theme CSS chain (same order as layout.tpl)
+  Developer tool: previews each theme CSS chain (same order as layout.tpl)
   against representative Bootstrap 3 markup, without needing a full install.
   Serve the repo root over HTTP, e.g.:  python3 -m http.server -d . 8642
-  then open http://localhost:8642/_tools/theme-preview.html
+  then open http://localhost:8642/_tools/theme-preview.html?theme=datelove
 -->
 <link rel="stylesheet" href="/static/css/bootstrap.css">
 <link rel="stylesheet" href="/static/css/bootstrap_customize.css">
@@ -20,11 +20,48 @@
 <link rel="stylesheet" href="/templates/themes/base/css/js/jquery/apprise.css">
 <link rel="stylesheet" href="/templates/themes/base/css/js/jquery/tipTip.css">
 <link rel="stylesheet" href="/templates/themes/base/css/design_system.css">
+<script>
+const previewParameters = new URLSearchParams(window.location.search);
+const selectedTheme = previewParameters.get('theme') || 'base';
+const derivativeThemes = ['cartoon', 'datelove', 'zendate'];
+const premiumOverrides = ['common.css', 'style.css', 'layout.css', 'color.css', 'form.css'];
+
+if (selectedTheme === 'premium') {
+    document.querySelectorAll('link[href*="/templates/themes/base/"]').forEach((link) => {
+        const stylesheetName = new URL(link.href).pathname.split('/').pop();
+        if (premiumOverrides.includes(stylesheetName)) {
+            link.href = link.href.replace('/templates/themes/base/', '/templates/themes/premium/');
+        }
+    });
+} else if (derivativeThemes.includes(selectedTheme)) {
+    const customStylesheet = document.createElement('link');
+    customStylesheet.rel = 'stylesheet';
+    customStylesheet.href = `/templates/themes/${selectedTheme}/css/_inc/common.custom.css`;
+    document.head.append(customStylesheet);
+}
+
+const previewRevision = previewParameters.get('audit');
+if (previewRevision) {
+    document.querySelectorAll('link[rel="stylesheet"]').forEach((link) => {
+        const stylesheetUrl = new URL(link.href);
+        stylesheetUrl.searchParams.set('audit', previewRevision);
+        link.href = stylesheetUrl.toString();
+    });
+}
+</script>
 </head>
-<body style="padding: 24px;">
+<body style="padding: 24px 0;">
 <div class="container">
-    <h1>Base theme style guide</h1>
-    <p>Every component below uses stock Bootstrap 3 markup, restyled by <code>design_system.css</code>.</p>
+    <h1>Theme style guide</h1>
+    <p>Every component below uses stock Bootstrap 3 markup and the selected theme's production CSS chain.</p>
+    <p aria-label="Choose preview theme">
+        Theme:
+        <a class="btn btn-default btn-xs" href="?theme=base">Base</a>
+        <a class="btn btn-default btn-xs" href="?theme=cartoon">Cartoon</a>
+        <a class="btn btn-default btn-xs" href="?theme=datelove">DateLove</a>
+        <a class="btn btn-default btn-xs" href="?theme=premium">Premium</a>
+        <a class="btn btn-default btn-xs" href="?theme=zendate">ZenDate</a>
+    </p>
 
     <h2>Buttons</h2>
     <p>

--- a/templates/themes/base/css/form.css
+++ b/templates/themes/base/css/form.css
@@ -48,7 +48,7 @@ textarea {
 }
 
 input:not([type=image]):not([type=range]), textarea, select {
-    box-sizing: content-box; /* Bugfix with Botstrap for transition in forms */
+    box-sizing: border-box;
     font-size: 14px;
     border: 1px solid #ccc;
     color: #3F3F3F;

--- a/templates/themes/base/tpl/layout.tpl
+++ b/templates/themes/base/tpl/layout.tpl
@@ -217,7 +217,11 @@
 
     {* Cookie info bar *}
     {if $is_cookie_consent_bar}
-      <script src="https://cdn.jsdelivr.net/npm/cookie-bar/cookiebar-latest.min.js?always=1"></script>
+      <script
+        src="https://cdn.jsdelivr.net/npm/cookie-bar@1.10.3/cookiebar-latest.min.js?always=1"
+        integrity="sha384-uLZyDSeIDuxDTgQovVDh6PEtbh5UJDfdGWeEo5F3w9gEeIUHdqqowv84xY3IYhJO"
+        crossorigin="anonymous"
+      ></script>
     {/if}
 
     {* JS code Injection *}

--- a/templates/themes/premium/css/form.css
+++ b/templates/themes/premium/css/form.css
@@ -48,7 +48,7 @@ textarea {
 }
 
 input:not([type=image]):not([type=range]), textarea, select {
-    box-sizing: content-box; /* Bugfix with Botstrap for transition in forms */
+    box-sizing: border-box;
     font-size: 14px;
     border: 1px solid #ccc;
     color: #3F3F3F;

--- a/templates/themes/premium/tpl/layout.tpl
+++ b/templates/themes/premium/tpl/layout.tpl
@@ -217,7 +217,11 @@
 
     {* Cookie info bar *}
     {if $is_cookie_consent_bar}
-      <script src="https://cdn.jsdelivr.net/npm/cookie-bar/cookiebar-latest.min.js?always=1"></script>
+      <script
+        src="https://cdn.jsdelivr.net/npm/cookie-bar@1.10.3/cookiebar-latest.min.js?always=1"
+        integrity="sha384-uLZyDSeIDuxDTgQovVDh6PEtbh5UJDfdGWeEo5F3w9gEeIUHdqqowv84xY3IYhJO"
+        crossorigin="anonymous"
+      ></script>
     {/if}
 
     {* JS code Injection *}


### PR DESCRIPTION
## Summary

- bind every membership purchase to a one-use session checkout, server-owned membership data, displayed amount, VAT, and currency
- validate PayPal, Stripe, Braintree, and 2Checkout results against trusted totals and provider-specific completion data
- correct 2Checkout HMAC/legacy return handling, PayPal pending-payment handling, Stripe minor units, Braintree configuration, and payment-log redaction
- restore mobile form sizing across the base and premium themes, pin the cookie-bar asset with SRI, and move admin charts to the supported Google Charts loader
- expand the theme preview across all bundled themes and harden repository workflows and maintenance scripts
- repair duplicate English gettext entries and align installer/framework metadata for v18.5.1

## Why

The release audit found that payment form fields were trusted after returning from a gateway, VAT was interpreted inconsistently, pending PayPal payments could be accepted, legacy 2Checkout SHA validation was not keyed correctly, and responsive form controls could overflow narrow screens. It also found retired/unpinned browser assets, gettext duplicates, and smaller automation hygiene defects.

The payment flow now fails closed when checkout state, membership availability, amount, currency, merchant, transaction status, or callback signature does not match the server-owned checkout.

## Validation

- `composer test` — 542 tests, 1,419 assertions
- `composer analyse` — 755 files, no errors
- focused PHP 8.5 `E_ALL` run — 50 tests, 832 assertions
- all 981 non-vendor PHP files syntax-checked
- all 349 PH7Tpl templates compiled and syntax-checked
- all 11 installer templates compiled
- root and installer Composer validation/platform checks passed
- root and installer Composer audits found no advisories
- `actionlint`, `shellcheck`, `msgfmt --check --check-format`, XML, JSON, and JavaScript validation passed
- all five bundled themes checked at 320px, 768px, and 1440px without document overflow or missing assets
- pinned cookie-bar SRI verified; Google Charts, Braintree Drop-in, and Stripe Checkout assets returned HTTP 200

Live gateway settlement was not performed because it requires merchant credentials. The callback and amount validation paths are covered locally and the full PHP 8.2–8.5/Docker GitHub Actions matrix remains the merge gate.
