### PR TITLE
Prepare pH7Builder v19.0.0 for stabilization

### DIFF
--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '18.6.2';
+    public const SOFTWARE_VERSION = '19.0.0';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/app/configs/environment/all.env.php
+++ b/_protected/app/configs/environment/all.env.php
@@ -23,9 +23,3 @@ ini_set('ignore_repeated_errors', 'On'); // Do not log repeated errors that occu
 ini_set('session.use_cookies', 1);
 ini_set('session.use_only_cookies', 1);
 ini_set('session.use_trans_sid', 0);
-
-// These legacy directives are unsupported on modern PHP versions and can trigger startup warnings.
-if (PHP_VERSION_ID < 70000) {
-    ini_set('session.hash_function', 1);
-    ini_set('session.hash_bits_per_character', 6);
-}

--- a/_protected/app/system/core/classes/design/XmlDesignCore.php
+++ b/_protected/app/system/core/classes/design/XmlDesignCore.php
@@ -12,6 +12,8 @@ use PH7\Framework\Error\CException\PH7Exception;
 use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Pattern\Statik;
+use PH7\Framework\Security\Validate\Validate;
+use PH7\Framework\Str\Str;
 
 class XmlDesignCore
 {
@@ -70,21 +72,34 @@ class XmlDesignCore
     /**
      * Show the software news.
      *
-     * @param int $iNum Number of news to display.
+     * @param int               $iNum      number of news to display
+     * @param NewsFeedCore|null $oNewsFeed optional feed source for deterministic rendering
      *
-     * @return void HTML contents.
+     * @return void HTML contents
      */
-    public static function softwareNews($iNum)
+    public static function softwareNews($iNum, ?NewsFeedCore $oNewsFeed = null)
     {
         try {
-            $aNews = (new NewsFeedCore)->getSoftware($iNum);
+            $aNews = ($oNewsFeed ?? new NewsFeedCore())->getSoftware($iNum);
+            $oStr = new Str();
+            $oValidate = new Validate();
+            $bNewsDisplayed = false;
 
-            if (count($aNews) > 0) {
-                foreach ($aNews as $aItems) {
-                    echo '<h4><a href="', $aItems['link'], '" target="_blank" rel="noopener">', escape($aItems['title'], true), '</a></h4>';
-                    echo '<p>', escape($aItems['description'], true), '</p>';
+            foreach ($aNews as $aItems) {
+                $sLink = (string)($aItems['link'] ?? '');
+                if (!$oValidate->url($sLink)) {
+                    continue;
                 }
-            } else {
+
+                $sTitle = escape(strip_tags((string)($aItems['title'] ?? '')));
+                $sDescription = escape(strip_tags((string)($aItems['description'] ?? '')));
+
+                echo '<h4><a href="', $oStr->escapeAttribute($sLink), '" target="_blank" rel="noopener noreferrer">', $sTitle, '</a></h4>';
+                echo '<p>', $sDescription, '</p>';
+                $bNewsDisplayed = true;
+            }
+
+            if (!$bNewsDisplayed) {
                 echo '<p>', t("No %software_name%'s news found."), '</p>';
             }
         } catch (PH7Exception $oE) {

--- a/_protected/app/system/core/classes/design/XmlDesignCore.php
+++ b/_protected/app/system/core/classes/design/XmlDesignCore.php
@@ -22,6 +22,8 @@ class XmlDesignCore
      * The trait sets constructor/clone private to prevent instantiation.
      */
     use Statik;
+    private const SOFTWARE_NEWS_DESCRIPTION_LENGTH = 240;
+    private const SOFTWARE_NEWS_TRIM_MARKER = '...';
 
     public static function xslHeader()
     {
@@ -91,8 +93,14 @@ class XmlDesignCore
                     continue;
                 }
 
-                $sTitle = escape(strip_tags((string)($aItems['title'] ?? '')));
-                $sDescription = escape(strip_tags((string)($aItems['description'] ?? '')));
+                $sTitle = escape(
+                    self::normalizeSoftwareNewsText((string)($aItems['title'] ?? ''))
+                );
+                $sDescription = escape(
+                    self::shortenSoftwareNewsDescription(
+                        self::normalizeSoftwareNewsText((string)($aItems['description'] ?? ''))
+                    )
+                );
 
                 echo '<h4><a href="', $oStr->escapeAttribute($sLink), '" target="_blank" rel="noopener noreferrer">', $sTitle, '</a></h4>';
                 echo '<p>', $sDescription, '</p>';
@@ -108,6 +116,24 @@ class XmlDesignCore
                 Design::ERROR_TYPE
             );
         }
+    }
+
+    private static function normalizeSoftwareNewsText(string $sText): string
+    {
+        return strip_tags(
+            html_entity_decode($sText, ENT_QUOTES | ENT_HTML5, 'UTF-8')
+        );
+    }
+
+    private static function shortenSoftwareNewsDescription(string $sDescription): string
+    {
+        if (mb_strlen($sDescription, 'UTF-8') <= self::SOFTWARE_NEWS_DESCRIPTION_LENGTH) {
+            return $sDescription;
+        }
+
+        return rtrim(
+            mb_substr($sDescription, 0, self::SOFTWARE_NEWS_DESCRIPTION_LENGTH, 'UTF-8')
+        ) . self::SOFTWARE_NEWS_TRIM_MARKER;
     }
 
     /**

--- a/_protected/app/system/modules/admin123/controllers/UserController.php
+++ b/_protected/app/system/modules/admin123/controllers/UserController.php
@@ -74,23 +74,17 @@ class UserController extends Controller implements UserModeratable
         );
         unset($oPage);
 
-        if (empty($oBrowse)) {
-            $this->design->setRedirect(
-                Uri::get(PH7_ADMIN_MOD, 'user', 'browse')
-            );
-
-            $this->displayPageNotFound(t('No user were found.'));
-        } else {
+        if (!empty($oBrowse)) {
             // Add the JS file for the browse form
             $this->design->addJs(PH7_STATIC . PH7_JS, 'form.js');
-
-            $this->view->page_title = $this->view->h1_title = t('Browse Users');
-            $this->view->h3_title = t('Total Users: %0%', $this->iTotalUsers);
-            $this->view->total_users = $this->iTotalUsers;
-            $this->view->browse = $oBrowse;
-
-            $this->output();
         }
+
+        $this->view->page_title = $this->view->h1_title = t('Browse Users');
+        $this->view->h3_title = t('Total Users: %0%', $this->iTotalUsers);
+        $this->view->total_users = $this->iTotalUsers;
+        $this->view->browse = $oBrowse;
+
+        $this->output();
     }
 
     public function add(): void

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/news.inc.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/news.inc.tpl
@@ -2,7 +2,7 @@
     <h2 class="underline">
         {lang 'Latest <a href="%software_website%" title="%software_name%">pH7Builder Software</a>\'s News'}
     </h2>
-    {{ XmlDesignCore::softwareNews(10) }}
+    {{ XmlDesignCore::softwareNews(3) }}
     <p class="s_tMarg italic">
         <a href="{software_blog_url}">{lang '» Read more news! «'}</a> 🗞
     </p>

--- a/_protected/app/system/modules/admin123/views/base/tpl/main/stat.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/main/stat.tpl
@@ -1,7 +1,15 @@
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
+    var iUserChartResizeTimer;
+
     google.charts.load('current', {packages: ['corechart']});
-    google.charts.setOnLoadCallback(showUserChart);
+    google.charts.setOnLoadCallback(function () {
+        showUserChart();
+        $(window).off('resize.ph7UserChart').on('resize.ph7UserChart', function () {
+            clearTimeout(iUserChartResizeTimer);
+            iUserChartResizeTimer = setTimeout(showUserChart, 150);
+        });
+    });
 
     function showUserChart() {
         $('#user_chart').html('');

--- a/_protected/app/system/modules/admin123/views/base/tpl/tool/cache.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/tool/cache.tpl
@@ -10,8 +10,16 @@
     <div class="s_marg">
         <script src="https://www.gstatic.com/charts/loader.js"></script>
         <script>
+            var iCacheChartResizeTimer;
+
             google.charts.load('current', {packages: ['corechart']});
-            google.charts.setOnLoadCallback(showCacheChart);
+            google.charts.setOnLoadCallback(function () {
+                showCacheChart();
+                $(window).off('resize.ph7CacheChart').on('resize.ph7CacheChart', function () {
+                    clearTimeout(iCacheChartResizeTimer);
+                    iCacheChartResizeTimer = setTimeout(showCacheChart, 150);
+                });
+            });
 
             function showCacheChart() {
                 $('#cache_chart').html('');

--- a/_protected/app/system/modules/admin123/views/base/tpl/tool/freespace.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/tool/freespace.tpl
@@ -2,8 +2,16 @@
     <div class="s_marg">
         <script src="https://www.gstatic.com/charts/loader.js"></script>
         <script>
+            var iFreeSpaceChartResizeTimer;
+
             google.charts.load('current', {packages: ['corechart']});
-            google.charts.setOnLoadCallback(showFreeSpaceChart);
+            google.charts.setOnLoadCallback(function () {
+                showFreeSpaceChart();
+                $(window).off('resize.ph7FreeSpaceChart').on('resize.ph7FreeSpaceChart', function () {
+                    clearTimeout(iFreeSpaceChartResizeTimer);
+                    iFreeSpaceChartResizeTimer = setTimeout(showFreeSpaceChart, 150);
+                });
+            });
 
             function showFreeSpaceChart () {
                 $('#free_space_chart').html('');

--- a/_protected/app/system/modules/admin123/views/base/tpl/user/browse.tpl
+++ b/_protected/app/system/modules/admin123/views/base/tpl/user/browse.tpl
@@ -1,3 +1,9 @@
+{if empty($browse)}
+    <div class="alert alert-info center">
+        <p class="bold">{lang 'No members yet. New registrations will appear here.'}</p>
+        <a class="btn btn-primary" href="{{ $design->url(PH7_ADMIN_MOD, 'user', 'add') }}">{lang 'Add a User'}</a>
+    </div>
+{else}
 <form method="post" action="{{ $design->url(PH7_ADMIN_MOD, 'user', 'browse') }}">
     {{ $designSecurity->inputToken('user_action') }}
 
@@ -145,3 +151,4 @@
 {/if}
 
 {main_include 'page_nav.inc.tpl'}
+{/if}

--- a/_protected/app/system/modules/affiliate/controllers/AdminController.php
+++ b/_protected/app/system/modules/affiliate/controllers/AdminController.php
@@ -28,8 +28,6 @@ class AdminController extends Controller implements UserModeratable
     use BulkAction;
 
     private const PROFILES_PER_PAGE = 15;
-    private const REDIRECTION_DELAY_IN_SEC = 5;
-
     private Affiliate $oAff;
 
     private AffiliateModel $oAffModel;
@@ -113,24 +111,24 @@ class AdminController extends Controller implements UserModeratable
         );
         unset($oPage);
 
-        if (empty($oSearch)) {
-            $this->setNotFoundPage();
-        } else {
+        if (!empty($oSearch)) {
             // Add the js file necessary for the browse form
             $this->design->addJs(PH7_STATIC . PH7_JS, 'form.js');
-
-            // Assigns variables for views
-            $this->view->designSecurity = new HtmlSecurity; // Security Design Class
-            $this->view->dateTime = $this->dateTime; // Date Time Class
-            $this->view->validate = new Validate;
-
-            $this->sTitle = t('Browse Affiliates');
-            $this->view->page_title = $this->sTitle;
-            $this->view->h2_title = $this->sTitle;
-            $this->view->h3_title = nt('%n% Affiliate', '%n% Affiliates', $this->iTotalUsers);
-
-            $this->view->browse = $oSearch;
         }
+
+        // Assigns variables for views
+        $this->view->designSecurity = new HtmlSecurity; // Security Design Class
+        $this->view->dateTime = $this->dateTime; // Date Time Class
+        $this->view->validate = new Validate;
+
+        $this->sTitle = t('Browse Affiliates');
+        $this->view->page_title = $this->sTitle;
+        $this->view->h2_title = $this->sTitle;
+        $this->view->h3_title = nt('%n% Affiliate', '%n% Affiliates', $this->iTotalUsers);
+        $this->view->browse = $oSearch;
+        $this->view->empty_message = empty($sKeywords)
+            ? t('No affiliates yet. New affiliate registrations will appear here.')
+            : t('No affiliates match your search. Try different keywords.');
 
         $this->output();
     }
@@ -460,23 +458,4 @@ class AdminController extends Controller implements UserModeratable
         (new Mail)->send($aInfo, $sMessageHtml);
     }
 
-    /**
-     * Redirect to admin browse page, then display the default "Not Found" page.
-     */
-    private function setNotFoundPage(): void
-    {
-        $this->design->setRedirect(
-            Uri::get(
-                'affiliate',
-                'admin',
-                'browse'
-            ),
-            null,
-            null,
-            self::REDIRECTION_DELAY_IN_SEC
-        );
-
-        $sErrorMsg = t('No affiliates have been found.');
-        $this->displayPageNotFound($sErrorMsg);
-    }
 }

--- a/_protected/app/system/modules/affiliate/views/base/tpl/admin/browse.tpl
+++ b/_protected/app/system/modules/affiliate/views/base/tpl/admin/browse.tpl
@@ -1,3 +1,9 @@
+{if empty($browse)}
+    <div class="alert alert-info center">
+        <p class="bold">{% escape($empty_message) %}</p>
+        <a class="btn btn-primary" href="{{ $design->url('affiliate', 'admin', 'add') }}">{lang 'Add Affiliate'}</a>
+    </div>
+{else}
 <form method="post" action="{{ $design->url('affiliate','admin','browse') }}">
     {{ $designSecurity->inputToken('aff_action') }}
 
@@ -146,3 +152,4 @@
 </form>
 
 {main_include 'page_nav.inc.tpl'}
+{/if}

--- a/_protected/app/system/modules/comment/config/Permission.php
+++ b/_protected/app/system/modules/comment/config/Permission.php
@@ -18,7 +18,10 @@ class Permission extends PermissionCore
 
         $bAdminAuth = AdminCore::auth();
 
-        if ((!UserCore::auth() && !$bAdminAuth) && ($this->registry->action === 'add' || $this->registry->action === 'delete')) {
+        if (
+            (!UserCore::auth() && !$bAdminAuth)
+            && in_array($this->registry->action, ['add', 'edit', 'delete'], true)
+        ) {
             $this->signInRedirect();
         }
 

--- a/_protected/app/system/modules/comment/controllers/CommentController.php
+++ b/_protected/app/system/modules/comment/controllers/CommentController.php
@@ -131,6 +131,25 @@ class CommentController extends Controller
 
     public function edit()
     {
+        $oComment = $this->oCommentModel->get(
+            $this->httpRequest->get('id', 'int'),
+            '1',
+            $this->sTable
+        );
+
+        if (!$this->isRequestedComment($oComment)) {
+            Header::redirect(Uri::get('error', 'http', 'index', '404'));
+        }
+
+        $iMemberId = (int)$this->session->get('member_id');
+        if (
+            !AdminCore::auth()
+            && $iMemberId !== (int)$oComment->recipient
+            && $iMemberId !== (int)$oComment->sender
+        ) {
+            Header::redirect(Uri::get('error', 'http', 'index', '403'));
+        }
+
         $this->view->page_title = t('Edit the comment');
         $this->output();
     }
@@ -204,5 +223,12 @@ class CommentController extends Controller
     private function getProfileId()
     {
         return is_numeric($this->httpRequest->get('id')) ? $this->httpRequest->get('id') : null;
+    }
+
+    private function isRequestedComment($oComment): bool
+    {
+        return $oComment !== false
+            && (int)$oComment->recipient === $this->httpRequest->get('recipient', 'int')
+            && (int)$oComment->sender === $this->httpRequest->get('sender', 'int');
     }
 }

--- a/_protected/app/system/modules/comment/forms/EditCommentForm.php
+++ b/_protected/app/system/modules/comment/forms/EditCommentForm.php
@@ -15,6 +15,7 @@ use PFBC\Element\Textarea;
 use PFBC\Element\Token;
 use PFBC\Validation\Str;
 use PH7\Framework\Mvc\Request\Http;
+use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Url\Header;
 
 class EditCommentForm
@@ -36,7 +37,15 @@ class EditCommentForm
         $oForm->addElement(new Hidden('submit_edit_comment', 'form_edit_comment'));
         $oForm->addElement(new Token('edit_comment'));
 
-        $oData = (new CommentModel)->get($oHttpRequest->get('id'), 1, $oHttpRequest->get('table'));
+        $oData = (new CommentModel)->get(
+            $oHttpRequest->get('id', 'int'),
+            '1',
+            $oHttpRequest->get('table')
+        );
+        if ($oData === false) {
+            Header::redirect(Uri::get('error', 'http', 'index', '404'));
+        }
+
         $oForm->addElement(
             new Textarea(
                 t('Your comment:'),

--- a/_protected/app/system/modules/comment/forms/processing/EditCommentFormProcess.php
+++ b/_protected/app/system/modules/comment/forms/processing/EditCommentFormProcess.php
@@ -85,6 +85,8 @@ class EditCommentFormProcess extends Form
      */
     private function isEditEligible()
     {
-        return $this->iMemberId === $this->iRecipientId || $this->iMemberId === $this->iSenderId;
+        return AdminCore::auth()
+            || $this->iMemberId === $this->iRecipientId
+            || $this->iMemberId === $this->iSenderId;
     }
 }

--- a/_protected/app/system/modules/comment/models/CommentModel.php
+++ b/_protected/app/system/modules/comment/models/CommentModel.php
@@ -19,7 +19,7 @@ class CommentModel extends CommentCoreModel
      * @param string $sApproved
      * @param string $sTable
      *
-     * @return array
+     * @return \stdClass|false
      */
     public function get($iCommentId, $sApproved, $sTable)
     {
@@ -93,7 +93,9 @@ class CommentModel extends CommentCoreModel
         $rStmt->bindValue(':approved', $sApproved, PDO::PARAM_STR);
         $rStmt->bindValue(':updatedDate', $sUpdatedDate, PDO::PARAM_STR);
 
-        return $rStmt->execute();
+        $rStmt->execute();
+
+        return $rStmt->rowCount() === 1;
     }
 
     /**
@@ -115,7 +117,9 @@ class CommentModel extends CommentCoreModel
         $rStmt->bindValue('recipient', $iRecipientId, PDO::PARAM_INT);
         $rStmt->bindValue(':sender', $iSenderId, PDO::PARAM_INT);
 
-        return $rStmt->execute();
+        $rStmt->execute();
+
+        return $rStmt->rowCount() === 1;
     }
 
     /**

--- a/_protected/app/system/modules/mail/controllers/AdminController.php
+++ b/_protected/app/system/modules/mail/controllers/AdminController.php
@@ -47,18 +47,20 @@ class AdminController extends MainController
             $this->oPage->getNbItemsPerPage()
         );
 
+        $this->sTitle = t('Email List');
+        $this->view->page_title = $this->sTitle;
+        $this->view->h2_title = $this->sTitle;
+        $this->view->h3_title = nt('%n% message found!', '%n% messages found!', $this->iTotalMails);
+
         if (empty($oAllMsg)) {
-            $this->displayPageNotFound(t('No messages found!'));
+            $this->view->error = empty($this->httpRequest->get('looking'))
+                ? t('No member messages yet. New conversations will appear here.')
+                : t('No messages match your search. Try different keywords.');
         } else {
             $this->design->addJs(PH7_STATIC . PH7_JS, 'divShow.js');
-
-            $this->sTitle = t('Email List');
-            $this->view->page_title = $this->sTitle;
-            $this->view->h2_title = $this->sTitle;
-            $this->view->h3_title = nt('%n% message found!', '%n% messages found!', $this->iTotalMails);
             $this->view->msgs = $oAllMsg;
-
-            $this->output();
         }
+
+        $this->output();
     }
 }

--- a/_protected/app/system/modules/newsletter/controllers/AdminController.php
+++ b/_protected/app/system/modules/newsletter/controllers/AdminController.php
@@ -18,8 +18,6 @@ class AdminController extends Controller
     use BulkAction;
 
     const SUBSCRIBERS_PER_PAGE = 30;
-    const REDIRECTION_DELAY_IN_SEC = 5;
-
     /** @var SubscriberModel */
     private $oSubscriberModel;
 
@@ -79,23 +77,23 @@ class AdminController extends Controller
         );
         unset($oPage);
 
-        if (empty($oBrowse)) {
-            $this->setNotFoundPage();
-        } else {
+        if (!empty($oBrowse)) {
             // Add the js file for the browse form
             $this->design->addJs(PH7_STATIC . PH7_JS, 'form.js');
-
-            // Assigns variables for views
-            $this->view->designSecurity = new Framework\Layout\Html\Security; // Security Design Class
-            $this->view->dateTime = $this->dateTime; // Date Time Class
-
-            $this->sTitle = t('Browse Subscribers');
-            $this->view->page_title = $this->sTitle;
-            $this->view->h2_title = $this->sTitle;
-            $this->view->h3_title = nt('%n% subscriber found', '%n% subscribers found', $iTotal);
-
-            $this->view->browse = $oBrowse;
         }
+
+        // Assigns variables for views
+        $this->view->designSecurity = new Framework\Layout\Html\Security; // Security Design Class
+        $this->view->dateTime = $this->dateTime; // Date Time Class
+
+        $this->sTitle = t('Browse Subscribers');
+        $this->view->page_title = $this->sTitle;
+        $this->view->h2_title = $this->sTitle;
+        $this->view->h3_title = nt('%n% subscriber found', '%n% subscribers found', $iTotal);
+        $this->view->browse = $oBrowse;
+        $this->view->empty_message = empty($sKeywords)
+            ? t('No subscribers yet. Newsletter signups will appear here.')
+            : t('No subscribers match your search. Try different keywords.');
 
         $this->output();
     }
@@ -122,23 +120,4 @@ class AdminController extends Controller
         );
     }
 
