### PR TITLE
Tighten post-release setup guidance and regression coverage

### DIFF
--- a/_tests/Unit/App/System/Core/Forms/ShareEmbedCoreFormTest.php
+++ b/_tests/Unit/App/System/Core/Forms/ShareEmbedCoreFormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PH7\Tests\Unit\App\System\Core\Forms;
+namespace PH7\Test\Unit\App\System\Core\Forms;
 
 use PHPUnit\Framework\TestCase;
 

--- a/_tests/Unit/Framework/Mail/MailTest.php
+++ b/_tests/Unit/Framework/Mail/MailTest.php
@@ -16,6 +16,7 @@ use PH7\Framework\Mail\Mailable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -101,6 +102,25 @@ final class MailTest extends TestCase
         );
         $this->assertSame('site@example.com', $oMail->aFallbackData['from']);
         $this->assertSame('visitor@external.example', $oMail->aFallbackData['reply_to']);
+    }
+
+    public function testMalformedDsnIsRejectedByTheTransportFactory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new TestableMail())->transport('not-a-dsn');
+    }
+
+    public function testConfiguredTransportFailureDoesNotUseNativeMail(): void
+    {
+        putenv('PH7_MAILER_DSN=smtp://smtp.example.com:587');
+        $oMail = new FallbackMail();
+
+        $this->assertFalse($oMail->send(
+            ['to' => 'recipient@example.com', 'subject' => 'Transport failure test'],
+            '<p>Body</p>'
+        ));
+        $this->assertSame([], $oMail->aFallbackData);
     }
 }
 

