### PR TITLE
Prepare pH7Builder v18.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip.sha256
-sha256sum -c pH7Builder-v18.6.1.zip.sha256
-unzip pH7Builder-v18.6.1.zip
-cd pH7Builder-v18.6.1
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip.sha256
+sha256sum -c pH7Builder-v18.6.2.zip.sha256
+unzip pH7Builder-v18.6.2.zip
+cd pH7Builder-v18.6.2
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.1 pH7Builder-v18.6.1 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.2 pH7Builder-v18.6.2 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '18.6.1';
+    public const SOFTWARE_VERSION = '18.6.2';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '18.6.1';
+    public const KERNEL_VERSION = '18.6.2';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-08-15';
+    public const KERNEL_RELEASE_DATE = '2026-08-17';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -53,7 +53,7 @@ final class Version
      */
     public const KERNEL_VERSION = '18.6.2';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-08-17';
+    public const KERNEL_RELEASE_DATE = '2026-08-26';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_tests/Unit/Framework/Security/VersionTest.php
+++ b/_tests/Unit/Framework/Security/VersionTest.php
@@ -31,12 +31,12 @@ final class VersionTest extends TestCase
             [
                 'is_alert' => true,
                 'name' => 'REVOLUTIONARY™',
-                'version' => '18.6.1',
+                'version' => '18.6.2',
                 'build' => '1'
             ],
             $this->parseReleaseXml(
                 '<software><ph7><ph7builder><upd-alert>true</upd-alert><name> REVOLUTIONARY™ </name>' .
-                '<version>18.6.1</version><build>1</build></ph7builder></ph7></software>'
+                '<version>18.6.2</version><build>1</build></ph7builder></ph7></software>'
             )
         );
     }
@@ -52,7 +52,7 @@ final class VersionTest extends TestCase
             '<build>1</build></ph7builder></ph7></software>'
         ];
         yield 'invalid build' => [
-            '<software><ph7><ph7builder><name>Release</name><version>18.6.1</version>' .
+            '<software><ph7><ph7builder><name>Release</name><version>18.6.2</version>' .
             '<build>beta</build></ph7builder></ph7></software>'
         ];
     }

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.1/pH7Builder-v18.6.1.zip.sha256
-sha256sum -c pH7Builder-v18.6.1.zip.sha256
-unzip pH7Builder-v18.6.1.zip
-cp -a pH7Builder-v18.6.1/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip.sha256
+sha256sum -c pH7Builder-v18.6.2.zip.sha256
+unzip pH7Builder-v18.6.2.zip
+cp -a pH7Builder-v18.6.2/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v18.6.1` and run:
+For a source checkout instead, clone tag `v18.6.2` and run:
 
 ```console
-git clone --branch v18.6.1 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v18.6.1
-cd pH7Builder-v18.6.1
+git clone --branch v18.6.2 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v18.6.2
+cd pH7Builder-v18.6.2
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.1 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.2 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive

--- a/docs/RELEASE_BACKLOG_18.6.0.md
+++ b/docs/RELEASE_BACKLOG_18.6.0.md
@@ -85,8 +85,8 @@ the codebase coherent without disrupting existing sites.
 
 Make release publication update and verify the external pH7Builder update feed
 only after the GitHub tag, ZIP, and checksum are publicly available. For the
-18.6.1 patch publication, its `ph7builder` entry must say `REVOLUTIONARY™`,
-version `18.6.1`, SQL schema `1.6.6`, and build `1` before `upd-alert` is
+18.6.2 patch publication, its `ph7builder` entry must say `REVOLUTIONARY™`,
+version `18.6.2`, SQL schema `1.6.6`, and build `1` before `upd-alert` is
 enabled.
 
 **Launch impact:** installed sites discover real, downloadable releases without

--- a/docs/RELEASE_NOTES_18.6.1.md
+++ b/docs/RELEASE_NOTES_18.6.1.md
@@ -47,7 +47,6 @@ PostgreSQL are not verified or supported by this patch.
 
 ## Post-publication operational step
 
-- [ ] After the GitHub tag, ZIP, and checksum are public, update the live
-      `ph7builder` feed entry to `REVOLUTIONARY™`, version `18.6.1`, SQL schema
-      `1.6.6`, and build `1`; enable `upd-alert` only after its download target
-      is verified.
+- [ ] Superseded by the 18.6.2 operational step. The feed was not advanced for
+      18.6.1, so installed sites were not directed to an older patch while the
+      gettext hardening release was prepared.