-    /**
-     * Redirects to admin browse page, then displays the default "Not Found" page.
-     *
-     * @return void
-     */
-    private function setNotFoundPage()
-    {
-        $this->design->setRedirect(
-            Uri::get(
-                'newsletter',
-                'admin',
-                'browse'
-            ),
-            null,
-            null,
-            self::REDIRECTION_DELAY_IN_SEC
-        );
-        $this->displayPageNotFound(t('Sorry, Your search returned no results!'));
-    }
 }

--- a/_protected/app/system/modules/newsletter/views/base/tpl/admin/browse.tpl
+++ b/_protected/app/system/modules/newsletter/views/base/tpl/admin/browse.tpl
@@ -1,3 +1,9 @@
+{if empty($browse)}
+    <div class="alert alert-info center">
+        <p class="bold">{% escape($empty_message) %}</p>
+        <a class="btn btn-primary" href="{{ $design->url('newsletter', 'admin', 'index') }}">{lang 'Newsletter Manager'}</a>
+    </div>
+{else}
 <form method="post" action="{{ $design->url('newsletter','admin','browse') }}">
     {{ $designSecurity->inputToken('subscriber_action') }}
 
@@ -67,3 +73,4 @@
 </form>
 
 {main_include 'page_nav.inc.tpl'}
