### PR TITLE
Remove remaining PHP 8 compatibility failures

### DIFF
--- a/WebsiteChecker.php
+++ b/WebsiteChecker.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 
 namespace PH7;
 
-defined('PH7') or exit(header('Location: ./'));
+if (!defined('PH7')) {
+    header('Location: ./');
+    exit;
+}
 
 use RuntimeException;
 

--- a/_install/data/configs/constants.php
+++ b/_install/data/configs/constants.php
@@ -9,7 +9,10 @@
 
 namespace PH7;
 
-defined('PH7') or exit(header('Location: ./'));
+if (!defined('PH7')) {
+    header('Location: ./');
+    exit;
+}
 
 ########## VARIABLES ##########
 

--- a/_install/inc/fns/misc.php
+++ b/_install/inc/fns/misc.php
@@ -581,7 +581,6 @@ function check_url($sUrl)
     curl_setopt_array($rCurl, [CURLOPT_RETURNTRANSFER => true, CURLOPT_URL => $sUrl]);
     curl_exec($rCurl);
     $iResponse = (int)curl_getinfo($rCurl, CURLINFO_HTTP_CODE);
-    curl_close($rCurl);
 
     return $iResponse === 200 || $iResponse === 301 || $iResponse === 302;
 }

--- a/_protected/app/system/modules/admin123/inc/class/ImportUser.php
+++ b/_protected/app/system/modules/admin123/inc/class/ImportUser.php
@@ -71,7 +71,7 @@ class ImportUser extends Core
         // Initialize the necessary attributes
         $this->aFile = $aFile;
         $this->rHandler = @fopen($this->aFile['tmp_name'], 'rb');
-        $this->aFileData = (array)@fgetcsv($this->rHandler, 0, $sDelimiter, $sEnclosure);
+        $this->aFileData = (array)@fgetcsv($this->rHandler, 0, $sDelimiter, $sEnclosure, '\\');
         $this->aRes = $this->run($sDelimiter, $sEnclosure);
     }
 
@@ -261,7 +261,7 @@ class ImportUser extends Core
             $oExistsModel = new ExistCoreModel;
             $oValidate = new Validate;
 
-            while (false !== ($aUserData = fgetcsv($this->rHandler, 0, $sDelimiter, $sEnclosure))) {
+            while (false !== ($aUserData = fgetcsv($this->rHandler, 0, $sDelimiter, $sEnclosure, '\\'))) {
                 $sEmail = trim($aUserData[$this->aTmpData['email']]);
 
                 // Make sure the email is valid and doesn't exist yet in the database

--- a/_protected/framework/Http/Http.class.php
+++ b/_protected/framework/Http/Http.class.php
@@ -196,7 +196,7 @@ class Http
             header(sprintf('WWW-Authenticate: Basic realm="%s"', $sMsg));
             static::setHeadersByCode(StatusCode::UNAUTHORIZED);
             echo t('You must enter a valid login ID and password to access this resource.') . "\n";
-            exit(false);
+            exit;
         }
 
         return true;

--- a/_tests/Unit/App/System/Module/Admin123/Inc/Classes/ImportUserCsvCompatibilityTest.php
+++ b/_tests/Unit/App/System/Module/Admin123/Inc/Classes/ImportUserCsvCompatibilityTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / App / System / Module / Admin123 / Inc / Classes
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\Admin123\Inc\Classes;
+
+use PHPUnit\Framework\TestCase;
+
+final class ImportUserCsvCompatibilityTest extends TestCase
+{
+    public function testCsvReaderKeepsItsEscapeCharacterExplicit(): void
+    {
+        $sSource = file_get_contents(
+            dirname(__DIR__, 8) . '/_protected/app/system/modules/admin123/inc/class/ImportUser.php'
+        );
+        $sExplicitEscapeArgument = <<<'SOURCE'
+$sEnclosure, '\\')
+SOURCE;
+
+        $this->assertIsString($sSource);
+        $this->assertSame(2, substr_count($sSource, 'fgetcsv('));
+        $this->assertSame(2, substr_count($sSource, $sExplicitEscapeArgument));
+    }
+}

--- a/_tests/Unit/Framework/Http/HttpTest.php
+++ b/_tests/Unit/Framework/Http/HttpTest.php
@@ -78,6 +78,14 @@ final class HttpTest extends TestCase
         $this->assertFalse($sIsSsl);
     }
 
+    public function testAuthenticationFailureDoesNotPassBooleanToExit(): void
+    {
+        $sSource = file_get_contents(PH7_PATH_FRAMEWORK . 'Http/Http.class.php');
+
+        $this->assertIsString($sSource);
+        $this->assertStringNotContainsString('exit(false)', $sSource);
+    }
+
     public function testDetectSubdomain(): void
     {
         $bIsASubdomain = $this->oHttp->detectSubdomain('https://learning.ph7builder.com');

--- a/_tests/Unit/Root/InstallerHardeningTest.php
+++ b/_tests/Unit/Root/InstallerHardeningTest.php
@@ -176,6 +176,13 @@ final class InstallerHardeningTest extends TestCase
         $this->assertStringNotContainsString("PH7_URL_INSTALL . 'test_mod_rewrite'", $sFunctions);
     }
 
+    public function testInstallerDoesNotCallDeprecatedCurlClose(): void
+    {
+        $sFunctions = $this->readProjectFile('_install/inc/fns/misc.php');
+
+        $this->assertStringNotContainsString('curl_close(', $sFunctions);
+    }
+
     public function testInstallerPinsCanonicalAuthorityWithoutTrustingRequestHeaders(): void
     {
         $sInstallerConstants = $this->readProjectFile('_install/constants.php');

--- a/_tests/Unit/Root/WebsiteCheckerTest.php
+++ b/_tests/Unit/Root/WebsiteCheckerTest.php
@@ -71,6 +71,19 @@ final class WebsiteCheckerTest extends TestCase
         $this->assertStringNotContainsString("\$_SERVER['PHP_SELF']", $sChecker);
     }
 
+    public function testDirectAccessGuardsDoNotPassHeaderReturnValueToExit(): void
+    {
+        $sProjectRoot = dirname(__DIR__, 3);
+
+        foreach (['WebsiteChecker.php', '_install/data/configs/constants.php'] as $sRelativePath) {
+            $sSource = file_get_contents($sProjectRoot . '/' . $sRelativePath);
+
+            $this->assertIsString($sSource);
+            $this->assertStringContainsString("if (!defined('PH7'))", $sSource);
+            $this->assertStringNotContainsString("exit(header(", $sSource);
+        }
+    }
+
     public function testIncompatiblePhpVersionFlagIsFalseOnCurrentRuntime(): void
     {
         $oChecker = new WebsiteChecker;


### PR DESCRIPTION
Removes the remaining PHP 8.4/8.5 runtime warnings and failures in direct-access guards, CSV imports, installer URL checks, and response exits.

Verified on PHP 8.5: 842 tests, 2,398 assertions; PHPStan clean.

Best, [Pierre-Henry](https://github.com/pH-7)