### PR TITLE
Publish pH7Builder v19.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip.sha256
-sha256sum -c pH7Builder-v18.6.2.zip.sha256
-unzip pH7Builder-v18.6.2.zip
-cd pH7Builder-v18.6.2
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip.sha256
+sha256sum -c pH7Builder-v19.0.0.zip.sha256
+unzip pH7Builder-v19.0.0.zip
+cd pH7Builder-v19.0.0
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.2 pH7Builder-v18.6.2 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.0 pH7Builder-v19.0.0 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -41,7 +41,7 @@ final class Version
      * 1.0, 1.1 branches were "pOH", 1.2 was "pOW", 1.3, 1.4 were "p[H]", v2.* was "H2O",
      * v3.* was "H3O", v4.* was "HCO", v5.* was "pCO", v6.* was "WoW",
      * v7.* and v8.* were "NaOH", v10.* was "pKa", v12.* was "PHS", v14.* was "pKb",
-     * v15.* was ABSOLUTE™, v16.* was ACIDIC, v17.* was PURE™ and v18 is REVOLUTIONARY™
+     * v15.* was ABSOLUTE™, v16.* was ACIDIC, v17.* was PURE™, and v18-v19 are REVOLUTIONARY™
      */
     public const KERNEL_VERSION_NAME = 'REVOLUTIONARY™';
 
@@ -53,7 +53,7 @@ final class Version
      */
     public const KERNEL_VERSION = '19.0.0';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-08-26';
+    public const KERNEL_RELEASE_DATE = '2026-08-28';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v18.6.2/pH7Builder-v18.6.2.zip.sha256
-sha256sum -c pH7Builder-v18.6.2.zip.sha256
-unzip pH7Builder-v18.6.2.zip
-cp -a pH7Builder-v18.6.2/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip.sha256
+sha256sum -c pH7Builder-v19.0.0.zip.sha256
+unzip pH7Builder-v19.0.0.zip
+cp -a pH7Builder-v19.0.0/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v18.6.2` and run:
+For a source checkout instead, clone tag `v19.0.0` and run:
 
 ```console
-git clone --branch v18.6.2 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v18.6.2
-cd pH7Builder-v18.6.2
+git clone --branch v19.0.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.0.0
+cd pH7Builder-v19.0.0
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:18.6.2 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.0 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive

--- a/docs/RELEASE_NOTES_19.0.0.md
+++ b/docs/RELEASE_NOTES_19.0.0.md
@@ -1,10 +1,10 @@
-# pH7Builder 19.0.0 — Draft Release Notes
+# pH7Builder 19.0.0 — Release Notes
 
-> Release candidate only. pH7Builder 19.0.0 has not been published. Stable
-> download and installation instructions intentionally remain on 18.6.2 until
-> the final v19 package and checksum are public and independently verified.
+Released on 28 August 2026 as **REVOLUTIONARY™**, pH7Builder 19.0.0 is a major
+stability, security, PHP 8 compatibility, installer, and usability release for
+self-hosted dating and social communities.
 
-## Candidate highlights
+## Highlights
 
 - Rejects unsafe template override paths before resolving files, preventing
   path traversal while preserving valid theme overrides.
@@ -39,29 +39,21 @@
 ## Compatibility and upgrade status
 
 - PHP 8.2 or newer and MySQL 8.0 or newer remain required.
-- The current candidate does not change the SQL schema from 18.6.2
-  (`1.6.6`). This must be rechecked against the final release commit before
-  confirming that no v19 database migration is required.
+- This release does not change the SQL schema from 18.6.2 (`1.6.6`), so there
+  is no `18.6.2-19.0.0` database migration.
 - Deployments older than 18.6.0 must still apply every applicable documented
   migration in order. Preserve local configuration, uploads, custom modules,
   custom themes, language packs, and payment credentials.
-- Stable README, Quick Start, and upgrade commands must not move from 18.6.2
-  until a final v19 artifact and checksum exist at those exact URLs.
 