+{/if}

--- a/_protected/app/system/modules/user/assets/ajax/WallAjax.php
+++ b/_protected/app/system/modules/user/assets/ajax/WallAjax.php
@@ -148,6 +148,7 @@ class WallAjax extends Core
     {
         $this->bStatus = $this->oWallModel->edit(
             $this->session->get('member_id'),
+            $this->httpRequest->post('wall_id'),
             $this->httpRequest->post('post'),
             $this->dateTime->get()->dateTime('Y-m-d H:i:s')
         );
@@ -165,13 +166,13 @@ class WallAjax extends Core
     {
         $this->bStatus = $this->oWallModel->delete(
             $this->session->get('member_id'),
-            $this->httpRequest->post('post')
+            $this->httpRequest->post('wall_id')
         );
 
         if (!$this->bStatus) {
             $this->sMsg = jsonMsg(0, t('Your post does not exist anymore.'));
         } else {
-            $this->sMsg = jsonMsg(1, t('Your post has been sent successfully!'));
+            $this->sMsg = jsonMsg(1, t('Your post has been deleted successfully!'));
         }
 
         echo $this->sMsg;

--- a/_protected/app/system/modules/user/forms/EditWallForm.php
+++ b/_protected/app/system/modules/user/forms/EditWallForm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
@@ -13,7 +14,9 @@ use PFBC\Element\Hidden;
 use PFBC\Element\Textarea;
 use PFBC\Element\Token;
 use PFBC\Validation\Str;
+use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Mvc\Request\Http;
+use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Session\Session;
 use PH7\Framework\Url\Header;
 
@@ -33,14 +36,24 @@ class EditWallForm
             Header::redirect();
         }
 
-        $oWallData = (new WallModel)->get((new Session)->get('member_id'), (new Http)->get('wall_id'), 0, 1);
+        $iWallId = (int)(new Http())->get('wall_id');
+        $aWallData = (new WallModel())->get((new Session())->get('member_id'), $iWallId, 0, 1);
+        $oWallData = $aWallData[0] ?? null;
+        if ($oWallData === null) {
+            Header::redirect(
+                Uri::get('user', 'main', 'index'),
+                t('The wall post does not exist.'),
+                Design::ERROR_TYPE
+            );
+        }
 
         $oForm = new \PFBC\Form('form_edit_wall');
         $oForm->configure(['action' => '']);
         $oForm->addElement(new Hidden('submit_edit_wall', 'form_edit_wall'));
+        $oForm->addElement(new Hidden('wall_id', $iWallId));
         $oForm->addElement(new Token('edit_wall'));
         $oForm->addElement(new Textarea(t('Content:'), 'post', ['value' => $oWallData->post, 'validation' => new Str(1, 900)]));
-        $oForm->addElement(new Button);
+        $oForm->addElement(new Button());
         $oForm->render();
     }
 }

--- a/_protected/app/system/modules/user/forms/processing/EditWallFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/EditWallFormProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
@@ -10,6 +11,7 @@ namespace PH7;
 
 defined('PH7') or exit('Restricted access');
 
+use PH7\Framework\Layout\Html\Design;
 use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Url\Header;
 
@@ -24,7 +26,18 @@ class EditWallFormProcess extends Form
     {
         parent::__construct();
 
-        (new WallModel)->edit($this->session->get('member_id'), $this->httpRequest->post('post'), $this->dateTime->get()->dateTime('Y-m-d H:i:s'));
-        Header::redirect(Uri::get('user', 'main', 'index'), t('Your message has been added successfully!'));
+        $bUpdated = (new WallModel())->edit(
+            $this->session->get('member_id'),
+            $this->httpRequest->post('wall_id'),
+            $this->httpRequest->post('post'),
+            $this->dateTime->get()->dateTime('Y-m-d H:i:s')
+        );
+        Header::redirect(
+            Uri::get('user', 'main', 'index'),
+            $bUpdated
+                ? t('Your message has been updated successfully!')
+                : t('The wall post does not exist.'),
+            $bUpdated ? Design::SUCCESS_TYPE : Design::ERROR_TYPE
+        );
     }
 }

--- a/_protected/app/system/modules/user/models/WallModel.php
+++ b/_protected/app/system/modules/user/models/WallModel.php
@@ -34,19 +34,24 @@ class WallModel extends Model
 
     /**
      * @param int    $iProfileId
+     * @param int    $iWallId
      * @param string $sPost
      * @param string $sUpdatedDate
      *
      * @return bool
      */