--- a/docs/RELEASE_NOTES_18.6.2.md
+++ b/docs/RELEASE_NOTES_18.6.2.md
@@ -1,0 +1,45 @@
+# pH7Builder 18.6.2 — Release Notes
+
+## Highlights
+
+- Restricts gettext plural rules from language packs to the expected numeric
+  grammar instead of permitting unexpected identifiers.
+- Falls back to a safe English singular/plural rule when a language pack has a
+  malformed expression, avoiding a broken request while preserving valid
+  gettext formulas.
+- Adds regression coverage for rejected identifiers and invalid arithmetic.
+
+## Upgrade notes
+
+- This is a code-only patch over 18.6.1. The SQL schema remains `1.6.6`; there
+  is no `18.6.1-18.6.2` database migration.
+- Deploy the 18.6.2 package without overwriting local configuration, uploaded
+  data, custom modules, custom themes, language packs, or payment credentials.
+- Source deployments must reinstall the locked production dependencies.
+- Clear application caches, then verify every installed language and its plural
+  strings before reopening the site.
+- Sites older than 18.6.0 must follow every applicable intermediate upgrade
+  path, including the 18.5.1-18.6.0 database migration.
+
+PHP 8.2+ and MySQL 8.0+ remain required. Older MySQL versions, MariaDB, and
+PostgreSQL are not verified or supported by this patch.
+
+## Release verification before publication
+
+- [ ] Framework and installer versions, release date, docs, planned tag, and
+      release title all identify `18.6.2`.
+- [ ] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
+      validation, and dependency audits pass.
+- [ ] A fresh MySQL 8 install completes, including admin creation and installer
+      removal.
+- [ ] Valid gettext plural formulas work and malformed expressions fail safely.
+- [ ] A reproducible release-candidate ZIP is built from the committed tree,
+      includes locked dependencies, excludes development files, and matches its
+      SHA-256 file.
+
+## Post-publication operational step
+
+- [ ] After the GitHub tag, ZIP, and checksum are public, update the live
+      `ph7builder` feed entry to `REVOLUTIONARY™`, version `18.6.2`, SQL schema
+      `1.6.6`, and build `1`; enable `upd-alert` only after its download target
+      is verified.

--- a/docs/RELEASE_NOTES_18.6.2.md
+++ b/docs/RELEASE_NOTES_18.6.2.md
@@ -26,14 +26,14 @@ PostgreSQL are not verified or supported by this patch.
 
 ## Release verification before publication
 
-- [ ] Framework and installer versions, release date, docs, planned tag, and
+- [x] Framework and installer versions, release date, docs, planned tag, and
       release title all identify `18.6.2`.
-- [ ] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
+- [x] The complete PHPUnit suite, PHPStan, PHP syntax sweep, Composer
       validation, and dependency audits pass.
-- [ ] A fresh MySQL 8 install completes, including admin creation and installer
+- [x] A fresh MySQL 8 install completes, including admin creation and installer
       removal.
-- [ ] Valid gettext plural formulas work and malformed expressions fail safely.
-- [ ] A reproducible release-candidate ZIP is built from the committed tree,
+- [x] Valid gettext plural formulas work and malformed expressions fail safely.
+- [x] A reproducible release-candidate ZIP is built from the committed tree,
       includes locked dependencies, excludes development files, and matches its
       SHA-256 file.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,20 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 18.6.2 patch release
+
+pH7Builder 18.6.2 is a code-only security-hardening patch over 18.6.1. It does
+not change the SQL schema, so an installation already running 18.6.0 or 18.6.1
+needs no database migration. Deploy the 18.6.2 files without overwriting local
+configuration, uploaded data, custom modules, custom themes, or gateway
+credentials. Reinstall dependencies from the committed lock file when
+deploying from source, clear application caches, and verify every installed
+language before reopening the site.
+
+Sites older than 18.6.0 must still follow every applicable intermediate path
+below. In particular, an 18.5.1 database still requires the reviewed
+`18.5.1-18.6.0` migration before the 18.6.2 application is used.
+
 ## 18.6.1 patch release
 
 pH7Builder 18.6.1 is a code-only patch over 18.6.0. It does not change the SQL
@@ -58,7 +72,7 @@ web root and protect it as production data.
 
 ## Direct 18.5.1 → 18.6.x path
 
-1. Deploy the tagged 18.6.1 source without overwriting local configuration,
+1. Deploy the tagged 18.6.2 source without overwriting local configuration,
    uploads, custom modules, custom themes, or gateway credentials. Merge the
    safer payment defaults deliberately; do not replace a live payment config
    with the release template.

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:18.6.1 pH7Builder-v18.6.1 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:18.6.2 pH7Builder-v18.6.2 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder


### PR DESCRIPTION
Packages the merged gettext plural-rule hardening as v18.6.2, with synchronized runtime/installer versions, upgrade guidance, and release notes.

Local PHPUnit, PHPStan, Composer validation/audits, package construction, and SHA-256 verification pass.

Best,
[Pierre-Henry](https://github.com/pH-7)