-## Publication gates
+## Upgrade
 
-- [ ] Confirm the v19 release codename; the candidate currently retains the
-      v18 `REVOLUTIONARY™` name rather than inventing a replacement.
-- [ ] Set `KERNEL_RELEASE_DATE` to the real publication date.
-- [ ] Rebase or merge the final reviewed changes, then rerun PHPUnit, PHPStan,
-      syntax checks, Composer validation, and both dependency audits.
-- [ ] Build the production ZIP from the exact release commit, verify its
-      contents, generate its SHA-256 file, and run a fresh packaged install on
-      supported PHP and MySQL versions.
-- [ ] Recheck installer token access, schema creation, admin login, public
-      signup, member login, Notes, HTML/XML site maps, RSS feeds and feed list,
-      responsive public/admin views, logs, and post-install `_install` removal.
-- [ ] Update the stable README, Quick Start, upgrade guide, and release notes
-      only after the final artifact names and upgrade path are known.
-- [ ] Publish the annotated tag, ZIP, and checksum; verify all public asset
-      digests before enabling any external update alert.
+Back up the database, application files, local configuration, uploads, custom
+modules and themes, language packs, and gateway credentials. Upgrade a staging
+copy first and follow the complete [Upgrade Guide](UPGRADING.md). Deployments
+older than 18.6.0 must apply each applicable documented database migration in
+order.
+
+The ready-to-run `pH7Builder-v19.0.0.zip` archive includes locked production
+dependencies. Verify it with the attached `.sha256` file before deployment,
+then follow the [Production Quick Start](QUICK_START.md) and
+[Launch Checklist](LAUNCH_CHECKLIST.md).

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,26 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 19.0.0 major release
+
+pH7Builder 19.0.0 is a code-only security, compatibility, and usability release
+over 18.6.2. The SQL schema remains `1.6.6`, so an installation already running
+18.6.0, 18.6.1, or 18.6.2 needs no database migration. Deploy the tagged 19.0.0
+package without overwriting local configuration, uploaded data, custom modules,
+custom themes, language packs, or gateway credentials. Reinstall dependencies
+from the committed lock file when deploying from source, clear application
+caches, and complete the post-upgrade checks below before reopening the site.
+
+Sites older than 18.6.0 must still apply every applicable intermediate migration
+in order. In particular, an 18.5.1 database requires the reviewed
+`18.5.1-18.6.0` migration before the 19.0.0 application is used.
+
+This release tightens installer access, request authorization, output escaping,
+template-path validation, and ownership checks. Do not restore older copies of
+the changed application or framework files after deployment. Review custom
+themes and modules for the same output-encoding and ownership boundaries before
+re-enabling them.
+
 ## 18.6.2 patch release
 
 pH7Builder 18.6.2 is a code-only security-hardening patch over 18.6.1. It does

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:18.6.2 pH7Builder-v18.6.2 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.0 pH7Builder-v19.0.0 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder


### PR DESCRIPTION
## Release scope

- Sets the real v19.0.0 publication date and retains the established REVOLUTIONARY™ codename.
- Finalizes the v19 release notes and code-only upgrade path.
- Synchronizes README, Quick Start, and packaged installation instructions with the v19.0.0 ZIP, checksum, tag, and Composer version.

## Exact-head validation

- PHPUnit: 867 tests, 2,563 assertions.
- PHPStan: 758 files, no errors.
- Composer validation passed; runtime and installer audits report no advisories.
- Two independent production builds are byte-identical: SHA-256 e9786702454f7bfd1ec17ea103df0819c535efc91dbd99e6ffbad8d90b621e17.
- Packaged install passed on PHP 8.5.1 and MySQL 8.4.11: installer access, schema import, admin creation/login, public signup, member login, Notes, sitemap/XML, RSS, and post-install cleanup.

The annotated v19.0.0 tag and public GitHub release will be created from the exact merged commit only after this PR is green and merged.