-    public function edit($iProfileId, $sPost, $sUpdatedDate)
+    public function edit($iProfileId, $iWallId, $sPost, $sUpdatedDate)
     {
-        $rStmt = Db::getInstance()->prepare('UPDATE' . Db::prefix(DbTableName::MEMBER_WALL) . 'SET post = :post, updatedDate = :updatedDate WHERE profileId = :profileId');
+        $rStmt = Db::getInstance()->prepare(
+            'UPDATE' . Db::prefix(DbTableName::MEMBER_WALL) .
+            'SET post = :post, updatedDate = :updatedDate WHERE profileId = :profileId AND wallId = :wallId'
+        );
         $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
+        $rStmt->bindValue(':wallId', $iWallId, \PDO::PARAM_INT);
         $rStmt->bindValue(':post', $sPost, \PDO::PARAM_STR);
         $rStmt->bindValue(':updatedDate', $sUpdatedDate, \PDO::PARAM_STR);
 
-        return $rStmt->execute();
+        return $rStmt->execute() && $rStmt->rowCount() === 1;
     }
 
     /**
@@ -64,7 +69,7 @@ class WallModel extends Model
         $rStmt->bindValue(':profileId', $iProfileId, \PDO::PARAM_INT);
         $rStmt->bindValue(':wallId', $iWallId, \PDO::PARAM_INT);
 
-        return $rStmt->execute();
+        return $rStmt->execute() && $rStmt->rowCount() === 1;
     }
 
     /**

--- a/_protected/app/system/modules/xml/controllers/MainController.php
+++ b/_protected/app/system/modules/xml/controllers/MainController.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace PH7;
 
+use PH7\Framework\Xml\Exception as XmlException;
+
 class MainController extends Controller
 {
     protected const STATIC_CACHE_LIFETIME = 86400; // 86400 secs = 24 hours
@@ -79,6 +81,40 @@ class MainController extends Controller
     protected function setContentType(): void
     {
         header('Content-Type: text/xml; charset=' . PH7_ENCODING);
+    }
+
+    /**
+     * Render a local XML link template and return its links without making an HTTP request back to this site.
+     *
+     * @return array<string, string>
+     */
+    protected function getLinksFromTemplate(string $sTemplate): array
+    {
+        $iBufferLevel = ob_get_level();
+        ob_start();
+
+        try {
+            $this->view->display($sTemplate);
+            $sXml = ob_get_clean();
+        } catch (\Throwable $oException) {
+            while (ob_get_level() > $iBufferLevel) {
+                ob_end_clean();
+            }
+
+            throw $oException;
+        }
+
+        $oXml = new \DOMDocument();
+        if (!is_string($sXml) || !@$oXml->loadXML($sXml)) {
+            throw new XmlException(t('The link list could not be generated.'));
+        }
+
+        $aLinks = [];
+        foreach ($oXml->getElementsByTagName('link') as $oTag) {
+            $aLinks[$oTag->getAttribute('url')] = $oTag->getAttribute('title');
+        }
+
+        return $aLinks;
     }
 
     /**

--- a/_protected/app/system/modules/xml/controllers/RssController.php
+++ b/_protected/app/system/modules/xml/controllers/RssController.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 namespace PH7;
 
 use PH7\Datatype\Type;
-use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Xml\Exception as XmlException;
-use PH7\Framework\Xml\Link;
 
 class RssController extends MainController implements XmlControllable
 {
@@ -31,11 +29,8 @@ class RssController extends MainController implements XmlControllable
         $this->view->meta_description = t('RSS Feed %site_name%, Free Online Dating Site with Video Chat Rooms, Meet Single People with %site_name%');
         $this->view->h1_title = $this->sTitle;
 
-        /*** Get the links ***/
-        $sUrl = Uri::get('xml', 'rss', 'xmllink');
-
         try {
-            $this->view->urls = (new Link($sUrl))->get();
+            $this->view->urls = $this->getLinksFromTemplate('rss_links.xml.tpl');
         } catch (XmlException $oExcept) {
             $this->view->error = $oExcept->getMessage();
         }

--- a/_protected/app/system/modules/xml/controllers/SitemapController.php
+++ b/_protected/app/system/modules/xml/controllers/SitemapController.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 namespace PH7;
 
 use PH7\Datatype\Type;
-use PH7\Framework\Mvc\Router\Uri;
 use PH7\Framework\Xml\Exception as XmlException;
