### PR TITLE
Clarify branch governance

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -1,6 +1,10 @@
 name: Check Composer
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 18.x
+  pull_request:
 
 jobs:
   run:

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-2022', 'macos-latest' ]
         php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.os }}
+    name: PHP ${{ matrix.php-versions }} Composer on ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.os }}
+    name: PHP ${{ matrix.php-versions }} PHPStan on ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,6 +1,10 @@
 name: PHPStan
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 18.x
+  pull_request:
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 18.x
+  pull_request:
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
         phpunit-version: [ '11.5' ]
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.os }}
+    name: PHP ${{ matrix.php-versions }} PHPUnit on ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,11 @@ MySQL 8.0+, and Apache/nginx (see `nginx.conf` / `sample.htaccess`).
 
 ## Before you open a pull request
 
+Open pull requests against `18.x`, the current active default branch. The
+software version is defined by release tags and the version constants, not by
+the branch name. Develop each change on a focused, short-lived branch; once its
+pull request is merged, that working branch can be deleted.
+
 1. **Follow the [Code Convention](https://ph7builder.com/doc/en/code-convention).** The short version:
    - Variables use camelCase with a type-prefix (Hungarian notation): `$sName` (string), `$iCount` (int), `$aItems` (array), `$oUser` (object), `$bEnabled` (bool), `$mValue` (mixed), `$fPrice` (float).
    - Framework classes end in `.class.php`, traits in `.trait.php`, interfaces in `.interface.php` (with a `-ble` name when possible). App classes under `_protected/app` are plain `.php`.


### PR DESCRIPTION
## Summary

- give PHPUnit, PHPStan, and Composer checks distinct names
- document `18.x` as the active contribution target without tying it to the software version
- clarify that merged working branches can be deleted

## Verification

- `git diff --check`
- workflow YAML parsing

