### PR TITLE
Keep the mobile splash header readable

### DIFF
--- a/templates/themes/base/css/splash.css
+++ b/templates/themes/base/css/splash.css
@@ -208,6 +208,15 @@ video#bgvid {
 
 /* 760px or less */
 @media (max-width: 760px) {
+    html, body {
+        overflow-x: hidden;
+    }
+
+    #logo {
+        height: auto;
+        min-height: 45px;
+    }
+
     .left, .right, .login_block {
         text-align: center;
         margin-left: auto;


### PR DESCRIPTION
Long site names can wrap outside the fixed logo box and overlap the first splash headline on narrow screens. Let the logo area expand and prevent entrance animations from creating horizontal page scrolling.

Verified at 320 px, 390 px, and 1280 px with the packaged application.

Best, [Pierre-Henry](https://github.com/pH-7)