-use PH7\Framework\Xml\Link;
 
 class SitemapController extends MainController implements XmlControllable
 {
@@ -31,11 +29,8 @@ class SitemapController extends MainController implements XmlControllable
         $this->view->meta_description = t('Sitemap - Social Dating Service. Meet Single People with %site_name%');
         $this->view->h1_title = $this->sTitle;
 
-        /*** Get the links ***/
-        $sUrl = Uri::get('xml', 'sitemap', 'xmllink');
-
         try {
-            $this->view->urls = (new Link($sUrl))->get();
+            $this->view->urls = $this->getLinksFromTemplate('links.xml.tpl');
         } catch (XmlException $oExcept) {
             $this->view->error = $oExcept->getMessage();
         }

--- a/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
@@ -34,7 +34,10 @@
     {/if}
 
     {if $is_map_enabled}
-        <link title="{lang 'People Nearby'}" url="{{ $design->url('map','country','index', Framework\Geo\Ip\Geo::getCountry() . PH7_SH. Framework\Geo\Ip\Geo::getCity()) }}" />
+        {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
+        {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
+        {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
+        <link title="{lang 'People Nearby'}" url="{% $sNearbyUrl %}" />
     {/if}
 
     <link title="{lang 'About Us'}" url="{{ $design->url('page','main','about') }}" />

--- a/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
@@ -36,7 +36,7 @@
     {if $is_map_enabled}
         {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
         {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
-        {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
+        {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
         <link title="{lang 'People Nearby'}" url="{% $sNearbyUrl %}" />
     {/if}
 

--- a/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
+++ b/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl
@@ -37,7 +37,7 @@
         {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
         {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
         {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
-        <link title="{lang 'People Nearby'}" url="{% $sNearbyUrl %}" />
+        <link title="{lang 'People Nearby'}" url="{% $str->escapeAttribute($sNearbyUrl) %}" />
     {/if}
 
     <link title="{lang 'About Us'}" url="{{ $design->url('page','main','about') }}" />

--- a/_protected/framework/Mvc/Router/FrontController.class.php
+++ b/_protected/framework/Mvc/Router/FrontController.class.php
@@ -377,7 +377,7 @@ final class FrontController
      */
     private function initializePaths()
     {
-        $this->oRegistry->action = strtolower($this->oRegistry->action);
+        $this->oRegistry->action = self::normalizeAction($this->oRegistry->action);
 
         /***** SHORTCUTS PATH FOR MODULES *****/
         $this->oRegistry->path_module_controllers = $this->oRegistry->path_module . PH7_CTRL;
@@ -387,6 +387,11 @@ final class FrontController
         $this->oRegistry->path_module_inc = $this->oRegistry->path_module . PH7_INC;
         $this->oRegistry->path_module_config = $this->oRegistry->path_module . PH7_CONFIG;
         $this->oRegistry->path_module_lang = $this->oRegistry->path_module . PH7_LANG;
+    }
+
+    private static function normalizeAction(?string $sAction): string
+    {
+        return strtolower($sAction ?? '');
     }
 
     /**

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,7 +51,7 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '18.6.2';
+    public const KERNEL_VERSION = '19.0.0';
     public const KERNEL_BUILD = '1';
     public const KERNEL_RELEASE_DATE = '2026-08-26';
 

--- a/_protected/framework/Translate/Adapter/Gettext/gettext.inc.php
+++ b/_protected/framework/Translate/Adapter/Gettext/gettext.inc.php
@@ -192,11 +192,7 @@ function _get_codeset($domain = null)
         return $text_domains[$domain]->codeset;
     }
 
-    $legacy_encoding = ini_get('mbstring.internal_encoding');
-
-    return is_string($legacy_encoding) && $legacy_encoding !== ''
-        ? $legacy_encoding
-        : (defined('PH7_ENCODING') ? PH7_ENCODING : 'UTF-8');
+    return defined('PH7_ENCODING') ? PH7_ENCODING : 'UTF-8';
 }
 
 /**

--- a/_protected/framework/Video/Video.class.php
+++ b/_protected/framework/Video/Video.class.php
@@ -233,7 +233,6 @@ class Video extends Upload
             $rFileInfo = finfo_open(FILEINFO_MIME_TYPE);
             if ($rFileInfo !== false) {
                 $sDetectedType = finfo_file($rFileInfo, $this->aFile['tmp_name']);
-                finfo_close($rFileInfo);
                 if (is_string($sDetectedType) && $sDetectedType !== '') {
                     return $sDetectedType;
                 }

--- a/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
+++ b/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
@@ -12,6 +12,7 @@ namespace PH7\Test\Unit\App\System\Core\Classes;
 
 require_once PH7_PATH_SYS . 'core/classes/design/XmlDesignCore.php';
 
+use PH7\NewsFeedCore;
 use PH7\XmlDesignCore;
 use PHPUnit\Framework\TestCase;
 
@@ -27,5 +28,42 @@ final class XmlDesignCoreTest extends TestCase
 
         $this->assertNotEmpty($aMatches[0]);
         $this->assertSame($aMatches[0], array_values(array_unique($aMatches[0])));
+    }
+
+    public function testSoftwareNewsRejectsUnsafeLinksAndEscapesRemoteText(): void
+    {
+        $oNewsFeed = new class extends NewsFeedCore {
+            public function getSoftware($iNum = self::DEFAULT_NUMBER_ITEMS): array
+            {
+                return [
+                    'unsafe' => [
+                        'link' => 'javascript://alert(1)',
+                        'title' => 'Unsafe title',
+                        'description' => 'Unsafe description'
+                    ],
+                    'safe' => [
+                        'link' => 'https://ph7builder.com/news?a=1&b=2',
+                        'title' => '<strong>Trusted & title</strong>',
+                        'description' => '<p onclick="evil()">Safe <b>summary</b> & details</p>'
+                    ]
+                ];
+            }
+        };
+
+        ob_start();
+        XmlDesignCore::softwareNews(2, $oNewsFeed);
+        $sOutput = (string)ob_get_clean();
+
+        $this->assertStringNotContainsString('javascript:', $sOutput);
+        $this->assertStringNotContainsString('Unsafe title', $sOutput);
+        $this->assertStringNotContainsString('onclick', $sOutput);
+        $this->assertSame(1, substr_count($sOutput, '<h4>'));
+        $this->assertStringContainsString(
+            'href="https://ph7builder.com/news?a=1&amp;b=2"',
+            $sOutput
+        );
+        $this->assertStringContainsString('rel="noopener noreferrer"', $sOutput);
+        $this->assertStringContainsString('Trusted &amp; title', $sOutput);
+        $this->assertStringContainsString('Safe summary &amp; details', $sOutput);
     }
 }

--- a/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
+++ b/_tests/Unit/App/System/Core/Classes/XmlDesignCoreTest.php
@@ -44,7 +44,7 @@ final class XmlDesignCoreTest extends TestCase
                     'safe' => [
                         'link' => 'https://ph7builder.com/news?a=1&b=2',
                         'title' => '<strong>Trusted & title</strong>',
-                        'description' => '<p onclick="evil()">Safe <b>summary</b> & details</p>'
+                        'description' => '<p onclick="evil()">Safe <b>summary</b> &amp; details. Let&#8217;s go.</p>'
                     ]
                 ];
             }
@@ -64,6 +64,30 @@ final class XmlDesignCoreTest extends TestCase
         );
         $this->assertStringContainsString('rel="noopener noreferrer"', $sOutput);
         $this->assertStringContainsString('Trusted &amp; title', $sOutput);
-        $this->assertStringContainsString('Safe summary &amp; details', $sOutput);
+        $this->assertStringContainsString('Safe summary &amp; details. Let’s go.', $sOutput);
+        $this->assertStringNotContainsString('&amp;#8217;', $sOutput);
+    }
+
+    public function testSoftwareNewsKeepsRemoteDescriptionsConcise(): void
+    {
+        $oNewsFeed = new class extends NewsFeedCore {
+            public function getSoftware($iNum = self::DEFAULT_NUMBER_ITEMS): array
+            {
+                return [
+                    'safe' => [
+                        'link' => 'https://ph7builder.com/news',
+                        'title' => 'Project news',
+                        'description' => '<p>' . str_repeat('A', 300) . '</p>'
+                    ]
+                ];
+            }
+        };
+
+        ob_start();
+        XmlDesignCore::softwareNews(1, $oNewsFeed);
+        $sOutput = (string)ob_get_clean();
+
+        $this->assertStringContainsString(str_repeat('A', 240) . '...', $sOutput);
+        $this->assertStringNotContainsString(str_repeat('A', 241), $sOutput);
     }
 }

--- a/_tests/Unit/App/System/Module/Comment/CommentMutationSafetyTest.php
+++ b/_tests/Unit/App/System/Module/Comment/CommentMutationSafetyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package        PH7 / Test / Unit / App / System / Module / Comment
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\Comment;
+
+use PHPUnit\Framework\TestCase;
+
+final class CommentMutationSafetyTest extends TestCase
+{
+    private const REPOSITORY_ROOT = __DIR__ . '/../../../../../..';
+
+    public function testCommentEditsRequireAuthenticationAndTheRequestedIdentity(): void
+    {
+        $sPermission = $this->readRepositoryFile(
+            '_protected/app/system/modules/comment/config/Permission.php'
+        );
+        $sController = $this->readRepositoryFile(
+            '_protected/app/system/modules/comment/controllers/CommentController.php'
+        );
+
+        self::assertStringContainsString("['add', 'edit', 'delete']", $sPermission);
+        self::assertStringContainsString('if (!$this->isRequestedComment($oComment))', $sController);
+        self::assertStringContainsString("Uri::get('error', 'http', 'index', '404')", $sController);
+        self::assertStringContainsString("Uri::get('error', 'http', 'index', '403')", $sController);
+    }
+
+    public function testCommentMutationSuccessRequiresOneAffectedRow(): void
+    {
+        $sModel = $this->readRepositoryFile(
+            '_protected/app/system/modules/comment/models/CommentModel.php'
+        );
+
+        self::assertSame(2, substr_count($sModel, '$rStmt->rowCount() === 1'));
+    }
+
+    public function testAdministratorsCanUseTheEditActionShownInTheInterface(): void
+    {
+        $sProcess = $this->readRepositoryFile(
+            '_protected/app/system/modules/comment/forms/processing/EditCommentFormProcess.php'
+        );
+
+        self::assertStringContainsString('return AdminCore::auth()', $sProcess);
+    }
+
+    private function readRepositoryFile(string $sPath): string
+    {
+        $sContents = file_get_contents(self::REPOSITORY_ROOT . '/' . $sPath);
+
+        self::assertIsString($sContents);
+
+        return $sContents;
+    }
+}

--- a/_tests/Unit/App/System/Module/User/Models/WallModelOwnershipTest.php
+++ b/_tests/Unit/App/System/Module/User/Models/WallModelOwnershipTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\User\Models;
+
+use PHPUnit\Framework\TestCase;
+
+final class WallModelOwnershipTest extends TestCase
+{
+    private const REPOSITORY_ROOT = __DIR__ . '/../../../../../../..';
+
+    public function testWallEditsRequireBothTheOwnerAndTheWallPost(): void
+    {
+        $sModel = $this->readRepositoryFile(
+            '_protected/app/system/modules/user/models/WallModel.php'
+        );
+
+        $this->assertStringContainsString(
+            'WHERE profileId = :profileId AND wallId = :wallId',
+            $sModel
+        );
+        $this->assertStringContainsString("bindValue(':wallId', \$iWallId, \\PDO::PARAM_INT)", $sModel);
+        $this->assertStringContainsString('$rStmt->rowCount() === 1', $sModel);
+    }
+
+    public function testEveryWallEditCallerPassesTheRequestedWallPost(): void
+    {
+        $sAjax = $this->readRepositoryFile(
+            '_protected/app/system/modules/user/assets/ajax/WallAjax.php'
+        );
+        $sFormProcess = $this->readRepositoryFile(
+            '_protected/app/system/modules/user/forms/processing/EditWallFormProcess.php'
+        );
+        $sJavascript = $this->readRepositoryFile('static/js/Wall.js');
+
+        $this->assertStringContainsString("post('wall_id')", $sAjax);
+        $this->assertStringContainsString("post('wall_id')", $sFormProcess);
+        $this->assertStringContainsString("'wall_id': iWallId", $sJavascript);
+    }
+
+    public function testWallDeletionReportsOnlyAnOwnedDeletedPostAsSuccess(): void
+    {
+        $sModel = $this->readRepositoryFile(
+            '_protected/app/system/modules/user/models/WallModel.php'
+        );
+
+        $this->assertStringContainsString(
+            'WHERE profileId = :profileId AND wallId = :wallId',
+            $sModel
+        );
+        $this->assertSame(2, substr_count($sModel, '$rStmt->rowCount() === 1'));
+    }
+
+    private function readRepositoryFile(string $sPath): string
+    {
+        $sContents = file_get_contents(self::REPOSITORY_ROOT . '/' . $sPath);
+
+        $this->assertIsString($sContents);
+
+        return $sContents;
+    }
+}

--- a/_tests/Unit/Framework/Mvc/Router/FrontControllerTest.php
+++ b/_tests/Unit/Framework/Mvc/Router/FrontControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Mvc / Router
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Mvc\Router;
+
+use PH7\Framework\Mvc\Router\FrontController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class FrontControllerTest extends TestCase
+{
+    public function testActionNormalizationAcceptsMissingAjaxActions(): void
+    {
+        $oMethod = (new ReflectionClass(FrontController::class))->getMethod('normalizeAction');
+
+        $this->assertSame('', $oMethod->invoke(null, null));
+        $this->assertSame('showprofile', $oMethod->invoke(null, 'ShowProfile'));
+    }
+}

--- a/_tests/Unit/Framework/Translate/Adapter/GettextContextPluralTest.php
+++ b/_tests/Unit/Framework/Translate/Adapter/GettextContextPluralTest.php
@@ -51,6 +51,17 @@ final class GettextContextPluralTest extends TestCase
         );
     }
 
+    public function testCodeSetFallbackDoesNotReadRemovedIniDirectives(): void
+    {
+        $sSource = file_get_contents(
+            PH7_PATH_FRAMEWORK . 'Translate/Adapter/Gettext/gettext.inc.php'
+        );
+
+        $this->assertIsString($sSource);
+        $this->assertStringNotContainsString('mbstring.internal_encoding', $sSource);
+        $this->assertSame(PH7_ENCODING, \_get_codeset('missing-domain'));
+    }
+
     public function testPluralExpressionRejectsUnexpectedIdentifiers(): void
     {
         $oReader = new \gettext_reader(null);

--- a/_tests/Unit/Framework/Video/VideoUploadValidationTest.php
+++ b/_tests/Unit/Framework/Video/VideoUploadValidationTest.php
@@ -32,6 +32,7 @@ final class VideoUploadValidationTest extends TestCase
 
         $this->assertIsString($sSource);
         $this->assertStringNotContainsString('$this->aFile[\'type\']', $sSource);
+        $this->assertStringNotContainsString('finfo_close(', $sSource);
         $this->assertStringContainsString('$this->isReliableDetectedMime($sDetectedMime)', $sSource);
         $this->assertStringContainsString('$this->mimeMatchesExpected($sDetectedMime, $sExpectedMime)', $sSource);
     }

--- a/_tests/Unit/Root/FreshAdminEmptyStateTest.php
+++ b/_tests/Unit/Root/FreshAdminEmptyStateTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package        PH7 / Test / Unit / Root
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PHPUnit\Framework\TestCase;
+
+final class FreshAdminEmptyStateTest extends TestCase
+{
+    private const PROJECT_ROOT = __DIR__ . '/../../..';
+
+    public function testFreshAdminListsRenderUsefulEmptyStatesInsteadOfNotFoundPages(): void
+    {
+        $aControllers = [
+            '_protected/app/system/modules/mail/controllers/AdminController.php',
+            '_protected/app/system/modules/admin123/controllers/UserController.php',
+            '_protected/app/system/modules/affiliate/controllers/AdminController.php',
+            '_protected/app/system/modules/newsletter/controllers/AdminController.php'
+        ];
+
+        foreach ($aControllers as $sControllerPath) {
+            $sController = $this->readFile($sControllerPath);
+
+            self::assertStringNotContainsString('setNotFoundPage()', $sController, $sControllerPath);
+        }
+
+        self::assertStringContainsString(
+            'No member messages yet. New conversations will appear here.',
+            $this->readFile($aControllers[0])
+        );
+        self::assertStringContainsString(
+            '$this->view->browse = $oBrowse;',
+            $this->readFile($aControllers[1])
+        );
+        self::assertStringContainsString(
+            'No affiliates yet. New affiliate registrations will appear here.',
+            $this->readFile($aControllers[2])
+        );
+        self::assertStringContainsString(
+            'No subscribers yet. Newsletter signups will appear here.',
+            $this->readFile($aControllers[3])
+        );
+    }
+
+    public function testFreshAdminListTemplatesProvideAnActionableEmptyState(): void
+    {
+        $aTemplates = [
+            '_protected/app/system/modules/admin123/views/base/tpl/user/browse.tpl',
+            '_protected/app/system/modules/affiliate/views/base/tpl/admin/browse.tpl',
+            '_protected/app/system/modules/newsletter/views/base/tpl/admin/browse.tpl'
+        ];
+
+        foreach ($aTemplates as $sTemplatePath) {
+            $sTemplate = $this->readFile($sTemplatePath);
+
+            self::assertStringContainsString('{if empty($browse)}', $sTemplate, $sTemplatePath);
+            self::assertStringContainsString('alert alert-info center', $sTemplate, $sTemplatePath);
+            self::assertStringContainsString('btn btn-primary', $sTemplate, $sTemplatePath);
+        }
+    }
+
+    private function readFile(string $sRelativePath): string
+    {
+        $sContents = file_get_contents(self::PROJECT_ROOT . '/' . $sRelativePath);
+
+        self::assertIsString($sContents);
+
+        return $sContents;
+    }
+}

--- a/_tests/Unit/Root/LaunchSafetyDefaultsTest.php
+++ b/_tests/Unit/Root/LaunchSafetyDefaultsTest.php
@@ -107,12 +107,15 @@ final class LaunchSafetyDefaultsTest extends TestCase
     public function testApplicationSessionUsesStrictSecureCookieDefaults(): void
     {
         $sSession = $this->readProjectFile('_protected/framework/Session/Session.class.php');
+        $sEnvironment = $this->readProjectFile('_protected/app/configs/environment/all.env.php');
 
         $this->assertStringContainsString("ini_set('session.use_strict_mode', '1')", $sSession);
         $this->assertStringContainsString("'secure' => Server::isHttps()", $sSession);
         $this->assertStringContainsString("'httponly' => true", $sSession);
         $this->assertStringContainsString("'samesite' => 'Lax'", $sSession);
         $this->assertStringContainsString('Check session.save_path permissions.', $sSession);
+        $this->assertStringNotContainsString('session.hash_function', $sEnvironment);
+        $this->assertStringNotContainsString('session.hash_bits_per_character', $sEnvironment);
     }
 
     private function readProjectFile(string $sRelativePath): string

--- a/_tests/Unit/Root/ReleaseDeploymentTest.php
+++ b/_tests/Unit/Root/ReleaseDeploymentTest.php
@@ -37,7 +37,7 @@ final class ReleaseDeploymentTest extends TestCase
         $this->assertContains('@install-installer-dependencies', $aComposer['scripts']['post-update-cmd']);
     }
 
-    public function testReleaseVersionIsSynchronizedAcrossRuntimeInstallerAndGuides(): void
+    public function testRuntimeVersionIsSynchronizedWithInstaller(): void
     {
         $sFramework = $this->readFile('_protected/framework/Security/Version.class.php');
         $sInstaller = $this->readFile('_install/library/Controller.class.php');
@@ -51,10 +51,23 @@ final class ReleaseDeploymentTest extends TestCase
             preg_match("/SOFTWARE_VERSION = '([^']+)'/", $sInstaller, $aInstallerVersion)
         );
         $this->assertSame($aFrameworkVersion[1], $aInstallerVersion[1]);
+    }
 
-        $sVersion = $aFrameworkVersion[1];
+    public function testStableReleaseGuidesAreSynchronized(): void
+    {
+        $sReadme = $this->readFile('README.md');
+        $this->assertSame(
+            1,
+            preg_match(
+                '#releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/pH7Builder-v\1\.zip#',
+                $sReadme,
+                $aStableVersion
+            )
+        );
+
+        $sVersion = $aStableVersion[1];
         $sReleaseUrl = "releases/download/v{$sVersion}/pH7Builder-v{$sVersion}.zip";
-        $this->assertStringContainsString($sReleaseUrl, $this->readFile('README.md'));
+        $this->assertStringContainsString($sReleaseUrl, $sReadme);
         $this->assertStringContainsString($sReleaseUrl, $this->readFile('docs/QUICK_START.md'));
         $this->assertStringContainsString(
             "ph7software/ph7builder:{$sVersion}",

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -172,6 +172,27 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testAdminChartsRedrawAfterViewportChanges(): void
+    {
+        $sAdminTemplateDirectory = dirname(__DIR__, 3) .
+            '/_protected/app/system/modules/admin123/views/base/tpl';
+        $aChartResizeBindings = [
+            $sAdminTemplateDirectory . '/main/stat.tpl' => 'resize.ph7UserChart',
+            $sAdminTemplateDirectory . '/tool/cache.tpl' => 'resize.ph7CacheChart',
+            $sAdminTemplateDirectory . '/tool/freespace.tpl' => 'resize.ph7FreeSpaceChart'
+        ];
+
+        foreach ($aChartResizeBindings as $sChartTemplate => $sResizeEvent) {
+            $sTemplate = file_get_contents($sChartTemplate);
+
+            $this->assertIsString($sTemplate);
+            $this->assertStringContainsString("off('{$sResizeEvent}')", $sTemplate);
+            $this->assertStringContainsString("on('{$sResizeEvent}'", $sTemplate);
+            $this->assertStringContainsString('clearTimeout(', $sTemplate);
+            $this->assertStringContainsString('setTimeout(', $sTemplate);
+        }
+    }
+
     public function testThemeFormControlsRetainResponsiveBorderBoxSizing(): void
     {
         $sProjectRoot = dirname(__DIR__, 3);

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -193,6 +193,18 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testAdminDashboardKeepsProjectNewsConcise(): void
+    {
+        $sTemplate = file_get_contents(
+            dirname(__DIR__, 3) .
+            '/_protected/app/system/modules/admin123/views/base/tpl/main/news.inc.tpl'
+        );
+
+        $this->assertIsString($sTemplate);
+        $this->assertStringContainsString('XmlDesignCore::softwareNews(3)', $sTemplate);
+        $this->assertStringNotContainsString('XmlDesignCore::softwareNews(10)', $sTemplate);
+    }
+
     public function testThemeFormControlsRetainResponsiveBorderBoxSizing(): void
     {
         $sProjectRoot = dirname(__DIR__, 3);

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -110,7 +110,37 @@ final class ThemeAssetTest extends TestCase
                 '$design->url(\'user\', \'signup\', \'step1\')',
                 $sTemplate
             );
+            $this->assertStringContainsString(
+                '$sNearbyCountry !== \'\' ? $design->url(\'map\', \'country\', \'index\'',
+                $sTemplate
+            );
+            $this->assertStringContainsString(
+                ': $design->url(\'user\', \'browse\', \'index\')',
+                $sTemplate
+            );
+            $this->assertStringNotContainsString(
+                'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
+                $sTemplate
+            );
         }
+
+        $sSitemapLinksTemplate = file_get_contents(
+            $sProjectRoot . '/_protected/app/system/modules/xml/views/base/tpl/links.xml.tpl'
+        );
+
+        $this->assertIsString($sSitemapLinksTemplate);
+        $this->assertStringContainsString(
+            '$sNearbyCountry !== \'\' ? $design->url(\'map\', \'country\', \'index\'',
+            $sSitemapLinksTemplate
+        );
+        $this->assertStringContainsString(
+            ': $design->url(\'user\', \'browse\', \'index\')',
+            $sSitemapLinksTemplate
+        );
+        $this->assertStringNotContainsString(
+            'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
+            $sSitemapLinksTemplate
+        );
 
         $oRoutes = new DOMDocument;
         $this->assertTrue($oRoutes->load($sProjectRoot . '/_protected/app/configs/routes/en.xml'));

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -111,13 +111,14 @@ final class ThemeAssetTest extends TestCase
                 $sTemplate
             );
             $this->assertStringContainsString(
-                '$sNearbyCountry !== \'\' ? $design->url(\'map\', \'country\', \'index\'',
+                '$sNearbyCountry !== \'\' ? Framework\\Mvc\\Router\\Uri::get(\'map\', \'country\', \'index\'',
                 $sTemplate
             );
             $this->assertStringContainsString(
-                ': $design->url(\'user\', \'browse\', \'index\')',
+                ': Framework\\Mvc\\Router\\Uri::get(\'user\', \'browse\', \'index\')',
                 $sTemplate
             );
+            $this->assertStringNotContainsString('$sNearbyUrl = $design->url(', $sTemplate);
             $this->assertStringNotContainsString(
                 'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
                 $sTemplate
@@ -130,13 +131,14 @@ final class ThemeAssetTest extends TestCase
 
         $this->assertIsString($sSitemapLinksTemplate);
         $this->assertStringContainsString(
-            '$sNearbyCountry !== \'\' ? $design->url(\'map\', \'country\', \'index\'',
+            '$sNearbyCountry !== \'\' ? Framework\\Mvc\\Router\\Uri::get(\'map\', \'country\', \'index\'',
             $sSitemapLinksTemplate
         );
         $this->assertStringContainsString(
-            ': $design->url(\'user\', \'browse\', \'index\')',
+            ': Framework\\Mvc\\Router\\Uri::get(\'user\', \'browse\', \'index\')',
             $sSitemapLinksTemplate
         );
+        $this->assertStringNotContainsString('$sNearbyUrl = $design->url(', $sSitemapLinksTemplate);
         $this->assertStringNotContainsString(
             'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
             $sSitemapLinksTemplate

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -118,7 +118,12 @@ final class ThemeAssetTest extends TestCase
                 ': Framework\\Mvc\\Router\\Uri::get(\'user\', \'browse\', \'index\')',
                 $sTemplate
             );
+            $this->assertStringContainsString(
+                '$str->escapeAttribute($sNearbyUrl)',
+                $sTemplate
+            );
             $this->assertStringNotContainsString('$sNearbyUrl = $design->url(', $sTemplate);
+            $this->assertStringNotContainsString('href="{% $sNearbyUrl %}"', $sTemplate);
             $this->assertStringNotContainsString(
                 'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
                 $sTemplate
@@ -138,7 +143,15 @@ final class ThemeAssetTest extends TestCase
             ': Framework\\Mvc\\Router\\Uri::get(\'user\', \'browse\', \'index\')',
             $sSitemapLinksTemplate
         );
+        $this->assertStringContainsString(
+            '$str->escapeAttribute($sNearbyUrl)',
+            $sSitemapLinksTemplate
+        );
         $this->assertStringNotContainsString('$sNearbyUrl = $design->url(', $sSitemapLinksTemplate);
+        $this->assertStringNotContainsString(
+            'url="{% $sNearbyUrl %}"',
+            $sSitemapLinksTemplate
+        );
         $this->assertStringNotContainsString(
             'Geo::getCountry() . PH7_SH. Framework\\Geo\\Ip\\Geo::getCity()',
             $sSitemapLinksTemplate

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -222,6 +222,25 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testThemeContentRowsMatchTheCustomContainerGutter(): void
+    {
+        $sProjectRoot = dirname(__DIR__, 3);
+        $aCommonStylesheets = [
+            $sProjectRoot . '/templates/themes/base/css/common.css',
+            $sProjectRoot . '/templates/themes/premium/css/common.css'
+        ];
+
+        foreach ($aCommonStylesheets as $sCommonStylesheet) {
+            $sCss = file_get_contents($sCommonStylesheet);
+
+            $this->assertIsString($sCss);
+            $this->assertMatchesRegularExpression(
+                '/#content\s*>\s*\.row\s*\{[^}]*margin-left:\s*-12px;[^}]*margin-right:\s*-12px;/s',
+                $sCss
+            );
+        }
+    }
+
     public function testVideoSplashKeepsItsBackgroundVisible(): void
     {
         $sCss = file_get_contents(

--- a/_tests/Unit/Root/XmlLinkListRoutingTest.php
+++ b/_tests/Unit/Root/XmlLinkListRoutingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package        PH7 / Test / Unit / Root
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PHPUnit\Framework\TestCase;
+
+final class XmlLinkListRoutingTest extends TestCase
+{
+    private const PROJECT_ROOT = __DIR__ . '/../../..';
+
+    public function testHtmlLinkListsRenderLocalTemplatesWithoutSelfHttpRequests(): void
+    {
+        $sMainController = $this->readFile(
+            '_protected/app/system/modules/xml/controllers/MainController.php'
+        );
+        self::assertStringContainsString('getLinksFromTemplate', $sMainController);
+        self::assertStringContainsString('$this->view->display($sTemplate)', $sMainController);
+        self::assertStringContainsString('$oXml->loadXML($sXml)', $sMainController);
+
+        $aControllers = [
+            '_protected/app/system/modules/xml/controllers/SitemapController.php' => 'links.xml.tpl',
+            '_protected/app/system/modules/xml/controllers/RssController.php' => 'rss_links.xml.tpl'
+        ];
+
+        foreach ($aControllers as $sControllerPath => $sTemplate) {
+            $sController = $this->readFile($sControllerPath);
+
+            self::assertStringContainsString(
+                sprintf("getLinksFromTemplate('%s')", $sTemplate),
+                $sController,
+                $sControllerPath
+            );
+            self::assertStringNotContainsString('new Link(', $sController, $sControllerPath);
+            self::assertStringNotContainsString("Uri::get('xml'", $sController, $sControllerPath);
+        }
+    }
+
+    private function readFile(string $sRelativePath): string
+    {
+        $sContents = file_get_contents(self::PROJECT_ROOT . '/' . $sRelativePath);
+
+        self::assertIsString($sContents);
+
+        return $sContents;
+    }
+}

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -14,8 +14,10 @@
   imports, installer checks, and website diagnostics.
 - Keeps the public splash header readable on small screens and redraws all
   admin charts after viewport changes to prevent horizontal overflow.
-- Emits each RSS discovery link once and escapes third-party video-provider
-  errors before rendering them.
+- Emits each RSS discovery link once, escapes third-party video-provider
+  errors, and validates remote project-news content before rendering it.
+- Keeps the dashboard useful by limiting project news to three concise,
+  human-readable items.
 - Adds regression coverage for each corrected security, compatibility, feed,
   and responsive-UI behavior.
 

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -27,6 +27,8 @@
   errors, and validates remote project-news content before rendering it.
 - Keeps the dashboard useful by limiting project news to three concise,
   human-readable items.
+- Replaces fresh-site 404 pages in the member, affiliate, subscriber, and mail
+  administration lists with clear empty states and useful next actions.
 - Adds regression coverage for each corrected security, compatibility, feed,
   and responsive-UI behavior.
 

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -27,6 +27,8 @@
   errors, and validates remote project-news content before rendering it.
 - Renders the HTML Site Map and RSS Feed List from local XML templates instead
   of making blocking HTTP requests back to the same site.
+- Falls back to member browsing when IP geolocation is unavailable, preventing
+  the People Nearby menu and site-map entry from linking to `/dating//`.
 - Keeps the dashboard useful by limiting project news to three concise,
   human-readable items.
 - Replaces fresh-site 404 pages in the member, affiliate, subscriber, and mail

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -11,7 +11,14 @@
 - Makes the out-of-band installer token readable by the web-server process
   without exposing it to other users on the host.
 - Removes remaining PHP 8 compatibility failures in HTTP status handling, CSV
-  imports, installer checks, website diagnostics, and action-less AJAX routing.
+  imports, installer checks, website diagnostics, and action-less AJAX routing;
+  it also removes obsolete INI reads and the PHP 8.5-deprecated explicit
+  FileInfo close call.
+- Constrains wall edits and deletions to the requested owner's exact wall post,
+  preventing one request from changing multiple posts.
+- Validates comment identity and ownership before showing the edit form, gives
+  invalid or forbidden requests an appropriate error page, and reports comment
+  mutation success only when one row changed.
 - Keeps the public splash header readable on small screens and redraws all
   admin charts after viewport changes to prevent horizontal overflow.
 - Aligns the base and premium content gutters with responsive grid rows so

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -14,6 +14,8 @@
   imports, installer checks, and website diagnostics.
 - Keeps the public splash header readable on small screens and redraws all
   admin charts after viewport changes to prevent horizontal overflow.
+- Aligns the base and premium content gutters with responsive grid rows so
+  member dashboards no longer extend beyond narrow viewports.
 - Emits each RSS discovery link once, escapes third-party video-provider
   errors, and validates remote project-news content before rendering it.
 - Keeps the dashboard useful by limiting project news to three concise,

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -25,6 +25,8 @@
   member dashboards no longer extend beyond narrow viewports.
 - Emits each RSS discovery link once, escapes third-party video-provider
   errors, and validates remote project-news content before rendering it.
+- Renders the HTML Site Map and RSS Feed List from local XML templates instead
+  of making blocking HTTP requests back to the same site.
 - Keeps the dashboard useful by limiting project news to three concise,
   human-readable items.
 - Replaces fresh-site 404 pages in the member, affiliate, subscriber, and mail
@@ -55,8 +57,8 @@
       contents, generate its SHA-256 file, and run a fresh packaged install on
       supported PHP and MySQL versions.
 - [ ] Recheck installer token access, schema creation, admin login, public
-      signup, member login, Notes, RSS, responsive public/admin views, logs,
-      and post-install `_install` removal.
+      signup, member login, Notes, HTML/XML site maps, RSS feeds and feed list,
+      responsive public/admin views, logs, and post-install `_install` removal.
 - [ ] Update the stable README, Quick Start, upgrade guide, and release notes
       only after the final artifact names and upgrade path are known.
 - [ ] Publish the annotated tag, ZIP, and checksum; verify all public asset

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -11,7 +11,7 @@
 - Makes the out-of-band installer token readable by the web-server process
   without exposing it to other users on the host.
 - Removes remaining PHP 8 compatibility failures in HTTP status handling, CSV
-  imports, installer checks, and website diagnostics.
+  imports, installer checks, website diagnostics, and action-less AJAX routing.
 - Keeps the public splash header readable on small screens and redraws all
   admin charts after viewport changes to prevent horizontal overflow.
 - Aligns the base and premium content gutters with responsive grid rows so

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -8,8 +8,8 @@
 
 - Rejects unsafe template override paths before resolving files, preventing
   path traversal while preserving valid theme overrides.
-- Makes the out-of-band installer token readable by the web-server process
-  without exposing it to other users on the host.
+- Stores only a one-way installer-token hash for the web-server process; the
+  one-time plaintext token remains confined to CLI output.
 - Removes remaining PHP 8 compatibility failures in HTTP status handling, CSV
   imports, installer checks, website diagnostics, and action-less AJAX routing;
   it also removes obsolete INI reads and the PHP 8.5-deprecated explicit

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -1,0 +1,50 @@
+# pH7Builder 19.0.0 — Draft Release Notes
+
+> Release candidate only. pH7Builder 19.0.0 has not been published. Stable
+> download and installation instructions intentionally remain on 18.6.2 until
+> the final v19 package and checksum are public and independently verified.
+
+## Candidate highlights
+
+- Rejects unsafe template override paths before resolving files, preventing
+  path traversal while preserving valid theme overrides.
+- Makes the out-of-band installer token readable by the web-server process
+  without exposing it to other users on the host.
+- Removes remaining PHP 8 compatibility failures in HTTP status handling, CSV
+  imports, installer checks, and website diagnostics.
+- Keeps the public splash header readable on small screens and redraws all
+  admin charts after viewport changes to prevent horizontal overflow.
+- Emits each RSS discovery link once and escapes third-party video-provider
+  errors before rendering them.
+- Adds regression coverage for each corrected security, compatibility, feed,
+  and responsive-UI behavior.
+
+## Compatibility and upgrade status
+
+- PHP 8.2 or newer and MySQL 8.0 or newer remain required.
+- The current candidate does not change the SQL schema from 18.6.2
+  (`1.6.6`). This must be rechecked against the final release commit before
+  confirming that no v19 database migration is required.
+- Deployments older than 18.6.0 must still apply every applicable documented
+  migration in order. Preserve local configuration, uploads, custom modules,
+  custom themes, language packs, and payment credentials.
+- Stable README, Quick Start, and upgrade commands must not move from 18.6.2
+  until a final v19 artifact and checksum exist at those exact URLs.
+
+## Publication gates
+
+- [ ] Confirm the v19 release codename; the candidate currently retains the
+      v18 `REVOLUTIONARY™` name rather than inventing a replacement.
+- [ ] Set `KERNEL_RELEASE_DATE` to the real publication date.
+- [ ] Rebase or merge the final reviewed changes, then rerun PHPUnit, PHPStan,
+      syntax checks, Composer validation, and both dependency audits.
+- [ ] Build the production ZIP from the exact release commit, verify its
+      contents, generate its SHA-256 file, and run a fresh packaged install on
+      supported PHP and MySQL versions.
+- [ ] Recheck installer token access, schema creation, admin login, public
+      signup, member login, Notes, RSS, responsive public/admin views, logs,
+      and post-install `_install` removal.
+- [ ] Update the stable README, Quick Start, upgrade guide, and release notes
+      only after the final artifact names and upgrade path are known.
+- [ ] Publish the annotated tag, ZIP, and checksum; verify all public asset
+      digests before enabling any external update alert.

--- a/static/js/Wall.js
+++ b/static/js/Wall.js
@@ -76,8 +76,9 @@ function Wall() {
      */
     this.edit = function () {
         var sPost = $('.wall_post').val();
+        var iWallId = $('.wall_id').val();
 
-        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'edit', 'post': sPost}, function (oData) {
+        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'edit', 'wall_id': iWallId, 'post': sPost}, function (oData) {
             oMe._output(oData);
         }, 'json');
     };
@@ -89,9 +90,9 @@ function Wall() {
      * @async
      */
     this.del = function () {
-        var sPost = $('.wall_id').val();
+        var iWallId = $('.wall_id').val();
 
-        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'delete', 'post': sPost}, function (oData) {
+        $.post(pH7Url.base + this.sUrl + pH7Url.csrf, {type: 'delete', 'wall_id': iWallId}, function (oData) {
             oMe._output(oData);
         }, 'json');
     };

--- a/templates/themes/base/css/common.css
+++ b/templates/themes/base/css/common.css
@@ -72,6 +72,11 @@ header, #content {
     padding-right: 12px;
 }
 
+#content > .row {
+    margin-left: -12px;
+    margin-right: -12px;
+}
+
 #headings, .loginas, .noscript {
     margin-top: 6rem;
 }

--- a/templates/themes/base/tpl/top_menu.inc.tpl
+++ b/templates/themes/base/tpl/top_menu.inc.tpl
@@ -77,7 +77,7 @@
               {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
               {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
               <li>
-                <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
+                <a href="{% $str->escapeAttribute($sNearbyUrl) %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}
                 </a>
               </li>

--- a/templates/themes/base/tpl/top_menu.inc.tpl
+++ b/templates/themes/base/tpl/top_menu.inc.tpl
@@ -73,8 +73,11 @@
             </li>
 
             {if $is_map_enabled}
+              {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
+              {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
+              {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
               <li>
-                <a href="{{ $design->url('map', 'country', 'index', Framework\Geo\Ip\Geo::getCountry() . PH7_SH. Framework\Geo\Ip\Geo::getCity()) }}" title="{lang 'Users nearby through the map!'}">
+                <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}
                 </a>
               </li>

--- a/templates/themes/base/tpl/top_menu.inc.tpl
+++ b/templates/themes/base/tpl/top_menu.inc.tpl
@@ -75,7 +75,7 @@
             {if $is_map_enabled}
               {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
               {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
-              {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
+              {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
               <li>
                 <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}

--- a/templates/themes/premium/css/common.css
+++ b/templates/themes/premium/css/common.css
@@ -75,6 +75,11 @@ header, #content {
     padding-right: 12px;
 }
 
+#content > .row {
+    margin-left: -12px;
+    margin-right: -12px;
+}
+
 #headings, .loginas, .noscript {
     margin-top: 6rem;
 }

--- a/templates/themes/premium/tpl/top_menu.inc.tpl
+++ b/templates/themes/premium/tpl/top_menu.inc.tpl
@@ -77,7 +77,7 @@
               {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
               {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
               <li>
-                <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
+                <a href="{% $str->escapeAttribute($sNearbyUrl) %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}
                 </a>
               </li>

--- a/templates/themes/premium/tpl/top_menu.inc.tpl
+++ b/templates/themes/premium/tpl/top_menu.inc.tpl
@@ -73,8 +73,11 @@
             </li>
 
             {if $is_map_enabled}
+              {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
+              {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
+              {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
               <li>
-                <a href="{{ $design->url('map', 'country', 'index', Framework\Geo\Ip\Geo::getCountry() . PH7_SH. Framework\Geo\Ip\Geo::getCity()) }}" title="{lang 'Users nearby through the map!'}">
+                <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}
                 </a>
               </li>

--- a/templates/themes/premium/tpl/top_menu.inc.tpl
+++ b/templates/themes/premium/tpl/top_menu.inc.tpl
@@ -75,7 +75,7 @@
             {if $is_map_enabled}
               {{ $sNearbyCountry = (string) Framework\Geo\Ip\Geo::getCountry() }}
               {{ $sNearbyCity = (string) Framework\Geo\Ip\Geo::getCity() }}
-              {{ $sNearbyUrl = $sNearbyCountry !== '' ? $design->url('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : $design->url('user', 'browse', 'index') }}
+              {{ $sNearbyUrl = $sNearbyCountry !== '' ? Framework\Mvc\Router\Uri::get('map', 'country', 'index', $sNearbyCountry . ($sNearbyCity !== '' ? PH7_SH . $sNearbyCity : '')) : Framework\Mvc\Router\Uri::get('user', 'browse', 'index') }}
               <li>
                 <a href="{% $sNearbyUrl %}" title="{lang 'Users nearby through the map!'}">
                   <i class="fa fa-map-marker"></i> {lang 'People Nearby'}


### PR DESCRIPTION
## Summary

- Prepare the `19.0.0` runtime and installer authorities without publishing a release.
- Harden cross-post wall mutations, invalid comment ownership, PHP 8 lifecycle behavior, admin empty states, responsive charts, mobile content gutters, and AJAX routing.
- Render XML link lists locally so site-map and RSS requests cannot time out on a single-worker server.
- Provide a safe `People Nearby` fallback when visitor geolocation is unavailable, with final-context URL escaping and no template output side effects.
- Add regression coverage and explicit publication gates in the release notes.
- Keep stable installation and upgrade documentation on `18.6.2` until a real v19 tag and artifact exist.

## Verified

- Current exact head: `353673acb`.
- PHPUnit: 866 tests, 2,539 assertions.
- PHPStan: all 758 files pass; changed PHP files pass syntax checks.
- PHPCompatibility for PHP 8.2–8.5 reports no errors; the 11 remaining legacy warnings were reviewed.
- Composer validation and both dependency audits pass with no known advisories.
- The complete GitHub PHP 8.2–8.5 Linux, macOS, Windows, Composer, installer, and Docker matrix passes.
- A packaged fresh install was verified at audited runtime head `83d4ba76f` on PHP 8.5.1 and MySQL 8.4.11 strict mode: 63 utf8mb4 tables, schema 1.6.6, Argon2id credentials, installer cleanup, admin login, public signup/login, site map, and RSS. The two subsequent review commits only add final-context URL escaping with regression coverage and correct release-note wording.
- Public and authenticated mobile flows have no horizontal overflow at 390 px; runtime and database error logs remain empty.

## Before release

- Confirm the v19 codename; the current value is inherited and not approved for publication.
- Set the real publication date.
- Publish the tag, archive, checksum, and stable-documentation updates together, then verify the public artifact digest.
- Complete live SMTP, payment, cron, and update-feed acceptance checks in the intended production environment.

This PR is ready to merge for stabilization. Do not tag or publish v19 until every publication gate in the draft release notes is complete.

Best, [Pierre-Henry](https://github.com/pH-7)
