### PR TITLE
Validate template overrides to prevent path traversal

### DIFF
--- a/_protected/framework/Layout/LoadTemplate.class.php
+++ b/_protected/framework/Layout/LoadTemplate.class.php
@@ -168,16 +168,23 @@ class LoadTemplate
         return $this;
     }
 
-    private function initializeUserTplOverride()
+    private function initializeUserTplOverride(): void
     {
         $oCookie = new Cookie;
+        $mRequestedTpl = $_REQUEST[self::REQUEST_PARAM_NAME] ?? null;
+        $sRequestedTpl = $this->normalizeTemplateName($mRequestedTpl);
 
         $this->sUserTpl = null;
-        if ($this->isTplParamSet()) {
-            $this->sUserTpl = $_REQUEST[self::REQUEST_PARAM_NAME] ?? '';
+        if ($sRequestedTpl !== null) {
+            $this->sUserTpl = $sRequestedTpl;
             $oCookie->set(self::COOKIE_NAME, $this->sUserTpl, static::COOKIE_LIFETIME);
         } elseif ($oCookie->exists(self::COOKIE_NAME)) {
-            $this->sUserTpl = $oCookie->get(self::COOKIE_NAME);
+            $sCookieTpl = $this->normalizeTemplateName($oCookie->get(self::COOKIE_NAME, false));
+            if ($sCookieTpl !== null) {
+                $this->sUserTpl = $sCookieTpl;
+            } else {
+                $oCookie->remove(self::COOKIE_NAME);
+            }
         }
 
         unset($oCookie);
@@ -205,12 +212,19 @@ class LoadTemplate
         return $this->oConfig->load(PH7_PATH_TPL . PH7_DEFAULT_THEME . PH7_DS . PH7_CONFIG . PH7_CONFIG_FILE);
     }
 
-    /**
-     * Check if a template name has been specified and if it doesn't exceed the maximum length (50 characters).
-     */
-    private function isTplParamSet(): bool
+    private function normalizeTemplateName(mixed $mTemplateName): ?string
     {
-        return !empty($_REQUEST[self::REQUEST_PARAM_NAME]) &&
-            strlen($_REQUEST[self::REQUEST_PARAM_NAME]) <= static::MAX_TPL_FOLDER_LENGTH;
+        if (
+            !is_string($mTemplateName) ||
+            $mTemplateName === '' ||
+            $mTemplateName === '.' ||
+            $mTemplateName === '..' ||
+            strlen($mTemplateName) > self::MAX_TPL_FOLDER_LENGTH ||
+            preg_match('/\A[^\x00-\x1F\x7F\/\\\\]+\z/u', $mTemplateName) !== 1
+        ) {
+            return null;
+        }
+
+        return $mTemplateName;
     }
 }

--- a/_tests/Unit/Framework/Layout/LoadTemplateTest.php
+++ b/_tests/Unit/Framework/Layout/LoadTemplateTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package        PH7 / Test / Unit / Framework / Layout
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout;
+
+use PH7\Framework\Layout\LoadTemplate;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class LoadTemplateTest extends TestCase
+{
+    private array $aRequestBackup;
+    private array $aCookieBackup;
+
+    protected function setUp(): void
+    {
+        $this->aRequestBackup = $_REQUEST;
+        $this->aCookieBackup = $_COOKIE;
+        $_REQUEST = [];
+        $_COOKIE = [];
+    }
+
+    public function testAcceptsSafeCustomThemeName(): void
+    {
+        $_REQUEST['tpl'] = 'date.love_2-custom';
+
+        $this->assertSame('date.love_2-custom', $this->getUserTemplate(new LoadTemplate()));
+    }
+
+    public function testRejectsDirectoryTraversalRequest(): void
+    {
+        foreach (['../../_protected/app/system/global/views/base', '..\\base', '.', '..'] as $sTemplateName) {
+            $_REQUEST['tpl'] = $sTemplateName;
+
+            $this->assertNull($this->getUserTemplate(new LoadTemplate()));
+        }
+    }
+
+    public function testRejectsArrayRequestWithoutTypeError(): void
+    {
+        $_REQUEST['tpl'] = ['base'];
+
+        $this->assertNull($this->getUserTemplate(new LoadTemplate()));
+    }
+
+    public function testRejectsAndRemovesInvalidTemplateCookie(): void
+    {
+        $_COOKIE['site_tpl'] = '../base';
+
+        $this->assertNull($this->getUserTemplate(new LoadTemplate()));
+        $this->assertArrayNotHasKey('site_tpl', $_COOKIE);
+    }
+
+    protected function tearDown(): void
+    {
+        $_REQUEST = $this->aRequestBackup;
+        $_COOKIE = $this->aCookieBackup;
+
+        parent::tearDown();
+    }
+
+    private function getUserTemplate(LoadTemplate $oLoadTemplate): ?string
+    {
+        $oReflection = new ReflectionClass($oLoadTemplate);
+
+        return $oReflection->getProperty('sUserTpl')->getValue($oLoadTemplate);
+    }
+}


### PR DESCRIPTION
Template overrides now accept only safe single-directory names, discard invalid cookies, and reject array/path-traversal input without PHP errors.

Verified with 842 tests (2,393 assertions), PHPStan, syntax checks, and dependency audits.

Best, [Pierre-Henry](https://github.com/pH-7)