### PR TITLE
Prepare pH7Builder v18.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.0/pH7Builder-v18.6.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.0/pH7Builder-v18.6.0.zip.sha256
-sha256sum -c pH7Builder-v18.6.0.zip.sha256
-unzip pH7Builder-v18.6.0.zip
-cd pH7Builder-v18.6.0
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip.sha256
+sha256sum -c pH7Builder-v18.6.1.zip.sha256
+unzip pH7Builder-v18.6.1.zip
+cd pH7Builder-v18.6.1
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.0 pH7Builder-v18.6.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.1 pH7Builder-v18.6.1 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '18.6.0';
+    public const SOFTWARE_VERSION = '18.6.1';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '18.6.0';
+    public const KERNEL_VERSION = '18.6.1';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-08-09';
+    public const KERNEL_RELEASE_DATE = '2026-08-15';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_tests/Unit/Framework/Security/VersionTest.php
+++ b/_tests/Unit/Framework/Security/VersionTest.php
@@ -31,12 +31,12 @@ final class VersionTest extends TestCase
             [
                 'is_alert' => true,
                 'name' => 'REVOLUTIONARY™',
-                'version' => '18.6.0',
+                'version' => '18.6.1',
                 'build' => '1'
             ],
             $this->parseReleaseXml(
                 '<software><ph7><ph7builder><upd-alert>true</upd-alert><name> REVOLUTIONARY™ </name>' .
-                '<version>18.6.0</version><build>1</build></ph7builder></ph7></software>'
+                '<version>18.6.1</version><build>1</build></ph7builder></ph7></software>'
             )
         );
     }
@@ -52,7 +52,7 @@ final class VersionTest extends TestCase
             '<build>1</build></ph7builder></ph7></software>'
         ];
         yield 'invalid build' => [
-            '<software><ph7><ph7builder><name>Release</name><version>18.6.0</version>' .
+            '<software><ph7><ph7builder><name>Release</name><version>18.6.1</version>' .
             '<build>beta</build></ph7builder></ph7></software>'
         ];
     }

--- a/_tests/Unit/Root/ReleaseDeploymentTest.php
+++ b/_tests/Unit/Root/ReleaseDeploymentTest.php
@@ -37,6 +37,32 @@ final class ReleaseDeploymentTest extends TestCase
         $this->assertContains('@install-installer-dependencies', $aComposer['scripts']['post-update-cmd']);
     }
 
