### PR TITLE
Emit each RSS discovery link once

### DIFF
--- a/_protected/app/system/core/classes/design/XmlDesignCore.php
+++ b/_protected/app/system/core/classes/design/XmlDesignCore.php
@@ -58,7 +58,6 @@ class XmlDesignCore
     public static function rssHeaderLinks()
     {
         self::generateRssTagLink(t('Latest Blog Posts'), Uri::get('xml', 'rss', 'xmlrouter', 'blog'));
-        self::generateRssTagLink(t('Latest Blog Posts'), Uri::get('xml', 'rss', 'xmlrouter', 'blog'));
         self::generateRssTagLink(t('Latest Notes'), Uri::get('xml', 'rss', 'xmlrouter', 'note'));
         self::generateRssTagLink(t('Latest Forum Topics'), Uri::get('xml', 'rss', 'xmlrouter', 'forum-topic'));
         self::generateRssTagLink(t('Latest Profile Comments'), Uri::get('xml', 'rss', 'xmlrouter', 'comment-profile'));

--- a/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
+++ b/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / App / System / Core / Classes
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Core\Classes;
+
+require_once PH7_PATH_SYS . 'core/classes/design/XmlDesignCore.php';
+
+use PH7\XmlDesignCore;
+use PHPUnit\Framework\TestCase;
+
+final class XmlDesignCoreTest extends TestCase
+{
+    public function testRssHeaderLinksDoNotContainDuplicates(): void
+    {
+        ob_start();
+        XmlDesignCore::rssHeaderLinks();
+        $sOutput = (string) ob_get_clean();
+
+        preg_match_all('/<link\b[^>]*>/', $sOutput, $aMatches);
+
+        $this->assertNotEmpty($aMatches[0]);
+        $this->assertSame($aMatches[0], array_values(array_unique($aMatches[0])));
+    }
+}


### PR DESCRIPTION
Removes the duplicated blog RSS discovery tag and adds a regression test against the rendered output.

Best, [Pierre-Henry](https://github.com/pH-7)