### PR TITLE
Fix MySQL 8 notes compatibility

### DIFF
--- a/_protected/app/system/modules/note/models/NoteModel.php
+++ b/_protected/app/system/modules/note/models/NoteModel.php
@@ -64,7 +64,7 @@ class NoteModel extends NoteCoreModel
 
             $sSqlQuery = 'SELECT DISTINCT m.username FROM' . Db::prefix(DbTableName::MEMBER) .
                 'AS m INNER JOIN' . Db::prefix(DbTableName::NOTE) .
-                'AS n ON m.profileId = n.profileId GROUP BY m.username ASC, n.noteId LIMIT :offset, :limit';
+                'AS n ON m.profileId = n.profileId ORDER BY m.username ASC LIMIT :offset, :limit';
             $rStmt = Db::getInstance()->prepare($sSqlQuery);
 
             $rStmt->bindParam(':offset', $iOffset, PDO::PARAM_INT);

--- a/_tests/Unit/Framework/Mvc/Model/Engine/DbTest.php
+++ b/_tests/Unit/Framework/Mvc/Model/Engine/DbTest.php
@@ -10,13 +10,67 @@ declare(strict_types=1);
 
 namespace PH7\Test\Unit\Framework\Mvc\Model\Engine;
 
+use FilesystemIterator;
 use PH7\Framework\Mvc\Model\Engine\Db;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 final class DbTest extends TestCase
 {
-    public function testRequiredSqlVersionMatchesInstallerRequirement(): void
+    private const SQL_SOURCE_DIRECTORIES = [
+        '_protected/app',
+        '_protected/framework',
+        '_install/data/sql'
+    ];
+
+    public function testSqlCompatibilityRequirements(): void
     {
         $this->assertSame('5.5.3', Db::REQUIRED_SQL_VERSION);
+
+        $sProjectRoot = dirname(__DIR__, 6);
+        $aViolations = [];
+
+        foreach (self::SQL_SOURCE_DIRECTORIES as $sRelativeDirectory) {
+            foreach ($this->findSqlSourceFiles($sProjectRoot . '/' . $sRelativeDirectory) as $sSourceFile) {
+                $sSource = file_get_contents($sSourceFile);
+
+                if (is_string($sSource) && preg_match(
+                    '/\bGROUP\s+BY\b(?:(?!\bORDER\s+BY\b|\bLIMIT\b|;).)*\b(?:ASC|DESC)\b/is',
+                    $sSource
+                )) {
+                    $aViolations[] = $sSourceFile;
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $aViolations,
+            "These files use GROUP BY sort directions removed in MySQL 8.0.13:\n" . implode("\n", $aViolations)
+        );
+    }
+
+    private function findSqlSourceFiles(string $sDirectory): array
+    {
+        $aFiles = [];
+        $oIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sDirectory, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($oIterator as $oFile) {
+            if (!$oFile->isFile()) {
+                continue;
+            }
+
+            $sExtension = strtolower($oFile->getExtension());
+            if ($sExtension === 'php' || $sExtension === 'sql') {
+                $aFiles[] = $oFile->getPathname();
+            }
+        }
+
+        sort($aFiles);
+
+        return $aFiles;
     }
 }

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace PH7\Test\Unit\Root;
 
+use DOMDocument;
+use PH7\Framework\Mvc\Router\FrontController;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -76,7 +78,7 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
-    public function testTemplatesDoNotDisableBrowserZoom(): void
+    public function testTemplatesRetainAccessibleBrowserAndSignupNavigation(): void
     {
         $sProjectRoot = dirname(__DIR__, 3);
         $aTemplateFiles = array_merge(
@@ -94,6 +96,41 @@ final class ThemeAssetTest extends TestCase
                 sprintf('%s must allow users to zoom', $sTemplateFile)
             );
         }
+
+        $aTopMenuTemplates = [
+            $sProjectRoot . '/templates/themes/base/tpl/top_menu.inc.tpl',
+            $sProjectRoot . '/templates/themes/premium/tpl/top_menu.inc.tpl'
+        ];
+
+        foreach ($aTopMenuTemplates as $sTopMenuTemplate) {
+            $sTemplate = file_get_contents($sTopMenuTemplate);
+
+            $this->assertIsString($sTemplate);
+            $this->assertStringContainsString(
+                '$design->url(\'user\', \'signup\', \'step1\')',
+                $sTemplate
+            );
+        }
+
+        $oRoutes = new DOMDocument;
+        $this->assertTrue($oRoutes->load($sProjectRoot . '/_protected/app/configs/routes/en.xml'));
+
+        foreach ($oRoutes->getElementsByTagName('route') as $oRoute) {
+            if (!preg_match(
+                '`^' . $oRoute->getAttribute('url') . FrontController::REGEX_URL_EXTRA_OPTIONS . '$`',
+                'signup'
+            )) {
+                continue;
+            }
+
+            $this->assertSame('user', $oRoute->getAttribute('module'));
+            $this->assertSame('signup', $oRoute->getAttribute('controller'));
+            $this->assertSame('step1', $oRoute->getAttribute('action'));
+
+            return;
+        }
+
+        $this->fail('The public signup URL does not match a configured route.');
     }
 
     public function testCookieBarDependencyIsPinnedAndIntegrityChecked(): void

--- a/composer.lock
+++ b/composer.lock
@@ -6579,19 +6579,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
                 "shasum": ""
             },
             "require": {
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
@@ -6599,6 +6600,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
             },
             "bin": [
                 "bin/phpcbf",
@@ -6654,7 +6659,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-10T16:43:36+00:00"
+            "time": "2026-08-06T02:45:27+00:00"
         },
         {
             "name": "staabm/side-effects-detector",


### PR DESCRIPTION
## What changed

- replace the MySQL 8-incompatible `GROUP BY ... ASC` Notes query with deterministic `ORDER BY`
- add repository-wide SQL compatibility and public signup-route regression coverage
- update PHP_CodeSniffer from 4.0.1 to 4.0.4 to clear CVE-2026-67434

## Root cause

MySQL 8.0.13 removed `ASC` and `DESC` qualifiers from `GROUP BY`. The Notes author query still used this legacy MySQL 5.7 syntax, so MySQL 8 rejected it before returning the page.

## Impact

The Notes section works on MySQL 8 while preserving unique, alphabetically ordered authors. No schema migration is required. The signup route is also covered to prevent the unrelated `/signup` link report from regressing.

## Validation

- `composer test` — 542 tests, 1,428 assertions
- `composer analyse` — 755 files, no errors
- root and installer `composer audit` — no advisories
- strict Composer validation and platform requirements
- 981 PHP files linted
- 343 JavaScript files syntax-checked
- Action workflows, shell scripts, XML, JSON, and English translations validated
- `git diff --check`

Fixes #1227