+    public function testReleaseVersionIsSynchronizedAcrossRuntimeInstallerAndGuides(): void
+    {
+        $sFramework = $this->readFile('_protected/framework/Security/Version.class.php');
+        $sInstaller = $this->readFile('_install/library/Controller.class.php');
+
+        $this->assertSame(
+            1,
+            preg_match("/KERNEL_VERSION = '([^']+)'/", $sFramework, $aFrameworkVersion)
+        );
+        $this->assertSame(
+            1,
+            preg_match("/SOFTWARE_VERSION = '([^']+)'/", $sInstaller, $aInstallerVersion)
+        );
+        $this->assertSame($aFrameworkVersion[1], $aInstallerVersion[1]);
+
+        $sVersion = $aFrameworkVersion[1];
+        $sReleaseUrl = "releases/download/v{$sVersion}/pH7Builder-v{$sVersion}.zip";
+        $this->assertStringContainsString($sReleaseUrl, $this->readFile('README.md'));
+        $this->assertStringContainsString($sReleaseUrl, $this->readFile('docs/QUICK_START.md'));
+        $this->assertStringContainsString(
+            "ph7software/ph7builder:{$sVersion}",
+            $this->readFile('installation-instructions-(start-here).txt')
+        );
+        $this->assertFileExists(self::PROJECT_ROOT . "/docs/RELEASE_NOTES_{$sVersion}.md");
+    }
+
     public function testReleasePackagerDoesNotMutateOrCreateWorldWritableSourceFiles(): void
     {
         $sPackager = $this->readFile('_tools/packaging.sh');

--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -102,7 +102,7 @@ you serve.
 - [ ] Every membership name, permission, price, currency, duration, renewal,
       cancellation, and refund statement matches what the checkout promises.
 - [ ] Unused gateways are disabled and no example keys remain.
-- [ ] Stripe stays disabled in 18.6.0; the bundled legacy flow must be migrated
+- [ ] Stripe stays disabled in 18.6.x; the bundled legacy flow must be migrated
       to Checkout Sessions or Payment Intents before it is offered to members.
 - [ ] 2Checkout stays disabled until its bundled legacy flow is migrated to the
       2Checkout API 6.0.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.0/pH7Builder-v18.6.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.0/pH7Builder-v18.6.0.zip.sha256
-sha256sum -c pH7Builder-v18.6.0.zip.sha256
-unzip pH7Builder-v18.6.0.zip
-cp -a pH7Builder-v18.6.0/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip.sha256
+sha256sum -c pH7Builder-v18.6.1.zip.sha256
+unzip pH7Builder-v18.6.1.zip
+cp -a pH7Builder-v18.6.1/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v18.6.0` and run:
+For a source checkout instead, clone tag `v18.6.1` and run:
 
 ```console
-git clone --branch v18.6.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v18.6.0
-cd pH7Builder-v18.6.0
+git clone --branch v18.6.1 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v18.6.1
+cd pH7Builder-v18.6.1
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.0 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.1 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive
@@ -310,7 +310,7 @@ prove inbox delivery.
    permissions, prices, currencies, and expiry periods.
 4. Admin → Billing → Gateways Configuration: keep unused gateways disabled,
    enter sandbox/test credentials first, and never commit credentials.
-   Stripe is intentionally unavailable in 18.6.0 because its bundled legacy
+   Stripe is intentionally unavailable in 18.6.x because its bundled legacy
    flow is not SCA-ready; use another supported gateway until Stripe is
    migrated to Checkout Sessions or Payment Intents.
    The bundled 2Checkout flow is also unavailable until it is migrated to the

--- a/docs/RELEASE_BACKLOG_18.6.0.md
+++ b/docs/RELEASE_BACKLOG_18.6.0.md
@@ -22,9 +22,9 @@ public callback URL.
 
 Run the packaged browser installer, member signup, admin login, Notes, uploads,
 cron, and the direct database migration on every supported PHP minor and the
-supported MySQL 8 range. Add Apache and nginx package smoke tests. Docker was
-not available in the local 18.6.0 audit environment, so the existing Docker
-workflow remains dependent on CI verification.
+supported MySQL 8 range. Add Apache and nginx package smoke tests. The Docker
+workflow now builds the development image, starts its stack, and verifies the
+installer in CI; expand that coverage rather than duplicating it manually.
 
 **Launch impact:** this catches hosting-specific failures before a new owner
 meets them during deployment.
@@ -85,8 +85,9 @@ the codebase coherent without disrupting existing sites.
 
 Make release publication update and verify the external pH7Builder update feed
 only after the GitHub tag, ZIP, and checksum are publicly available. For the
-18.6.0 publication, its `ph7builder` entry must say `REVOLUTIONARY™`, version
-`18.6.0`, SQL schema `1.6.6`, and build `1` before `upd-alert` is enabled.
+18.6.1 patch publication, its `ph7builder` entry must say `REVOLUTIONARY™`,
+version `18.6.1`, SQL schema `1.6.6`, and build `1` before `upd-alert` is
+enabled.
 
 **Launch impact:** installed sites discover real, downloadable releases without
 being sent to missing assets or left on stale version metadata.

--- a/docs/RELEASE_NOTES_18.6.0.md
+++ b/docs/RELEASE_NOTES_18.6.0.md
@@ -96,6 +96,6 @@ validation and transaction guarantees.
 
 ## Post-publication operational step
 
-- [ ] After the release assets are public, the live update feed's `ph7builder`
-      entry says `REVOLUTIONARY™`, version `18.6.0`, SQL schema `1.6.6`, and
-      build `1`; only then is `upd-alert` enabled.
+- [ ] Superseded by the 18.6.1 operational step. The feed was not advanced for
+      18.6.0, so no installed site was directed to a missing or incomplete
+      patch; publish and verify 18.6.1 before enabling its update alert.

--- a/docs/RELEASE_NOTES_18.6.1.md
+++ b/docs/RELEASE_NOTES_18.6.1.md
@@ -1,0 +1,52 @@
+# pH7Builder 18.6.1 — Release Notes
+
+## Highlights
+
+- Preserves signup recovery parameters across immediate and delayed redirects.
+  HTML output remains encoded while HTTP headers use a validated request target.
+- Requires members to choose their identity and matching preferences instead
+  of guessing them from a first name, and avoids silently selecting a country
+  when geolocation has no reliable result.
+- Makes the three-step signup journey clearer and more usable on desktop and
+  mobile, with better progress, guidance, and validation recovery.
+- Restores the optional homepage video splash beneath readable login and signup
+  content.
+- Reports exact installer completion, clarifies database and URL-rewriting
+  guidance, and aligns installer attribution with the project license.
+- Restores useful project history, product imagery, creator information, and
+  legacy context while keeping the README focused on a fast first launch.
+
+## Upgrade notes
+
+- This is a code-only patch over 18.6.0. The SQL schema remains `1.6.6`; there
+  is no `18.6.0-18.6.1` database migration.
+- Deploy the 18.6.1 package without overwriting local configuration, uploaded
+  data, custom modules, custom themes, or payment credentials.
+- Source deployments must reinstall the locked production dependencies.
+- Clear application caches, then complete a new signup through login and check
+  the homepage, admin dashboard, Notes, email, cron, and enabled payments.
+- Sites older than 18.6.0 must follow every applicable intermediate upgrade
+  path, including the 18.5.1-18.6.0 database migration.
+
+PHP 8.2+ and MySQL 8.0+ remain required. Older MySQL versions, MariaDB, and
+PostgreSQL are not verified or supported by this patch.
+
+## Release verification before publication
+
+- [ ] Framework and installer versions, release date, docs, tag, and release
+      title all identify `18.6.1`.
+- [ ] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
+      validation, and dependency audits pass.
+- [ ] A fresh MySQL 8 install completes, including admin creation and installer
+      removal.
+- [ ] Signup completes through login; Notes, admin, video splash, and responsive
+      layouts remain functional.
+- [ ] The production ZIP is built from the committed tree, includes locked
+      dependencies, excludes development files, and matches its SHA-256 file.
+
+## Post-publication operational step
+
+- [ ] After the GitHub tag, ZIP, and checksum are public, update the live
+      `ph7builder` feed entry to `REVOLUTIONARY™`, version `18.6.1`, SQL schema
+      `1.6.6`, and build `1`; enable `upd-alert` only after its download target
+      is verified.

--- a/docs/RELEASE_NOTES_18.6.1.md
+++ b/docs/RELEASE_NOTES_18.6.1.md
@@ -33,16 +33,17 @@ PostgreSQL are not verified or supported by this patch.
 
 ## Release verification before publication
 
-- [ ] Framework and installer versions, release date, docs, tag, and release
-      title all identify `18.6.1`.
-- [ ] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
+- [x] Framework and installer versions, release date, docs, planned tag, and
+      release title all identify `18.6.1`.
+- [x] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
       validation, and dependency audits pass.
-- [ ] A fresh MySQL 8 install completes, including admin creation and installer
+- [x] A fresh MySQL 8 install completes, including admin creation and installer
       removal.
-- [ ] Signup completes through login; Notes, admin, video splash, and responsive
+- [x] Signup completes through login; Notes, admin, video splash, and responsive
       layouts remain functional.
-- [ ] The production ZIP is built from the committed tree, includes locked
-      dependencies, excludes development files, and matches its SHA-256 file.
+- [x] A reproducible release-candidate ZIP is built from the committed tree,
+      includes locked dependencies, excludes development files, and matches its
+      SHA-256 file.
 
 ## Post-publication operational step
 

--- a/docs/REPOSITORY_METADATA.md
+++ b/docs/REPOSITORY_METADATA.md
@@ -1,7 +1,7 @@
-# GitHub Repository Metadata Proposal
+# GitHub Repository Metadata
 
-This copy is intentionally factual and compact. Apply it in the GitHub
-repository settings when the 18.6.0 release is ready.
+This copy records the factual, compact metadata used in the GitHub repository
+settings. Keep it aligned when the product requirements or positioning change.
 
 ## Description
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,19 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 18.6.1 patch release
+
+pH7Builder 18.6.1 is a code-only patch over 18.6.0. It does not change the SQL
+schema, so an installation already running 18.6.0 needs no database migration.
+Deploy the 18.6.1 files without overwriting local configuration, uploaded data,
+custom modules, custom themes, or gateway credentials. Reinstall dependencies
+from the committed lock file when deploying from source, clear application
+caches, and test signup through login before reopening the site.
+
+Sites older than 18.6.0 must still follow every applicable intermediate path
+below. In particular, an 18.5.1 database still requires the reviewed
+`18.5.1-18.6.0` migration before the 18.6.1 application is used.
+
 ## 18.6.0 compatibility change
 
 pH7Builder 18.6.0 requires MySQL 8.0 or newer. Older MySQL versions and MariaDB
@@ -43,9 +56,9 @@ mysqldump --single-transaction --routines --triggers --default-character-set=utf
 Replace the example account names as needed. Keep the dump outside the public
 web root and protect it as production data.
 
-## Direct 18.5.1 → 18.6.0 path
+## Direct 18.5.1 → 18.6.x path
 
-1. Deploy the tagged 18.6.0 source without overwriting local configuration,
+1. Deploy the tagged 18.6.1 source without overwriting local configuration,
    uploads, custom modules, custom themes, or gateway credentials. Merge the
    safer payment defaults deliberately; do not replace a live payment config
    with the release template.
@@ -104,9 +117,9 @@ web root and protect it as production data.
    Replace the example document root first, then verify that exact `_install`
    path is absent. Do not run the command against a variable or broader path.
 9. Clear application caches in Admin → Tools → Caches.
-10. Confirm the site and admin panel report 18.6.0, then test signup, login,
-   Notes, profile editing, uploads, password reset, email, cron, memberships,
-   and payment callbacks.
+10. Confirm the site and admin panel report the deployed target version, then
+    test signup, login, Notes, profile editing, uploads, password reset, email,
+    cron, memberships, and payment callbacks.
 11. Inspect application, PHP-FPM, and web-server logs before taking the site out
    of maintenance mode.
 

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:18.6.0 pH7Builder-v18.6.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.1 pH7Builder-v18.6.1 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder


### PR DESCRIPTION
## Summary

- Prepares the 18.6.1 patch release for the merged signup, installer, and UI fixes.
- Aligns versions, downloads, upgrade guidance, and release notes.
- Records clean tests, static analysis, audits, reproducible packaging, and MySQL 8.4 installation.

Best,
[Pierre-Henry](https://github.com/pH-7)