### PR TITLE
Improve signup reliability and first-run experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ your niche, and retain control of the application, database, files, and member
 data. There is no required public “Powered by” link; the MIT license notice
 simply remains with copies or substantial portions of the software.
 
+Self-hosting also lets an owner choose energy-conscious infrastructure and
+control how media, caching, and server resources are used. The actual footprint
+depends on the host, traffic, content, and configuration.
+
+<p align="center">
+  <img
+    src="static/img/love-nature.svg"
+    width="150"
+    alt="Love nature and operate pH7Builder responsibly"
+  >
+</p>
+
 ## What is included
 
 - Member profiles, search, matchmaking, nearby people, friends, and activity
@@ -60,6 +72,30 @@ Features depend on the modules you enable and the external services you
 configure. Before accepting real users or payments, complete the
 [Launch Checklist](docs/LAUNCH_CHECKLIST.md) and test the exact production
 configuration.
+
+<details>
+  <summary><strong>Explore the feature set</strong></summary>
+
+- **Discovery and matching:** advanced member search, behavioral matchmaking,
+  related profiles, nearby people, Hot or Not, profile ratings, mutual friends,
+  visits, likes, profile backgrounds, and privacy controls.
+- **Publishing and conversation:** private mail, instant messaging, chat,
+  notifications, comments, blogs, notes, forums, pages, photo albums, videos,
+  newsletters, invitations, and activity streams.
+- **Business tools:** membership groups and permissions, paid plans,
+  advertisements, an affiliate programme, payment integrations, basic
+  analytics, database backups, file management, dynamic profile fields, and
+  CSV user import.
+- **Trust and moderation:** member and content approval queues, abuse reports,
+  blocking tools, country restrictions, login-attempt protection, registration
+  throttling, duplicate-content checks, optional image screening, two-factor
+  authentication, and optional SMS verification through configured providers.
+- **Platform and reach:** multilingual routes and interface packs, responsive
+  themes, SEO controls, sitemap and RSS support, a REST API module, PWA support,
+  cron automation, maintenance mode, and sample-profile generation for
+  non-production evaluation.
+
+</details>
 
 ## Requirements
 