--- a/_tests/Unit/Root/StoredContentOutputTest.php
+++ b/_tests/Unit/Root/StoredContentOutputTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PH7\Framework\Config\Config;
+use PH7\Framework\Layout\Tpl\Engine\PH7Tpl\Syntax\Curly;
+use PH7\Framework\Mvc\Model\Engine\Db;
+use PH7\Framework\Str\Str;
+use PH7\ProfileBaseController;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class StoredContentOutputTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        define('PH7_DOMAIN_COOKIE', 'localhost');
+        define('PH7_PATH_STATIC', dirname(PH7_PATH_PROTECTED) . '/static/');
+        define('PH7_PATH_TPL', dirname(PH7_PATH_PROTECTED) . '/templates/themes/');
+        define('PH7_ADMIN_USERNAME', 'admin');
+
+        Config::getInstance()->values['cache']['enable.general.cache'] = false;
+        $oPdo = new \PDO('sqlite::memory:');
+        $oPdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $oPdo->exec('CREATE TABLE ph7_settings (settingName TEXT, settingValue TEXT)');
+        $oPdo->exec("INSERT INTO ph7_settings VALUES ('banWordReplace', '***')");
+        (new \ReflectionProperty(Db::class, 'oInstance'))->setValue(null, (new \ReflectionClass(Db::class))->newInstanceWithoutConstructor());
+        (new \ReflectionProperty(Db::class, 'oDb'))->setValue(null, $oPdo);
+        (new \ReflectionProperty(Db::class, 'sPrefix'))->setValue(null, 'ph7_');
+    }
+
+    #[DataProvider('profileProvider')]
+    public function testStoredProfileDescriptionIsSanitizedAtReadTime(string $sModule, string $sClass, string $sContent): void
+    {
+        require_once PH7_PATH_SYS_MOD . $sModule . '/controllers/' . $sClass . '.php';
+
+        $oController = (new \ReflectionClass('PH7\\' . $sClass))->newInstanceWithoutConstructor();
+        (new \ReflectionProperty($oController, 'str'))->setValue($oController, new Str());
+        $aData = (new \ReflectionMethod(ProfileBaseController::class, 'getFilteredData'))->invoke(
+            $oController,
+            (object)['birthDate' => '1990-01-01'],
+            (object)['description' => $sContent]
+        );
+
+        $oDocument = $this->parseHtml($aData['description']);
+        $this->assertSame(0, (new \DOMXPath($oDocument))->query('//script|//svg|//iframe|//@onerror|//@onload|//@onclick|//@style')->length);
+        $this->assertStringNotContainsString('javascript:', strtolower($aData['description']));
+        $this->assertStringContainsString('Hello', $oDocument->textContent);
+        $this->assertStringContainsString('<strong>Hello</strong>', $aData['description']);
+
+        // Both controllers must pass the filtered value to their base/premium views.
+        $sController = file_get_contents(PH7_PATH_SYS_MOD . $sModule . '/controllers/' . $sClass . '.php');
+        $this->assertStringContainsString('$aData = $this->getFilteredData($oUser, $oFields);', $sController);
+        $this->assertStringContainsString('$this->view->description = nl2br($aData[\'description\']);', $sController);
+    }
+
+    public static function profileProvider(): array
+    {
+        $aCases = [];
+        foreach (['user' => 'ProfileController', 'cool-profile-page' => 'MainController'] as $sModule => $sClass) {
+            foreach (self::payloads() as $sName => $sPayload) {
+                $aCases[$sModule . ': ' . $sName] = [$sModule, $sClass, '<strong>Hello</strong>' . $sPayload];
+            }
+        }
+
+        return $aCases;
+    }
+
+    #[DataProvider('messageProvider')]
+    public function testStoredMessageIsEscapedInMemberAndAdminLists(bool $bAdmin, string $sContent, string $sExpectedText): void
+    {
+        require_once PH7_PATH_SYS_MOD . 'mail/models/MailModel.php';
+
+        $aVariables = [
+            'error' => '',
+            'is_admin_auth' => $bAdmin,
+            'is_user_auth' => !$bAdmin,
+            'member_id' => 2,
+            'csrf_token' => 'test-token',
+            'msgs' => [(object)[
+                'messageId' => 1,
+                'username' => 'sender',
+                'firstName' => 'Sender',
+                'title' => 'Hello',
+                'message' => $sContent,
+                'sender' => 1,
+                'recipient' => 2,
+                'trash' => '',
+                'status' => 0,
+                'sendDate' => '2026-01-01 12:00:00'
+            ]],
+            'design' => new class {
+                public function url(...$aParts): void
+                {
+                    echo '/test-message';
+                }
+            },
+            'avatarDesign' => new class {
+                public function get(...$aParts): void
+                {
+                    echo 'Sender';
+                }
+            },
+            'designSecurity' => new class {
+                public function inputToken(string $sName): void
+                {
+                }
+            }
+        ];
+        $sOutput = $this->renderTemplate('list.inc.tpl', $aVariables);
+        $oXPath = new \DOMXPath($this->parseHtml($sOutput));
+
+        $this->assertSame(0, $oXPath->query('//script|//svg|//iframe|//img|//@onerror|//@onload')->length);
+        $this->assertSame(0, $oXPath->query('//div[@class="message"]/*|//div[@id="divShow_1"]/*')->length);
+        $this->assertSame(1, $oXPath->query('//div[@class="message"]')->length);
+        $this->assertSame($sExpectedText, $oXPath->query('//div[@class="message"]')->item(0)->textContent);
+        if ($bAdmin) {
+            $oMessage = $oXPath->query('//div[@id="divShow_1"]')->item(0);
+            $this->assertNotNull($oMessage);
+            $this->assertSame($sExpectedText, $oMessage->textContent);
+        } else {
+            require_once PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+            $aVariables['msg'] = $aVariables['msgs'][0];
+            $oDetail = new \DOMXPath($this->parseHtml($this->renderTemplate('main/msg.inc.tpl', $aVariables)));
+            $this->assertSame(0, $oDetail->query('//dd[3]/*')->length);
+            $this->assertSame($sContent, $oDetail->query('//dd')->item(2)->textContent);
+        }
+    }
+
+    public static function messageProvider(): array
+    {
+        $aCases = [];
+        $aExpected = [
+            'svg_event' => '',
+            'image_event' => '',
+            'script' => 'alert(1)',
+            'encoded_scheme' => 'link',
+            'encoded_markup' => '<img src=x onerror=alert(1)>'
+        ];
+        foreach ([false, true] as $bAdmin) {
+            foreach (self::payloads() as $sName => $sPayload) {
+                $aCases[($bAdmin ? 'admin: ' : 'member: ') . $sName] = [$bAdmin, 'Hello' . $sPayload, 'Hello' . $aExpected[$sName]];
+            }
+        }
+
+        return $aCases;
+    }
+
+    public function display(string $sTemplate, string $sDirectory): void
+    {
+        // Pagination does not consume message content; leave only that include out.
+        $this->assertSame('page_nav.inc.tpl', $sTemplate);
+    }
+
+    private static function payloads(): array
+    {
+        return [
+            'svg_event' => '<svg onload="alert(1)"></svg>',
+            'image_event' => '<img src="x" onerror="alert(1)">',
+            'script' => '<script>alert(1)</script>',
+            'encoded_scheme' => '<a href="jav&#x61;script:alert(1)">link</a>',
+            'encoded_markup' => '&lt;img src=x onerror=alert(1)&gt;'
+        ];
+    }
+
+    private function parseHtml(string $sHtml): \DOMDocument
+    {
+        $oDocument = new \DOMDocument();
+        $oDocument->loadHTML('<!doctype html><html><body>' . $sHtml . '</body></html>', LIBXML_NOERROR | LIBXML_NOWARNING);
+
+        return $oDocument;
+    }
+
+    private function renderTemplate(string $sTemplate, array $aVariables): string
+    {
+        $oSyntax = new Curly();
+        $oSyntax->setCode(file_get_contents(PH7_PATH_SYS_MOD . 'mail/views/base/tpl/' . $sTemplate));
+        $oSyntax->parse();
+        extract($aVariables, EXTR_SKIP);
+        ob_start();
+        try {
+            // Only trusted, repository-owned template code is evaluated, never a payload.
+            eval('namespace PH7; ?>' . $oSyntax->getParsedCode());
+
+            return (string)ob_get_contents();
+        } finally {
+            ob_end_clean();
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -2157,16 +2157,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.15",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
+                "reference": "23d6f88a29f6d0eac45bd77d70307adf83ba7ab0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "url": "https://api.github.com/repos/symfony/console/zipball/23d6f88a29f6d0eac45bd77d70307adf83ba7ab0",
+                "reference": "23d6f88a29f6d0eac45bd77d70307adf83ba7ab0",
                 "shasum": ""
             },
             "require": {
@@ -2231,7 +2231,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -2251,7 +2251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:51:00+00:00"
+            "time": "2026-08-25T14:18:37+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2561,16 +2561,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.15",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "68c1f27c97edd0222eb8d440a6c8c4da5354ab46"
+                "reference": "b17c9bf3a551d5f635638a3b6c05f06c4dc87584"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/68c1f27c97edd0222eb8d440a6c8c4da5354ab46",
-                "reference": "68c1f27c97edd0222eb8d440a6c8c4da5354ab46",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/b17c9bf3a551d5f635638a3b6c05f06c4dc87584",
+                "reference": "b17c9bf3a551d5f635638a3b6c05f06c4dc87584",
                 "shasum": ""
             },
             "require": {
@@ -2621,7 +2621,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.15"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -2641,7 +2641,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-28T07:33:02+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/mime",

--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -102,13 +102,14 @@ you serve.
 - [ ] Every membership name, permission, price, currency, duration, renewal,
       cancellation, and refund statement matches what the checkout promises.
 - [ ] Unused gateways are disabled and no example keys remain.
-- [ ] Stripe stays disabled in 18.6.x; the bundled legacy flow must be migrated
+- [ ] Stripe stays disabled; the bundled legacy flow must be migrated
       to Checkout Sessions or Payment Intents before it is offered to members.
 - [ ] 2Checkout stays disabled until its bundled legacy flow is migrated to the
       2Checkout API 6.0.
 - [ ] If Braintree is enabled, its Drop-in UI migration is scheduled before
-      the provider's September 1, 2026 deprecation and September 1, 2027 end of
-      support.
+      [provider's October 1, 2026 deprecation and October 1, 2027 end of
+      support](https://developer.paypal.com/braintree/docs/guides/drop-in/overview/javascript/v3).
+      A PHP SDK update alone does not replace Drop-in.
 - [ ] Sandbox/test mode covers success, decline, cancellation, callback/webhook,
       duplicate notification, refund, and expired membership behavior.
 - [ ] The PayPal IPN URL is reachable over public HTTPS and a repeated verified

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -318,17 +318,18 @@ prove inbox delivery.
    permissions, prices, currencies, and expiry periods.
 4. Admin → Billing → Gateways Configuration: keep unused gateways disabled,
    enter sandbox/test credentials first, and never commit credentials.
-   Stripe is intentionally unavailable in 18.6.x because its bundled legacy
+   Stripe is intentionally unavailable because its bundled legacy
    flow is not SCA-ready; use another supported gateway until Stripe is
    migrated to Checkout Sessions or Payment Intents.
    The bundled 2Checkout flow is also unavailable until it is migrated to the
    2Checkout API 6.0.
    Braintree remains available, but its hosted
    [Drop-in UI](https://developer.paypal.com/braintree/docs/guides/drop-in/overview/javascript/v3)
-   is scheduled for deprecation on September 1, 2026 and loss of support on
-   September 1, 2027.
+   is scheduled for deprecation on October 1, 2026 and loss of support on
+   October 1, 2027, after which payment processing may be suspended.
    Treat it as a short-term option and plan a supported Braintree checkout
-   migration before those dates.
+   migration before those dates. Updating the PHP SDK alone does not replace
+   the Drop-in browser integration.
 5. Complete one test purchase end to end before replacing sandbox credentials
    with live credentials.
    For PayPal, keep the generated `/payment/main/notify/paypal` HTTPS callback

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -285,6 +285,13 @@ example, when the service is PHP 8.2:
 sudo systemctl reload php8.2-fpm
 ```
 
+On shared hosting, ask the host to set `PH7_MAILER_DSN` for the site's PHP web
+process or use its supported environment-variable panel. A shell `export`
+does not configure PHP-FPM, and pH7Builder does not automatically load a `.env`
+file. Do not put SMTP passwords in public files or support posts. If the host
+cannot expose this variable, ask whether it provides a working local mail
+transport before choosing the fallback below.
+
 If `PH7_MAILER_DSN` is present but invalid or the SMTP connection fails,
 pH7Builder records a transport error and does not silently send through another
 transport. Correct the DSN or provider access before launch.

--- a/docs/RELEASE_BACKLOG_18.6.0.md
+++ b/docs/RELEASE_BACKLOG_18.6.0.md
@@ -9,7 +9,7 @@ not weaken the requirements in the [Launch Checklist](LAUNCH_CHECKLIST.md).
 Keep Stripe and 2Checkout fail-closed until their legacy flows are replaced by
 the providers' current APIs. Migrate Braintree away from
 [Drop-in](https://developer.paypal.com/braintree/docs/guides/drop-in/overview/javascript/v3)
-before its September 1, 2026 deprecation and September 1, 2027 end of support. Add
+before its October 1, 2026 deprecation and October 1, 2027 end of support. Add
 provider-backed browser tests for successful, declined, cancelled, replayed,
 and refunded transactions before enabling a replacement by default.
 


### PR DESCRIPTION
Tighten post-release maintenance without changing schemas, themes, or gateway availability:

- Correct Braintree support dates and clarify shared-host SMTP setup.
- Add stored-content output tests for profiles and member/admin messages, plus SMTP failure coverage.
- Fix one test namespace skipped by Composer.
- Update Symfony Mailer to 7.4.17 and Console to 7.4.18; preserve all other locked dependencies.

Verified locally: 889 tests passed on PHP 8.5, focused checks on PHP 8.2, PHPStan, strict Composer validation/autoloading, and root/installer advisory audits.

These output-boundary tests do not certify the historical CVEs resolved. Browser reproduction and fixed-version attribution still need verification.

Best, [Pierre-Henry](https://github.com/pH-7)