@@ -116,6 +152,19 @@ sha256sum -c pH7Builder-v18.6.0.zip.sha256
 unzip pH7Builder-v18.6.0.zip
 cd pH7Builder-v18.6.0
 ```
+
+Composer can install the same tagged release from Packagist:
+
+```console
+composer create-project ph7software/ph7builder:18.6.0 pH7Builder-v18.6.0 --no-dev --prefer-dist
+```
+
+pH7Builder is also listed on
+[Softaculous](https://www.softaculous.com/apps/socialnetworking/pH7Builder) and
+[SourceForge](https://sourceforge.net/projects/ph7socialdating/). Those
+catalogues can lag behind GitHub and Packagist, so compare the offered version
+with the [latest GitHub release](https://github.com/pH7Software/pH7-Social-Dating-CMS/releases)
+before installing or upgrading.
 
 The complete copy-paste deployment procedure—including database creation,
 permissions, nginx/Apache notes, HTTPS, cron, mail, payments, and the first test
@@ -199,6 +248,9 @@ theme and enabled configuration.
 
 - [Official website](https://ph7builder.com)
 - [Release guides](docs/)
+- [Legacy how-to documentation](https://ph7builder.com/doc/) — useful for
+  older customization topics; prefer the release guides for installation,
+  upgrades, and security-sensitive instructions.
 - [Issue tracker](https://github.com/pH7Software/pH7-Social-Dating-CMS/issues)
 - [Discussions](https://github.com/pH7Software/pH7-Social-Dating-CMS/discussions)
 - [Security policy](SECURITY.md)
@@ -215,6 +267,9 @@ run the test and static-analysis commands listed there.
 
 ## Creator
 
+Designed and coded with lots of ❤️ by Pierre-Henry Soria, a passionate Belgian
+software engineer and open-source product creator.
+
 <table>
   <tr>
     <td width="180" align="center" valign="top">
@@ -230,19 +285,17 @@ run the test and static-analysis commands listed there.
       <strong>Pierre-Henry Soria</strong>
     </td>
     <td valign="top">
-      pH7Builder was created by <a href="https://ph7.me"><strong>Pierre-Henry Soria</strong></a>,
-      a Belgian software engineer and open-source product creator. He also
-      created the project-specific pH7Framework to give entrepreneurs a
+      <a href="https://ph7.me"><strong>Pierre-Henry Soria</strong></a> created
+      pH7Builder and the project-specific pH7Framework to give entrepreneurs a
       flexible, self-hosted foundation for dating services and social
       communities.
       <br><br>
       The project is developed openly through the
       <a href="https://github.com/pH7Software">pH7Software organization</a>.
-      Follow Pierre-Henry on
-      <a href="https://github.com/pH-7">GitHub</a>,
-      <a href="https://www.linkedin.com/in/ph7enry/">LinkedIn</a>,
+      Follow Pierre-Henry on <a href="https://github.com/pH-7">GitHub</a>,
       <a href="https://bsky.app/profile/pierrehenry.dev">Bluesky</a>, or
-      <a href="https://x.com/phenrysay">X</a>.
+      <a href="https://x.com/phenrysay">X</a>, and connect professionally on
+      <a href="https://www.linkedin.com/in/ph7enry/">LinkedIn</a>.
     </td>
   </tr>
 </table>
@@ -257,6 +310,10 @@ run the test and static-analysis commands listed there.
   >
   <br>
   <em>Pierre-Henry working on pH7Software at a Costa Coffee shop on February 4, 2017.</em>
+  <p>
+    Early versions were crafted with a deliberately practical toolset: LAMP,
+    Geany, Sublime Text, PhpStorm, GIMP, ImageOptim, Poedit, and Git.
+  </p>
 </details>
 
 If pH7Builder helps your business, you can support continued open-source

--- a/README.md
+++ b/README.md
@@ -25,7 +25,21 @@ certificate issuance, and mail-provider approval are outside that estimate.
 [Release guides](docs/) ·
 [Releases](https://github.com/pH7Software/pH7-Social-Dating-CMS/releases)
 
-![Bundled pH7Builder base-theme preview](templates/themes/base/img/preview.png)
+<p align="center">
+  <img
+    src="https://cloud.githubusercontent.com/assets/1325411/19419476/5475b32c-93d0-11e6-9756-8e7db8df129f.png"
+    width="760"
+    alt="Build a self-hosted social dating community with pH7Builder"
+  >
+</p>
+
+## Built for ownership
+
+pH7Builder gives entrepreneurs a self-hosted alternative to rented SaaS
+platforms. Deploy it on infrastructure you choose, adapt the source code to
+your niche, and retain control of the application, database, files, and member
+data. There is no required public “Powered by” link; the MIT license notice
+simply remains with copies or substantial portions of the software.
 
 ## What is included
 
@@ -146,6 +160,41 @@ Language packs live in the separate
 Keep application code and community translations in their respective
 repositories.
 
+## Product gallery
+
+The bundled themes are responsive and can be adapted to match a dating brand
+or community niche. The exact screens and modules shown depend on the selected
+theme and enabled configuration.
+
+<p align="center">
+  <img
+    src="templates/themes/base/img/preview.png"
+    width="760"
+    alt="Bundled pH7Builder base-theme preview"
+  >
+</p>
+
+<p align="center">
+  <img
+    src="https://user-images.githubusercontent.com/1325411/35779585-68f0d5fc-09c7-11e8-91eb-bf793fcfab6e.png"
+    width="49%"
+    alt="pH7Builder member profile page"
+  >
+  <img
+    src="https://cloud.githubusercontent.com/assets/1325411/14080251/b476e5c6-f4fb-11e5-825e-ddc992ba1055.png"
+    width="49%"
+    alt="pH7Builder administration panel user list"
+  >
+</p>
+
+<p align="center">
+  <img
+    src="https://cloud.githubusercontent.com/assets/1325411/19419481/657386a4-93d0-11e6-8eee-95deba2d30a0.png"
+    width="760"
+    alt="Create a social dating web application with pH7Builder"
+  >
+</p>
+
 ## Documentation and support
 
 - [Official website](https://ph7builder.com)
@@ -164,14 +213,56 @@ Bug fixes, tests, documentation, modules, themes, and translations are welcome.
 Please read [CONTRIBUTING.md](CONTRIBUTING.md), keep pull requests focused, and
 run the test and static-analysis commands listed there.
 
-## Creator and project
+## Creator
 
-pH7Builder was created by
-[Pierre-Henry Soria](https://ph7.me) ([GitHub](https://github.com/pH-7)) and is
-maintained in the [pH7Software organization](https://github.com/pH7Software).
-If the project helps your business, you can support continued maintenance via
-[Ko-fi](https://ko-fi.com/phenry) or
-[Buy Me a Coffee](https://www.buymeacoffee.com/ph7cms).
+<table>
+  <tr>
+    <td width="180" align="center" valign="top">
+      <a href="https://ph7.me">
+        <img
+          src="https://avatars0.githubusercontent.com/u/1325411?s=200"
+          width="144"
+          height="144"
+          alt="Pierre-Henry Soria"
+        >
+      </a>
+      <br>
+      <strong>Pierre-Henry Soria</strong>
+    </td>
+    <td valign="top">
+      pH7Builder was created by <a href="https://ph7.me"><strong>Pierre-Henry Soria</strong></a>,
+      a Belgian software engineer and open-source product creator. He also
+      created the project-specific pH7Framework to give entrepreneurs a
+      flexible, self-hosted foundation for dating services and social
+      communities.
+      <br><br>
+      The project is developed openly through the
+      <a href="https://github.com/pH7Software">pH7Software organization</a>.
+      Follow Pierre-Henry on
+      <a href="https://github.com/pH-7">GitHub</a>,
+      <a href="https://www.linkedin.com/in/ph7enry/">LinkedIn</a>,
+      <a href="https://bsky.app/profile/pierrehenry.dev">Bluesky</a>, or
+      <a href="https://x.com/phenrysay">X</a>.
+    </td>
+  </tr>
+</table>
+
+<details>
+  <summary><strong>A moment from the project history</strong></summary>
+  <br>
+  <img
+    src="https://user-images.githubusercontent.com/1325411/78962138-32ffa100-7ae3-11ea-8d35-83d78f3cbc48.jpg"
+    width="760"
+    alt="Pierre-Henry Soria working on pH7Software at a Costa Coffee shop on February 4, 2017"
+  >
+  <br>
+  <em>Pierre-Henry working on pH7Software at a Costa Coffee shop on February 4, 2017.</em>
+</details>
+
+If pH7Builder helps your business, you can support continued open-source
+maintenance through
+[![Ko-fi](static/img/kofi-logo.png)](https://ko-fi.com/phenry)
+[![Buy Me a Coffee](static/img/buymeacoffee-logo.svg)](https://www.buymeacoffee.com/ph7cms).
 
 ## License
 

--- a/README2.txt
+++ b/README2.txt
@@ -1,11 +1,34 @@
-pH7Builder
-=========
+==================================================
 
-This compatibility file remains for older packages and links. Current project,
-requirements, installation, upgrade, support, and contribution information is
-maintained in README.md.
+CREATED, DEVELOPED, PRODUCED, AND POWERED BY PIERRE-HENRY SORIA. All Rights Reserved.
 
-pH7Builder was created by Pierre-Henry Soria: https://ph7.me
+==================================================
+
+All of this code (meaning all files and folders of this software) was created
+by the pH7 development team, founded by Pierre-Henry Soria. All rights
+reserved.
+
+This excludes certain files and libraries (JavaScript, PHP, or others) whose
+licenses and authors are identified in the files or in accompanying text files.
+
+==================================================
+
+pH7Builder is based on pH7Framework, which was written specifically for this
+project. The software requires PHP 8.2 or newer, and the code is 100%
+object-oriented.
+
+We need help to continue this project, so we are waiting for you! We want to
+build a large team to work on this open-source dating software project. Please
+contact us to work on this exciting project. Thank you!
+
+For licensing information, please read LICENSE.md and COPYRIGHT.md.
+
+==================================================
+
+Author: Pierre-Henry Soria
+Website: https://ph7.me
+GitHub: https://github.com/pH-7
 Project: https://github.com/pH7Software/pH7-Social-Dating-CMS
+Contact: pierrehenrysoria {[AT]} gmail {[D0T]} com / hi {[AT]} ph7 {[D0T]} me
 
-License: see LICENSE.md and COPYRIGHT.md.
+==================================================

--- a/_install/langs/en/install.lang.php
+++ b/_install/langs/en/install.lang.php
@@ -3,7 +3,7 @@
  * @title            English Language File
  *
  * @author           Pierre-Henry Soria <ph7software@gmail.com>
- * @copyright        (c) 2012-2022, Pierre-Henry Soria. All Rights Reserved.
+ * @copyright        (c) 2012-2026, Pierre-Henry Soria and pH7Builder contributors.
  * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
  * @package          PH7 / Lang / EN
  */
@@ -19,10 +19,10 @@ $LANG = [
         Thank you for choosing <strong>pH7Builder</strong>, and we hope you will love it!</p>',
     'choose_install_lang' => 'Please choose your language to begin the installation',
     'requirements_desc' => 'The installer has checked the local PHP requirements. You can also review the <a href="' . Controller::SOFTWARE_REQUIREMENTS_URL . '" target="_blank" rel="noopener">complete server requirements</a>.',
-    'requirements2_desc' => 'Before to continue, please create a MySQL database and assign a user to it with full privileges. Once you created the MySQL database and its user, make sure to write down the database name, username and password since you will need them for the installation.',
+    'requirements2_desc' => 'Before continuing, create a MySQL database and assign a user with full privileges to it. Keep the database name, username, and password ready for the installation.',
     'config_path' => '&quot;protected&quot; folder path',
     'desc_config_path' => 'Please specify the full path of your &quot;protected&quot; folder.<br />
-        It is wise and advisable (but not mandatory in any case) to put this directory outside of the public directory of the Web server.',
+        For better security, place this directory outside the Web server\'s public directory whenever your hosting setup allows it.',
     'need_frame' => 'You must use a Web browser that supports inline frames!',
     'path_protected' => 'Path of the &quot;protected&quot; folder',
     'next' => 'Next',
@@ -117,18 +117,18 @@ $LANG = [
     'wait_importing_database' => 'Please wait while importing the database.<br />
         This may take several minutes.',
     'add_sample_data' => 'Generate sample profiles for local evaluation (remove them before production)',
-    'niche' => 'Choose the Kind of WebApp you Want to Build 😇',
+    'niche' => 'Choose the kind of community you want to build 😇',
     'social_dating_niche' => 'Social-Dating Niche 🥰',
     'social_niche' => 'Community Niche 🥳',
     'dating_niche' => 'Dating Niche 😍',
     'base_niche_desc' => 'By choosing this niche, the main modules will be enabled and the generic template (social dating community theme) will be chosen by default.',
-    'zendate_niche_desc' => 'By choosing the Social niche, only the Social modules will be enabled, profile photo won\'t be required by default and the Social theme will be the default one.',
+    'zendate_niche_desc' => 'By choosing the Community niche, only the social modules will be enabled, a profile photo will not be required by default, and the Social theme will be selected.',
     'datelove_niche_desc' => 'By choosing the Dating niche, only the Dating modules will be enabled on your website, profile photo will be required by default and the Dating theme will be the default one.',
     'go_social_dating' => 'Go for Social Dating!',
     'go_social' => 'Go for Social!',
     'go_dating' => 'Go for Dating!',
     'recommended' => 'Recommended Niche',
-    'recommended_desc' => 'Choose this niche if you haven\'t an idea yet.',
+    'recommended_desc' => 'Choose this niche if you are not sure yet.',
     'note_able_to_change_niche_settings_later' => 'Please note that you will be able to change the template and enable/disable the modules later in your admin panel.',
     'will_you_make_donation' => '😇 Will you help me to maintain &amp; improve the software?',
     'donate_here' => 'Subscribe now to be a patron 🏆',

--- a/_install/langs/en/license.html
+++ b/_install/langs/en/license.html
@@ -1,5 +1,5 @@
 <p>MIT License</p>
-<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria<br /></p>
+<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria and pH7Builder contributors<br /></p>
 
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy<br />
 of this software and associated documentation files (the "Software"), to deal<br />

--- a/_install/langs/es/license.html
+++ b/_install/langs/es/license.html
@@ -1,5 +1,5 @@
 <p>MIT License</p>
-<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria<br /></p>
+<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria and pH7Builder contributors<br /></p>
 
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy<br />
   of this software and associated documentation files (the "Software"), to deal<br />

--- a/_install/langs/fr/license.html
+++ b/_install/langs/fr/license.html
@@ -1,4 +1,4 @@
-<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria</p>
+<p>Copyright (c) 2011-<span id="copyrightYear">2026</span> Pierre-Henry Soria and pH7Builder contributors</p>
 <p>Licence Libre MIT<br /></p>
 
 <p>L'autorisation est accordée, gracieusement, à toute personne acquérant une copie<br />

--- a/_install/views/base/inc/header.tpl
+++ b/_install/views/base/inc/header.tpl
@@ -44,7 +44,7 @@
             <div id="particles-js"></div>
 
             {if !empty($sept_number)}
-                {assign var="progressbar_percentage" value=$sept_number*14.3}
+                {assign var="progressbar_percentage" value=($sept_number/$total_install_steps*100)|round}
 
                 <div class="progress">
                     <div

--- a/_protected/app/Bootstrap.php
+++ b/_protected/app/Bootstrap.php
@@ -154,17 +154,17 @@ class Bootstrap
     }
 
     /**
-     * Display an error message if the Apache mod_rewrite is not enabled.
+     * Display an error message if URL rewriting is not enabled.
      *
      * @return void HTML output
      */
     private function notRewriteModEnabledError(): void
     {
-        $sMsg = '<p class="warning"><a href="' . Kernel::SOFTWARE_WEBSITE . '">pH7Builder</a> requires Apache "mod_rewrite".</p>
-        <p>Firstly, please <strong>make sure the ".htaccess" file has been uploaded to the root directory where pH7Builder is installed</strong>. If not, use your FTP client (such as Filezilla) and upload it again from pH7Builder unziped package and try again.<br />
-        Secondly, please <strong>make sure URL rewriting is correctly configured</strong>.<br /> See the <a href="https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/18.x/docs/QUICK_START.md" target="_blank" rel="noopener">Production Quick Start</a> for Apache and nginx examples.<br /><br />
-        After that, please <a href="' . PH7_URL_ROOT . '">retry</a>.</p>';
+        $sMsg = '<p class="warning"><a href="' . Kernel::SOFTWARE_WEBSITE . '">pH7Builder</a> requires URL rewriting.</p>
+        <p>On Apache, confirm that the package\'s <strong>.htaccess file is present in the pH7Builder root directory</strong>.<br />
+        Then make sure URL rewriting is correctly configured for your Web server. See the <a href="https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/18.x/docs/QUICK_START.md" target="_blank" rel="noopener">Production Quick Start</a> for Apache and nginx examples.<br /><br />
+        Once configured, <a href="' . PH7_URL_ROOT . '">retry</a>.</p>';
 
-        echo html_body("Apache's mod_rewrite is required", $sMsg);
+        echo html_body('URL rewriting is required', $sMsg);
     }
 }

--- a/_protected/app/system/modules/user/controllers/MainController.php
+++ b/_protected/app/system/modules/user/controllers/MainController.php
@@ -179,7 +179,7 @@ class MainController extends Controller
     /**
      * Add CSS/JS files for visitor's homepage.
      */
-    private function addGuestAssetFiles(string $bIsBgVideo): void
+    private function addGuestAssetFiles(bool $bIsBgVideo): void
     {
         $sIsCssVidSplashFile = $bIsBgVideo === true ? 'video_splash.css,' : '';
         $this->design->addCss(

--- a/_protected/app/system/modules/user/controllers/SignupController.php
+++ b/_protected/app/system/modules/user/controllers/SignupController.php
@@ -1,11 +1,11 @@
 <?php
+
 /**
  * @title          SignUp Controller
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Module / User / Controller
  */
 
 namespace PH7;
@@ -16,7 +16,7 @@ use PH7\Framework\Url\Header;
 
 class SignupController extends Controller
 {
-    const TOTAL_SIGNUP_STEPS = 3;
+    public const TOTAL_SIGNUP_STEPS = 3;
 
     public function step1()
     {
@@ -24,6 +24,10 @@ class SignupController extends Controller
         $this->design->addCss(
             PH7_LAYOUT . PH7_TPL . PH7_TPL_NAME . PH7_SH . PH7_CSS,
             'zoomer.css'
+        );
+        $this->design->addCss(
+            PH7_LAYOUT . PH7_SYS . PH7_MOD . $this->registry->module . PH7_SH . PH7_TPL . PH7_TPL_MOD_NAME . PH7_SH . PH7_CSS,
+            'general.css'
         );
 
         $bRef = $this->httpRequest->getExists('ref');
@@ -62,7 +66,7 @@ class SignupController extends Controller
         }
 
         $this->view->page_title = $this->getSignupPageTitle($bUserRef, $sFirstName);
-        $this->view->meta_description = t('Sign Up today to meet friends, sex friends, singles, families, neighbors and many others people near or far from you! %site_name% is a free social dating with profiles, blog, rating, hot or not, video chat rooms');
+        $this->view->meta_description = t('Create your profile on %site_name% to meet new people nearby or around the world. Discover profiles, conversations, photos, and communities that match your interests.');
 
         $sH1Txt = $this->getSignupHeading($bUserRef, $sFirstName, $sUsername);
         $this->view->h1_title = '<div class="animated fadeInDown">' . $sH1Txt . '</div>';
@@ -74,7 +78,7 @@ class SignupController extends Controller
 
     public function step2()
     {
-        $this->setTitle(t('Sign up - Step 2/3'));
+        $this->setTitle(t('Create your profile — Step 2 of 3'));
         $this->setupProgressbar(2, 66);
 
         $this->output();
@@ -82,17 +86,17 @@ class SignupController extends Controller
 
     public function step3()
     {
-        $this->setTitle(t('Sign up - Step 3/3'));
-        $this->setupProgressbar(3, 99);
+        $this->setTitle(t('Create your profile — Step 3 of 3'));
+        $this->setupProgressbar(3, 100);
 
         $this->output();
     }
 
     public function step4()
     {
-        $this->setTitle(t('Now, Upload a Photo of You! 😃'));
+        $this->setTitle(t('Add a profile photo'));
         // Assign AvatarDesign to view for displaying the avatar lightBox through the step4.tpl
-        $this->view->avatarDesign = new AvatarDesignCore;
+        $this->view->avatarDesign = new AvatarDesignCore();
 
         $this->output();
     }
@@ -116,7 +120,7 @@ class SignupController extends Controller
                 )
             );
         } else {
-            if ((new UserMilestoneCore(new UserCoreModel))->isTotalUserReached()) {
+            if ((new UserMilestoneCore(new UserCoreModel()))->isTotalUserReached()) {
                 $sUrl = Uri::get(
                     'milestone-celebration',
                     'main',
@@ -141,8 +145,8 @@ class SignupController extends Controller
     }
 
     /**
-     * @param int $iStep Number of the current step (e.g. 1, 2, 3).
-     * @param int $iPercentage Percentage of progression.
+     * @param int $iStep       Number of the current step (e.g. 1, 2, 3).
+     * @param int $iPercentage percentage of progression
      *
      * @return void
      */
@@ -156,17 +160,17 @@ class SignupController extends Controller
     /**
      * Returns the appropriate sign up page title for the registration page.
      *
-     * @param bool $bUserRef
+     * @param bool   $bUserRef
      * @param string $sFirstName
      *
      * @return string
      */
     private function getSignupPageTitle($bUserRef, $sFirstName)
     {
-        $sPageTitle = t('Free Sign Up to Meet Lovely People!');
+        $sPageTitle = t('Join %site_name% and meet new people');
 
         if ($bUserRef) {
-            $sPageTitle = t('Sign up to meet %0% on %site_name%. The Real Social Dating app!', $sFirstName);
+            $sPageTitle = t('Join %site_name% to connect with %0%', $sFirstName);
         }
 
         return $sPageTitle;
@@ -175,7 +179,7 @@ class SignupController extends Controller
     /**
      * Returns the appropriate sign up heading for the registration page.
      *
-     * @param bool $bUserRef
+     * @param bool   $bUserRef
      * @param string $sFirstName
      * @param string $sUsername
      *
@@ -183,10 +187,10 @@ class SignupController extends Controller
      */
     private function getSignupHeading($bUserRef, $sFirstName, $sUsername)
     {
-        $sHeading = t('Sign Up on %site_name%! 🎉');
+        $sHeading = t('Create your profile on %site_name%');
 
         if ($bUserRef) {
-            $sHeading = t('😍 Sign Up to Meet <span class="pink2">%0%</span> (a.k.a <span class="pink1">%1%</span>) on <span class="pink2">%site_name%</span> 🥰', $sFirstName, $this->str->upperFirst($sUsername));
+            $sHeading = t('Join <span class="pink2">%site_name%</span> to connect with <span class="pink2">%0%</span> (<span class="pink1">%1%</span>)', $sFirstName, $this->str->upperFirst($sUsername));
         }
 
         return $sHeading;

--- a/_protected/app/system/modules/user/forms/JoinForm.php
+++ b/_protected/app/system/modules/user/forms/JoinForm.php
@@ -29,6 +29,7 @@ use PFBC\Validation\Password;
 use PFBC\Validation\Str;
 use PFBC\Validation\Username;
 use PH7\Framework\Geo\Ip\Geo;
+use PH7\Framework\Geo\Misc\Country;
 use PH7\Framework\Mvc\Model\DbConfig;
 use PH7\Framework\Mvc\Request\Http;
 use PH7\Framework\Mvc\Router\Uri;
@@ -37,69 +38,6 @@ use PH7\Framework\Url\Header;
 
 class JoinForm
 {
-    private static function predictGenderFromFirstName()
-    {
-        $sFirstName = (new Session)->get('first_name');
-
-        if (empty($sFirstName)) {
-            return GenderTypeUserCore::MALE;
-        }
-
-        $sNameInLowerCase = strtolower(trim($sFirstName));
-
-        $aCommonFemaleNames = [
-            'mary', 'maria', 'sarah', 'lisa', 'jennifer', 'linda', 'patricia',
-            'barbara', 'susan', 'jessica', 'nancy', 'margaret', 'ashley',
-            'emily', 'elizabeth', 'michelle', 'amanda', 'melissa', 'deborah',
-            'sophie', 'emma', 'olivia', 'ava', 'isabella', 'mia', 'charlotte',
-            'amelia', 'harper', 'sophia', 'evelyn', 'abigail', 'ella', 'grace',
-            'anna', 'marie', 'claire', 'julie', 'kate', 'katherine', 'laura',
-            'rebecca', 'rachel', 'hannah', 'alice', 'victoria', 'lucy', 'lily'
-        ];
-
-        $aCommonMaleNames = [
-            'james', 'john', 'robert', 'michael', 'william', 'david', 'richard',
-            'joseph', 'thomas', 'charles', 'christopher', 'daniel', 'matthew',
-            'anthony', 'mark', 'donald', 'steven', 'paul', 'andrew', 'joshua',
-            'kevin', 'brian', 'george', 'edward', 'ronald', 'timothy', 'jason',
-            'jeffrey', 'ryan', 'jacob', 'nicholas', 'eric', 'stephen', 'jonathan'
-        ];
-
-        if (in_array($sNameInLowerCase, $aCommonFemaleNames, true)) {
-            return GenderTypeUserCore::FEMALE;
-        }
-
-        if (in_array($sNameInLowerCase, $aCommonMaleNames, true)) {
-            return GenderTypeUserCore::MALE;
-        }
-
-        $aFemaleEndings = ['ia' => 2, 'ina' => 3, 'elle' => 4, 'ette' => 4, 'ine' => 3, 'anna' => 4, 'lyn' => 3];
-        foreach ($aFemaleEndings as $sEnding => $iLength) {
-            if (substr($sNameInLowerCase, -$iLength) === $sEnding && strlen($sNameInLowerCase) > $iLength) {
-                return GenderTypeUserCore::FEMALE;
-            }
-        }
-
-        return GenderTypeUserCore::MALE;
-    }
-
-    private static function getOppositeGenderPreferences($sUserGender = null)
-    {
-        if ($sUserGender === null) {
-            $sUserGender = self::predictGenderFromFirstName();
-        }
-
-        if ($sUserGender === GenderTypeUserCore::FEMALE) {
-            return [GenderTypeUserCore::MALE];
-        }
-
-        if ($sUserGender === GenderTypeUserCore::MALE) {
-            return [GenderTypeUserCore::FEMALE];
-        }
-
-        return [GenderTypeUserCore::MALE, GenderTypeUserCore::FEMALE];
-    }
-
     public static function step1()
     {
         if ((new Session)->exists('mail_step1')) {
@@ -169,9 +107,6 @@ class JoinForm
         $oForm->addElement(new Hidden('submit_join_user2', 'form_join_user2'));
         $oForm->addElement(new Token('join2'));
 
-        $sPredictedGender = self::predictGenderFromFirstName();
-        $aDefaultMatchPreferences = self::getOppositeGenderPreferences($sPredictedGender);
-
         $oForm->addElement(
             new Radio(
                 t('I am a'),
@@ -181,7 +116,7 @@ class JoinForm
                     GenderTypeUserCore::MALE => '👨 ' . t('Man'),
                     GenderTypeUserCore::COUPLE => '💑 ' . t('Couple')
                 ],
-                ['value' => $sPredictedGender, 'required' => 1]
+                ['required' => 1]
             )
         );
 
@@ -194,7 +129,7 @@ class JoinForm
                     GenderTypeUserCore::FEMALE => '👩 ' . t('Woman'),
                     GenderTypeUserCore::COUPLE => '💑 ' . t('Couple')
                 ],
-                ['value' => $aDefaultMatchPreferences, 'required' => 1]
+                ['required' => 1]
             )
         );
 
@@ -204,8 +139,12 @@ class JoinForm
             new Select(
                 t('Your Country'),
                 'country',
-                Form::getCountryValues(),
-                ['id' => 'str_country', 'value' => Geo::getCountryCode(), 'required' => 1]
+                ['' => t('')] + Form::getCountryValues(),
+                [
+                    'id' => 'str_country',
+                    'value' => Country::fixCode(Geo::getCountryCode()),
+                    'required' => 1
+                ]
             )
         );
 

--- a/_protected/app/system/modules/user/views/base/tpl/main/index.guest.inc.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/index.guest.inc.tpl
@@ -2,13 +2,13 @@
     <h1 class="red3 italic underline">{headline}</h1>
     <div class="center">
         <a href="{{ $design->url('user','main','login') }}" class="btn btn-primary btn-lg">
-            <strong>{lang 'Login'}</strong>
+            <strong>{lang 'Sign in'}</strong>
         </a>
     </div>
     {{ JoinForm::step1() }}
 
     <div class="counter center">
-        <h2 class="red3">{lang 'People love us! Realtime users using our service'}</h2>
+        <h2 class="red3">{lang 'Community members'}</h2>
         {{ $userDesign->userCounter() }}
     </div>
 </div>
@@ -38,7 +38,7 @@
     </div>
 
     <div class="block_txt">
-        <h2>{lang '🚀 Meet amazing people near %0%! 🎉', $design->geoIp(false)}</h2>
+        <h2>{lang 'Meet people near %0% who share your interests', $design->geoIp(false)}</h2>
         {promo_text}
     </div>
 

--- a/_protected/app/system/modules/user/views/base/tpl/main/index.guest_splash.inc.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/index.guest_splash.inc.tpl
@@ -19,7 +19,7 @@
     {* For small devices, the following will be activated through /templates/themes/base/css/splash.css *}
     <div class="login_button hidden center">
         <a href="{{ $design->url('user','main','login') }}" class="btn btn-primary btn-lg">
-            <strong>{lang 'Login'}</strong>
+            <strong>{lang 'Sign in'}</strong>
         </a>
     </div>
 

--- a/_protected/app/system/modules/user/views/base/tpl/main/user_promo_block.inc.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/main/user_promo_block.inc.tpl
@@ -6,6 +6,6 @@
 {/if}
 
 <div class="s_tMarg" id="promo_text">
-    <h2>{lang '🚀 Meet amazing people near %0%! 🎉', $design->geoIp(false)}</h2>
+    <h2>{lang 'Meet people near %0% who share your interests', $design->geoIp(false)}</h2>
     {promo_text}
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/progressbar.inc.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/progressbar.inc.tpl
@@ -1,11 +1,18 @@
-<div class="progress">
+<div class="signup_progress">
+    <p class="signup_progress_label">
+        <span>{lang 'Step %0% of %1%', $progressbar_step, $progressbar_total_steps}</span>
+        <strong>{progressbar_percentage}%</strong>
+    </p>
     <div
-        class="progress-bar progress-bar-striped active"
+        class="progress"
         role="progressbar"
         aria-valuenow="{progressbar_percentage}"
         aria-valuemin="0"
         aria-valuemax="100"
-        style="width:{progressbar_percentage}%"
-    >{progressbar_percentage}% - {lang 'STEP'} {progressbar_step}/{progressbar_total_steps}
+        aria-valuetext="{lang 'Step %0% of %1%', $progressbar_step, $progressbar_total_steps}"
+    >
+        <div class="progress-bar progress-bar-striped active" style="width:{progressbar_percentage}%">
+            <span class="sr-only">{progressbar_percentage}%</span>
+        </div>
     </div>
 </div>

--- a/_protected/app/system/modules/user/views/base/tpl/signup/step1.tpl
+++ b/_protected/app/system/modules/user/views/base/tpl/signup/step1.tpl
@@ -5,10 +5,21 @@
     </div>
 
     <div class="pull-right col-xs-12 col-sm-5 col-md-5 col-md-offset-1 col-lg-4 animated fadeInRight">
-        <div class="center">
-            <p>
-                {lang 'Already registered?'} <a href="{{ $design->url('user','main','login') }}"><strong>{lang 'Sign In!'}</strong></a>
-            </p>
+        <aside class="panel panel-default signup_support" aria-label="{lang 'Signup information'}">
+            <div class="panel-body">
+                <h2>{lang 'Create your profile with confidence'}</h2>
+                <ul class="list-unstyled">
+                    <li><i class="fa fa-check-circle" aria-hidden="true"></i> {lang 'Registration takes three short steps.'}</li>
+                    <li><i class="fa fa-check-circle" aria-hidden="true"></i> {lang 'You can update your profile, privacy, and notification settings later.'}</li>
+                </ul>
+                <p>
+                    {lang 'Already have an account?'}
+                    <a href="{{ $design->url('user','main','login') }}"><strong>{lang 'Sign in'}</strong></a>
+                </p>
+            </div>
+        </aside>
+
+        <div class="center signup_profiles">
             {if !empty($user_ref)}
                 <a href="{{ $design->getUserAvatar($username, $sex, 400) }}" title="{first_name}" data-popup="image">
                     <img

--- a/_protected/framework/Layout/Html/Design.class.php
+++ b/_protected/framework/Layout/Html/Design.class.php
@@ -241,7 +241,7 @@ class Design
             $this->setFlashMsg($sMsg, $sType);
         }
 
-        $sUrl = $sUrl !== null ? $sUrl : $this->oHttpRequest->currentUrl();
+        $sUrl = $sUrl !== null ? $sUrl : $this->oHttpRequest->currentUrlForHeader();
 
         header('Refresh: ' . $iTime . '; URL=' . $this->oHttpRequest->pH7Url($sUrl));
     }

--- a/_protected/framework/Mvc/Request/Http.class.php
+++ b/_protected/framework/Mvc/Request/Http.class.php
@@ -306,10 +306,22 @@ class Http extends \PH7\Framework\Http\Http
      */
     public function currentUrl()
     {
-        return htmlspecialchars(
-            PH7_URL_PROT . PH7_DOMAIN . $this->getUri(),
-            ENT_QUOTES
-        );
+        // Server::getVar() already encodes REQUEST_URI for safe HTML output.
+        return PH7_URL_PROT . PH7_DOMAIN . $this->getUri();
+    }
+
+    /**
+     * @return string The current URL decoded for use in an HTTP header.
+     */
+    public function currentUrlForHeader(): string
+    {
+        $sRequestUri = (string)($_SERVER['REQUEST_URI'] ?? PH7_SH);
+        $sRequestUri = str_replace(["\r", "\n"], '', $sRequestUri);
+        if (!str_starts_with($sRequestUri, PH7_SH)) {
+            $sRequestUri = PH7_SH;
+        }
+
+        return rtrim(PH7_URL_PROT . PH7_DOMAIN, PH7_SH) . $sRequestUri;
     }
 
     /**

--- a/_protected/framework/Url/Header.class.php
+++ b/_protected/framework/Url/Header.class.php
@@ -38,7 +38,7 @@ class Header
         Http::setHeadersByCode($iRedirectCode);
 
         $oHttpRequest = new HttpRequest;
-        $sUrl = $sUrl !== null ? $sUrl : $oHttpRequest->currentUrl();
+        $sUrl = $sUrl !== null ? $sUrl : $oHttpRequest->currentUrlForHeader();
         $sUrl = $oHttpRequest->pH7Url($sUrl);
         if (!self::isSafeRedirectUrl($sUrl)) {
             $sUrl = PH7_URL_ROOT;

--- a/_tests/Unit/App/System/Module/User/Controller/MainControllerAssetTest.php
+++ b/_tests/Unit/App/System/Module/User/Controller/MainControllerAssetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\User\Controller;
+
+use PHPUnit\Framework\TestCase;
+
+final class MainControllerAssetTest extends TestCase
+{
+    public function testBackgroundVideoFlagRemainsBooleanWhenSelectingSplashStyles(): void
+    {
+        $sSource = file_get_contents(PH7_PATH_SYS_MOD . 'user/controllers/MainController.php');
+        $this->assertIsString($sSource);
+
+        $this->assertStringContainsString(
+            'private function addGuestAssetFiles(bool $bIsBgVideo): void',
+            $sSource
+        );
+        $this->assertStringContainsString("\$bIsBgVideo === true ? 'video_splash.css,' : ''", $sSource);
+        $this->assertStringNotContainsString('string $bIsBgVideo', $sSource);
+    }
+}

--- a/_tests/Unit/Framework/Mvc/Request/HttpTest.php
+++ b/_tests/Unit/Framework/Mvc/Request/HttpTest.php
@@ -219,4 +219,31 @@ final class HttpTest extends TestCase
 
         $this->assertSame('api/main/ping', $this->oHttpRequest->requestUri());
     }
+
+    public function testCurrentUrlEncodesQuerySeparatorsOnlyOnce(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/signup/step2?signup_profile_id=2&signup_recovery_token=abc123';
+
+        $this->assertSame(
+            'http://localhost:8888/signup/step2?signup_profile_id=2&amp;signup_recovery_token=abc123',
+            $this->oHttpRequest->currentUrl()
+        );
+    }
+
+    public function testCurrentUrlForHeaderUsesRawQuerySeparators(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/signup/step2?signup_profile_id=2&signup_recovery_token=abc123';
+
+        $this->assertSame(
+            'http://localhost:8888/signup/step2?signup_profile_id=2&signup_recovery_token=abc123',
+            $this->oHttpRequest->currentUrlForHeader()
+        );
+    }
+
+    public function testCurrentUrlForHeaderRejectsAnAbsoluteRequestTarget(): void
+    {
+        $_SERVER['REQUEST_URI'] = "https://attacker.example/\r\nInjected: value";
+
+        $this->assertSame('http://localhost:8888/', $this->oHttpRequest->currentUrlForHeader());
+    }
 }

--- a/_tests/Unit/Root/InstallerHardeningTest.php
+++ b/_tests/Unit/Root/InstallerHardeningTest.php
@@ -144,6 +144,17 @@ final class InstallerHardeningTest extends TestCase
         $this->assertSame('ph7builder', \PH7\Cli\Misc\Database\DbDefaultConfig::NAME);
     }
 
+    public function testInstallerProgressEndsAtExactlyOneHundredPercent(): void
+    {
+        $sHeader = $this->readProjectFile('_install/views/base/inc/header.tpl');
+
+        $this->assertStringContainsString(
+            '($sept_number/$total_install_steps*100)|round',
+            $sHeader
+        );
+        $this->assertStringNotContainsString('$sept_number*14.3', $sHeader);
+    }
+
     public function testInstallerRequiresServerSideFileTypeDetection(): void
     {
         $sRequirements = $this->readProjectFile('_install/requirements.php');

--- a/_tests/Unit/Root/InstallerLanguageTest.php
+++ b/_tests/Unit/Root/InstallerLanguageTest.php
@@ -69,4 +69,18 @@ final class InstallerLanguageTest extends TestCase
         $this->assertIsString($sController);
         $this->assertStringContainsString(self::LOCKDOWN_URL, $sController);
     }
+
+    #[DataProvider('installerLanguageProvider')]
+    public function testInstallerLicenseCreditsContributors(string $sLanguage): void
+    {
+        $sLicense = file_get_contents(
+            __DIR__ . '/../../../_install/langs/' . $sLanguage . '/license.html'
+        );
+
+        $this->assertIsString($sLicense);
+        $this->assertStringContainsString(
+            'Pierre-Henry Soria and pH7Builder contributors',
+            $sLicense
+        );
+    }
 }

--- a/_tests/Unit/Root/SignupExperienceTest.php
+++ b/_tests/Unit/Root/SignupExperienceTest.php
@@ -66,6 +66,18 @@ final class SignupExperienceTest extends TestCase
         $this->assertStringContainsString('@media (max-width: 767px)', $sStyles);
     }
 
+    public function testSignupDoesNotGuessIdentityOrLocation(): void
+    {
+        $sForm = $this->readProjectFile(
+            '_protected/app/system/modules/user/forms/JoinForm.php'
+        );
+
+        $this->assertStringNotContainsString('predictGenderFromFirstName', $sForm);
+        $this->assertStringNotContainsString('getOppositeGenderPreferences', $sForm);
+        $this->assertStringContainsString("['' => t('')] + Form::getCountryValues()", $sForm);
+        $this->assertStringContainsString('Country::fixCode(Geo::getCountryCode())', $sForm);
+    }
+
     private function readProjectFile(string $sRelativePath): string
     {
         $sContents = file_get_contents(self::PROJECT_ROOT . '/' . $sRelativePath);

--- a/_tests/Unit/Root/SignupExperienceTest.php
+++ b/_tests/Unit/Root/SignupExperienceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package        PH7 / Test / Unit / Root
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PHPUnit\Framework\TestCase;
+
+final class SignupExperienceTest extends TestCase
+{
+    private const PROJECT_ROOT = __DIR__ . '/../../..';
+
+    public function testRequiredSignupStepsReportAccurateProgress(): void
+    {
+        $sController = $this->readProjectFile(
+            '_protected/app/system/modules/user/controllers/SignupController.php'
+        );
+        $sProgressTemplate = $this->readProjectFile(
+            '_protected/app/system/modules/user/views/base/tpl/progressbar.inc.tpl'
+        );
+
+        $this->assertStringContainsString('setupProgressbar(1, 33)', $sController);
+        $this->assertStringContainsString('setupProgressbar(2, 66)', $sController);
+        $this->assertStringContainsString('setupProgressbar(3, 100)', $sController);
+        $this->assertStringNotContainsString('setupProgressbar(3, 99)', $sController);
+        $this->assertStringContainsString("'general.css'", $sController);
+        $this->assertStringContainsString('aria-valuetext=', $sProgressTemplate);
+        $this->assertStringContainsString('Step %0% of %1%', $sProgressTemplate);
+        $this->assertStringContainsString('signup_progress_label', $sProgressTemplate);
+    }
+
+    public function testSignupCopyIsWelcomingAndSpecific(): void
+    {
+        $sController = $this->readProjectFile(
+            '_protected/app/system/modules/user/controllers/SignupController.php'
+        );
+        $sFirstStep = $this->readProjectFile(
+            '_protected/app/system/modules/user/views/base/tpl/signup/step1.tpl'
+        );
+        $sGuestHomepage = $this->readProjectFile(
+            '_protected/app/system/modules/user/views/base/tpl/main/index.guest.inc.tpl'
+        );
+
+        $this->assertStringContainsString('Create your profile on %site_name%', $sController);
+        $this->assertStringNotContainsString('sex friends', $sController);
+        $this->assertStringContainsString('Registration takes three short steps.', $sFirstStep);
+        $this->assertStringContainsString('privacy, and notification settings', $sFirstStep);
+        $this->assertStringContainsString('Community members', $sGuestHomepage);
+        $this->assertStringNotContainsString('People love us!', $sGuestHomepage);
+    }
+
+    public function testSignupSupportRemainsUsableOnSmallScreens(): void
+    {
+        $sStyles = $this->readProjectFile(
+            'templates/system/modules/user/themes/base/css/general.css'
+        );
+
+        $this->assertStringContainsString('.signup_support', $sStyles);
+        $this->assertStringContainsString('@media (max-width: 767px)', $sStyles);
+    }
+
+    private function readProjectFile(string $sRelativePath): string
+    {
+        $sContents = file_get_contents(self::PROJECT_ROOT . '/' . $sRelativePath);
+        $this->assertIsString($sContents);
+
+        return $sContents;
+    }
+}

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -189,6 +189,24 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testVideoSplashKeepsItsBackgroundVisible(): void
+    {
+        $sCss = file_get_contents(
+            dirname(__DIR__, 3) . '/templates/themes/base/css/video_splash.css'
+        );
+
+        $this->assertIsString($sCss);
+        $this->assertMatchesRegularExpression(
+            '/html, body\s*\{[^}]*background:\s*transparent;/s',
+            $sCss
+        );
+        $this->assertStringContainsString(
+            '#form_login_user label, #form_join_user label',
+            $sCss
+        );
+        $this->assertStringContainsString('color: #333 !important;', $sCss);
+    }
+
     private function findFiles(string $sDirectory, string $sSuffix): array
     {
         $aFiles = [];

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -61,6 +61,18 @@ cd pH7Builder-v18.6.0
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
+As another verified path, Composer can create the project directly from the
+tagged Packagist release. Run this from the parent of the intended deployment
+directory:
+
+```console
+composer create-project ph7software/ph7builder:18.6.0 ph7builder --no-dev --prefer-dist
+```
+
+Softaculous and SourceForge also list pH7Builder, but their available archive
+may lag behind the current GitHub and Packagist release. Confirm the exact
+version before using either channel.
+
 If Composer warns about running as root, stop and correct the directory owner
 before continuing.
 

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -15,6 +15,16 @@ https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/18.x/docs/LAUNCH_CHECK
 Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
+Composer installation of this release:
+composer create-project ph7software/ph7builder:18.6.0 pH7Builder-v18.6.0 --no-dev --prefer-dist
+
+Other distribution listings:
+Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder
+SourceForge: https://sourceforge.net/projects/ph7socialdating/
+
+Softaculous and SourceForge can lag behind GitHub and Packagist. Confirm the
+exact offered version before installing or upgrading.
+
 With PHP, MySQL, and the web server prepared, dependency installation and the
 guided browser installer normally take about 20–30 minutes. DNS, HTTPS
 certificate issuance, and mail-provider approval are outside that estimate.
@@ -26,3 +36,5 @@ signup before launch.
 
 Issues: https://github.com/pH7Software/pH7-Social-Dating-CMS/issues
 Discussions: https://github.com/pH7Software/pH7-Social-Dating-CMS/discussions
+
+I really hope you enjoy using pH7Builder as much as I enjoyed creating it! 😊

--- a/templates/system/modules/user/themes/base/css/general.css
+++ b/templates/system/modules/user/themes/base/css/general.css
@@ -7,3 +7,56 @@
 #general p {
     letter-spacing: .1rem;
 }
+
+.signup_progress_label {
+    color: var(--ph7-text-muted, #6b6b7a);
+    display: flex;
+    justify-content: space-between;
+    margin: 0 0 .6rem;
+}
+
+.signup_progress .progress {
+    margin-bottom: 2rem;
+}
+
+.signup_support {
+    margin: 0 0 1.5rem;
+    text-align: left;
+}
+
+.signup_support .panel-body {
+    padding: 1.5rem;
+}
+
+.signup_support h2 {
+    font-size: 1.8rem;
+    margin: 0 0 1rem;
+}
+
+.signup_support li {
+    display: flex;
+    gap: .7rem;
+    line-height: 1.5;
+    margin-bottom: .8rem;
+}
+
+.signup_support .fa {
+    color: var(--ph7-primary, #d6336c);
+    margin-top: .25rem;
+}
+
+.signup_support p {
+    border-top: 1px solid var(--ph7-border, #e4e4ec);
+    margin: 1rem 0 0;
+    padding-top: 1rem;
+}
+
+@media (max-width: 767px) {
+    .signup_support {
+        margin-top: 1.5rem;
+    }
+
+    .signup_profiles {
+        display: none;
+    }
+}

--- a/templates/themes/base/css/video_splash.css
+++ b/templates/themes/base/css/video_splash.css
@@ -1,16 +1,29 @@
 /*
  * Author:        Pierre-Henry Soria <hello@ph7builder.com>
- * Copyright:     (c) 2016-2019, Pierre-Henry Soria. All Rights Reserved.
+ * Copyright:     (c) 2016-2026, Pierre-Henry Soria and pH7Builder contributors.
  * License:       MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
  */
 
-/** Change the color text to a more visible one (darker/whiter) when the background video on the splash homepage is enabled **/
+/** Keep the video visible beneath the splash page's content. **/
+html, body {
+    background: transparent;
+}
+
+/** Change the color text to a more visible one (darker/whiter) when the background video on the splash homepage is enabled. **/
 body {
     color: #333 !important;
 }
 
-.bt_login_forgot a, #form_login_user label, #promo_text, #promo_text a, #form_join_user em {
+.bt_login_forgot a, #promo_text, #promo_text a {
     color: #FFF !important;
+}
+
+#form_login_user label, #form_join_user label, #form_join_user label a, #form_join_user em {
+    color: #333 !important;
+}
+
+#form_join_user .pfbc-label strong, #form_login_user .bt_login_forgot a {
+    color: var(--ph7-primary-dark, #C92E63) !important;
 }
 
 #promo_text h2, #promo_text h2 a {
@@ -19,6 +32,7 @@ body {
 
 #promo_text {
     max-width: 500px;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, .8);
 }
 
 footer a, footer p {
@@ -30,7 +44,7 @@ footer a, footer p {
     color: #EEE !important;
 }
 
-#form_join_user label, #form_join_user label a, nav.bottom_nav {
+nav.bottom_nav {
     color: #EEE !important;
 }
 
@@ -44,4 +58,15 @@ footer a, footer p {
 
 #logo a {
     color: #EEE;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, .8);
+}
+
+@media (prefers-color-scheme: dark) {
+    #form_login_user label, #form_join_user label, #form_join_user label a, #form_join_user em {
+        color: #EEE !important;
+    }
+
+    #form_join_user .pfbc-label strong, #form_login_user .bt_login_forgot a {
+        color: var(--ph7-link-hover, #FF9FBD) !important;
+    }
 }


### PR DESCRIPTION
## What changed

- improves signup guidance, progress, responsive presentation, and explicit profile choices;
- preserves signup recovery parameters across immediate and delayed redirects;
- restores the enabled video splash with readable contrast;
- clarifies installer progress, setup guidance, and attribution;
- restores useful README history, imagery, project context, and creator information.

The redirect bug came from encoding the current URL twice before sending it as an HTTP header. HTML output now remains encoded once, while protocol headers use a validated raw request target.

## Verification

- fresh browser installation on MySQL 8.4, including admin creation and cleanup;
- completed first signup through login;
- admin dashboard and Notes module checked;
- responsive and video-splash UI checked;
- 835 PHPUnit tests / 2,369 assertions;
- PHPStan: no errors;
- full PHP syntax sweep, Composer validation/audits, and diff checks passed.

Best, [Pierre-Henry](https://github.com/pH-7)
