### PR TITLE
Improve PFBC form UX after the frontend upgrades

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ pull request is merged, that working branch can be deleted.
 
 Theme/CSS contributions: `_tools/theme-preview.html` renders the base theme's CSS chain against sample markup without a full install — serve the repo root (e.g. `python3 -m http.server 8642`) and open it to check your changes, in both light and dark mode.
 
+For real PFBC forms, run `php -S 127.0.0.1:8642 -t .` and open
+`http://127.0.0.1:8642/_tools/pfbc-preview.php`. Check base and premium themes at
+desktop and mobile widths, then select **Run interaction checks** to verify
+agreement handling, password visibility, age sliders, character counts, and Ajax retry.
+This preview only runs on PHP's local development server and uses no application data.
+
 ## Reporting bugs & proposing features
 
 - Bugs: use the [issue tracker](https://github.com/pH7Software/pH7-Social-Dating-CMS/issues) and the bug-report template.

--- a/_protected/framework/Layout/Form/Engine/PFBC/Element/Range.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Element/Range.php
@@ -1,11 +1,13 @@
 <?php
+
 /**
- * File created by Pierre-Henry Soria <hi@ph7.me>
+ * File created by Pierre-Henry Soria <hi@ph7.me>.
  */
 
 namespace PFBC\Element;
 
 use PFBC\Validation\Numeric;
+use PH7\Framework\Str\Str;
 
 class Range extends Textbox
 {
@@ -13,15 +15,29 @@ class Range extends Textbox
     {
         $this->attributes += [
             'type' => 'range', // Range Type
-            'id' => 'rangeInput',
-            'oninput' => 'rangeOutput.value = rangeInput.value'
+            'id' => 'rangeInput'
         ];
-        $this->validation[] = new Numeric;
+        $this->validation[] = new Numeric();
         parent::render();
 
-        echo <<<'HTML'
-            <strong><output id="rangeOutput"></output></strong>
-            <script>$(function(){$("#rangeOutput").val($("#rangeInput").val())});</script>
-HTML;
+        $sInputId = (new Str())->escapeAttribute($this->attributes['id']);
+        echo '<strong><output id="', $sInputId, '_output" for="', $sInputId, '"></output></strong>';
+    }
+
+    public function jQueryDocumentReady()
+    {
+        $sInputId = json_encode($this->attributes['id'], JSON_HEX_TAG);
+        $sOutputId = json_encode($this->attributes['id'] . '_output', JSON_HEX_TAG);
+
+        echo <<<JS
+        (function() {
+            var oInput = document.getElementById($sInputId);
+            var oOutput = document.getElementById($sOutputId);
+            oOutput.value = oInput.value;
+            jQuery(oInput).on("input", function() {
+                oOutput.value = this.value;
+            });
+        })();
+JS;
     }
 }

--- a/_protected/framework/Layout/Form/Engine/PFBC/Element/Textarea.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Element/Textarea.php
@@ -23,7 +23,7 @@ class Textarea extends Element
         // Derive maxlength from a Str validator so the counter shows the limit and the browser enforces it.
         $this->applyMaxLengthFromValidation();
 
-        echo '<textarea onkeyup="textCounter(\'', $this->attributes['id'], '\',\'', $this->attributes['id'], '_rem_len\')"', $this->getAttributes('value'), $this->getHtmlRequiredIfApplicable(), '>';
+        echo '<textarea oninput="textCounter(\'', $this->attributes['id'], '\',\'', $this->attributes['id'], '_rem_len\')"', $this->getAttributes('value'), $this->getHtmlRequiredIfApplicable(), '>';
 
         if (!empty($this->attributes['value'])) {
             echo $this->filter($this->attributes['value']);

--- a/_protected/framework/Layout/Form/Engine/PFBC/Form.class.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Form.class.php
@@ -445,7 +445,7 @@ class Form extends Base
         /*For ajax, an anonymous onsubmit javascript function is bound to the form using jQuery.  jQuery's
         serialize function is used to grab each element's name/value pair.*/
         if (!empty($this->ajax)) {
-            echo 'jQuery("#', $id, '").on("submit", {';
+            echo 'jQuery("#', $id, '").on("submit", function() {';
             $this->error->clear();
             echo <<<JS
             jQuery.ajax({
@@ -468,11 +468,24 @@ JS;
 
             echo '}';
 
+            $sAjaxFailure = json_encode(t('Unable to submit the form. Please try again.'));
+            echo <<<JS
+                },
+                error: function() {
+                    jQuery("<div>", {
+                        "class": "pfbc-error ui-state-error ui-corner-all",
+                        "role": "alert",
+                        text: $sAjaxFailure
+                    }).prependTo("#$id");
+                },
+                complete: function() {
+JS;
+
             if ($this->isNotJQueryUIButtons()) {
                 /* Same jQuery UI 1.12+ fallback as the submit handler above. */
                 echo 'var $pfbcBtnReset = jQuery("#', $id, ' button[type=submit] span.ui-button-text");';
                 echo 'if (!$pfbcBtnReset.length) { $pfbcBtnReset = jQuery("#', $id, ' button[type=submit]"); }';
-                echo '$pfbcBtnReset.css("padding-right", "1em").find("img").remove();';
+                echo '$pfbcBtnReset.css("padding-right", "").find("img.pfbc-loading").remove();';
                 echo 'jQuery("#', $id, ' button[type=submit]").button("enable");';
             } else {
                 echo 'jQuery("#', $id, '").find("button[type=submit]").removeAttr("disabled");';

--- a/_protected/framework/Layout/Form/Engine/PFBC/View.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/View.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *  This file has been modified by pH7 developers team (Pierre-Henry SORIA).
  */
@@ -35,12 +36,12 @@ abstract class View extends Base
     {
         $id = $this->form->getId();
 
-        /*For ease-of-use, default styles are applied to form elements.*/
+        /* For ease-of-use, default styles are applied to form elements. */
         if (!in_array('style', $this->form->getPrevent(), true)) {
             echo <<<CSS
 #$id .pfbc-label label{font-weight:bold}
-#$id em{font-size:.9em;color:#888}
-#$id .pfbc-label strong{color:#990000}
+#$id em{font-size:.9em;color:var(--ph7-text-muted, #888)}
+#$id .pfbc-label strong{color:var(--ph7-error, #990000)}
 #$id img.pfbc-loading{position:absolute;top:50%;right:.5em;margin-top:-8px;border:0}
 CSS;
         }
@@ -52,8 +53,6 @@ CSS;
 
     /**
      * This method encapsulates the various pieces that are included in an element's label.
-     *
-     * @param Element $element
      */
     protected function renderLabel(Element $element)
     {

--- a/_protected/framework/Layout/Form/Engine/PFBC/View/Horizontal.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/View/Horizontal.php
@@ -1,7 +1,8 @@
 <?php
+
 /**
  * Changes made in this code from original PFBC's version.
- * By Pierre-Henry Soria <https://ph7.me>
+ * By Pierre-Henry Soria <https://ph7.me>.
  */
 
 namespace PFBC\View;
@@ -52,7 +53,7 @@ class Horizontal extends View
 
         parent::renderCSS();
         echo <<<CSS
-#$id .pfbc-element { float: left; margin-right: .5em; }
+#$id .pfbc-element { float: left; margin: 0 .5em .5em 0; max-width: 100%; }
 #$id .pfbc-label strong { color: #990000; }
 #$id .pfbc-label { float: left; margin-right: .25em; }
 CSS;

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/RangeTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/RangeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Layout / Form / Engine / PFBC / Element
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout\Form\Engine\PFBC\Element;
+
+require_once PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+
+use PFBC\Element\Range;
+use PFBC\Form;
+use PHPUnit\Framework\TestCase;
+
+final class RangeTest extends TestCase
+{
+    public function testCountersUseEachFieldsActualId(): void
+    {
+        $oForm = new Form('range_test');
+        $oAge = new Range('Age', 'age', ['value' => 30, 'min' => 18, 'max' => 99]);
+        $oDistance = new Range('Distance', 'distance', ['id' => 'distance', 'value' => 10]);
+        $oForm->addElement($oAge);
+        $oForm->addElement($oDistance);
+        $sHtml = $oForm->render(true);
+
+        foreach ([$oAge->getID(), $oDistance->getID()] as $sId) {
+            $this->assertStringContainsString('id="' . $sId . '_output" for="' . $sId . '"', $sHtml);
+            $this->assertStringContainsString('document.getElementById("' . $sId . '")', $sHtml);
+            $this->assertStringContainsString('document.getElementById("' . $sId . '_output")', $sHtml);
+        }
+        $this->assertStringNotContainsString('rangeInput', $sHtml);
+        $this->assertStringNotContainsString('rangeOutput', $sHtml);
+    }
+}

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TextboxMaxLengthTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TextboxMaxLengthTest.php
@@ -66,6 +66,7 @@ final class TextboxMaxLengthTest extends TestCase
 
         $this->assertStringContainsString('maxlength="2000"', $sHtml);
         $this->assertStringContainsString('/ 2000', $sHtml); // the "N / MAX" counter suffix
+        $this->assertStringContainsString('oninput="textCounter(', $sHtml);
     }
 
     private function render($oElement): string

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/FormAjaxTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/FormAjaxTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / Framework / Layout / Form / Engine / PFBC
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout\Form\Engine\PFBC;
+
+require_once PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+
+use PFBC\Element\Button;
+use PFBC\Form;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FormAjaxTest extends TestCase
+{
+    #[DataProvider('buttonProviders')]
+    public function testAjaxRendersAHandlerWithRetryAfterFailure(bool $bUseWidget): void
+    {
+        $oForm = new Form('ajax_retry');
+        $oForm->configure([
+            'ajax' => true,
+            'action' => '/submit',
+            'prevent' => $bUseWidget ? [] : ['jQueryUIButtons']
+        ]);
+        $oForm->addElement(new Button('Save'));
+
+        $sHtml = $oForm->render(true);
+
+        $this->assertStringNotContainsString('.on("submit", {', $sHtml);
+        $this->assertSame(2, substr_count($sHtml, '.on("submit", function() {'));
+        $this->assertStringContainsString('error: function()', $sHtml);
+        $this->assertStringContainsString('"role": "alert"', $sHtml);
+        $this->assertStringContainsString('Unable to submit the form. Please try again.', $sHtml);
+
+        $sComplete = substr($sHtml, strpos($sHtml, 'complete: function()'));
+        if ($bUseWidget) {
+            $this->assertStringContainsString('.button("enable")', $sComplete);
+            $this->assertStringContainsString('.find("img.pfbc-loading").remove()', $sComplete);
+        } else {
+            $this->assertStringContainsString('.removeAttr("disabled")', $sComplete);
+            $this->assertStringNotContainsString('.button(', $sHtml);
+        }
+    }
+
+    public static function buttonProviders(): array
+    {
+        return ['jQuery UI' => [true], 'plain HTML' => [false]];
+    }
+}

--- a/_tools/pfbc-preview.js
+++ b/_tools/pfbc-preview.js
@@ -1,0 +1,69 @@
+/* Browser regression checks for the real PFBC preview; no application data is used. */
+(function ($) {
+    'use strict';
+
+    $('#run_checks').on('click', async function () {
+        $(this).prop('disabled', true);
+        const aFailures = [];
+        let iAssertions = 0;
+        function assert(bCondition, sMessage) {
+            ++iAssertions;
+            if (!bCondition) {
+                aFailures.push(sMessage);
+            }
+        }
+
+        const $oJoin = $('#preview_join');
+        const $oLoginButton = $('#preview_login button[type=submit]');
+        const $oJoinButton = $oJoin.find('button[type=submit]');
+        const $oAgreement = $oJoin.find('input[name="agree[]"]');
+        $oAgreement.prop('checked', false).trigger('change');
+        assert(!$oLoginButton.prop('disabled'), 'Agreement must not disable login.');
+        assert($oJoinButton.prop('disabled'), 'Agreement must disable signup.');
+        assert($oJoinButton.button('option', 'disabled'), 'The button widget must track the disabled state.');
+        $oAgreement.prop('checked', true).trigger('change');
+        assert(!$oJoinButton.prop('disabled'), 'Agreement must re-enable signup.');
+        assert(!$oJoinButton.button('option', 'disabled'), 'The button widget must recover.');
+
+        const $oPassword = $oJoin.find('.pwd_field input');
+        const $oToggle = $oJoin.find('.pwd_toggle');
+        $oPassword.val('local-preview');
+        $oToggle.trigger('click');
+        assert($oPassword.attr('type') === 'text', 'Password reveal must work.');
+        assert($oToggle.attr('aria-pressed') === 'true', 'Password reveal must announce its state.');
+        $oToggle.trigger('click');
+        assert($oPassword.attr('type') === 'password', 'Password hide must work.');
+        assert($oPassword.val() === 'local-preview', 'Toggling must preserve the password.');
+
+        const $oAge = $oJoin.find('input[name=age]');
+        const $oDistance = $oJoin.find('input[name=distance]');
+        assert(document.getElementById($oAge.attr('id') + '_output').value === '30', 'The age counter must show its initial value.');
+        $oAge.val('42').trigger('input');
+        assert(document.getElementById($oAge.attr('id') + '_output').value === '42', 'The age counter must follow the slider.');
+        assert(document.getElementById($oDistance.attr('id') + '_output').value === '10', 'Updating one slider must not change another counter.');
+        $oAge.val('30').trigger('input');
+
+        const $oDescription = $oJoin.find('textarea');
+        $oDescription.val('Pasted text').trigger('input');
+        assert(document.getElementById($oDescription.attr('id') + '_rem_len').textContent === '11', 'The counter must update on input, including paste.');
+
+        for (const sReply of ['validation', 'failure', 'plain']) {
+            const $oAjax = $('#preview_' + sReply);
+            const $oButton = $oAjax.find('button');
+            const oCompleted = new Promise((resolve) => $(document).one('ajaxStop', resolve));
+            $oAjax.trigger('submit');
+            assert($oButton.prop('disabled'), sReply + ': prevent duplicate submission.');
+            // A timeout makes a missing Ajax handler visibly fail instead of hanging the preview.
+            await Promise.race([oCompleted, new Promise((resolve) => setTimeout(resolve, 3000))]);
+            assert(!$oButton.prop('disabled'), sReply + ': allow retry after the response.');
+            assert(sReply === 'plain' ? !$oButton.data('ui-button') : !$oButton.button('option', 'disabled'), sReply + ': preserve the configured button mode.');
+            assert($oAjax.find('img.pfbc-loading').length === 0, sReply + ': remove the loading indicator.');
+            assert($oAjax.find('.pfbc-error').length === 1, sReply + ': show one actionable error.');
+            assert($oAjax.find('.pfbc-error').text().includes(sReply === 'validation' ? 'Please check your email address.' : 'Unable to submit the form. Please try again.'), sReply + ': explain how to recover.');
+        }
+
+        assert(document.documentElement.scrollWidth <= innerWidth, 'The page must fit the viewport.');
+        $('#preview_result').text(aFailures.length ? aFailures.join(' ') : iAssertions + ' checks passed.');
+        $(this).prop('disabled', false);
+    });
+})(jQuery);

--- a/_tools/pfbc-preview.php
+++ b/_tools/pfbc-preview.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Local PFBC preview and browser regression checks. No database or application login required.
+ * Run: php -S 127.0.0.1:8642 -t .
+ * Open: http://127.0.0.1:8642/_tools/pfbc-preview.php
+ *
+ * @author Pierre-Henry Soria <hello@ph7builder.com>
+ * @license MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+if (PHP_SAPI !== 'cli-server' || !in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true)) {
+    http_response_code(404);
+    exit;
+}
+
+if (isset($_GET['reply'])) {
+    header('Content-Type: application/json');
+    if ($_GET['reply'] === 'failure') {
+        http_response_code(503);
+        echo '{}';
+    } else {
+        echo json_encode(['errors' => ['Please check your email address.']]);
+    }
+    exit;
+}
+
+session_name('ph7_pfbc_preview');
+session_start();
+define('PH7', true);
+define('PH7_DS', '/');
+define('PH7_SH', '/');
+define('PH7_JS', 'js/');
+define('PH7_URL_STATIC', '/static/');
+define('PH7_PATH_PROTECTED', dirname(__DIR__) . '/_protected/');
+define('PH7_PATH_FRAMEWORK', PH7_PATH_PROTECTED . 'framework/');
+require PH7_PATH_FRAMEWORK . 'Loader/Autoloader.php';
+PH7\Framework\Loader\Autoloader::getInstance()->init();
+require PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+
+// Fixed English labels keep this isolated fixture independent of application settings.
+function t(string $sText): string
+{
+    return $sText;
+}
+
+function nt(string $sOne, string $sMany, int $iCount): string
+{
+    return $iCount === 1 ? $sOne : $sMany;
+}
+
+$sTheme = ($_GET['theme'] ?? '') === 'premium' ? 'premium' : 'base';
+$sScheme = ($_GET['scheme'] ?? '') === 'dark' ? 'dark' : 'light';
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PFBC form preview</title>
+    <link rel="stylesheet" href="/static/css/js/jquery/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="/static/css/bootstrap.css">
+    <link rel="stylesheet" href="/static/css/bootstrap_customize.css">
+    <?php foreach (['common', 'style', 'layout', 'color', 'form'] as $sCss): ?>
+    <link rel="stylesheet" href="/templates/themes/<?= $sTheme ?>/css/<?= $sCss ?>.css">
+    <?php endforeach; ?>
+    <style>
+    <?php
+    // Exercise the actual theme's dark rules without changing the developer's OS preferences.
+    echo str_replace('(prefers-color-scheme: dark)', $sScheme === 'dark' ? 'all' : 'not all', file_get_contents(dirname(__DIR__) . '/templates/themes/base/css/design_system.css'));
+    ?>
+    :root { color-scheme: <?= $sScheme ?>; }
+    </style>
+    <script src="/static/js/jquery/jquery.js"></script>
+</head>
+<body>
+<main class="container" style="padding: 24px 15px; max-width: 760px">
+    <h1>PFBC form preview</h1>
+    <p>Actual PFBC output with the bundled Bootstrap, jQuery and jQuery UI. Submissions stay in this local fixture.</p>
+    <p><a href="?theme=base">Base theme</a> · <a href="?theme=premium">Premium theme</a> · <a href="theme-preview.html">Theme style guide</a></p>
+    <p><a href="?theme=<?= $sTheme ?>&amp;scheme=light">Light appearance</a> · <a href="?theme=<?= $sTheme ?>&amp;scheme=dark">Dark appearance</a></p>
+    <h2>Login</h2>
+    <?php
+    $oLogin = new PFBC\Form('preview_login');
+    $oLogin->configure(['view' => new PFBC\View\Horizontal(), 'onsubmit' => 'return false']);
+    $oLogin->addElement(new PFBC\Element\Email('', 'email', ['placeholder' => 'Your email', 'aria-label' => 'Login email', 'style' => 'width:190px'], false));
+    $oLogin->addElement(new PFBC\Element\Password('', 'password', ['placeholder' => 'Your password', 'aria-label' => 'Login password', 'style' => 'width:190px']));
+    $oLogin->addElement(new PFBC\Element\Button('Login', 'submit', ['icon' => 'key']));
+    $oLogin->render();
+
+    $oForm = new PFBC\Form('preview_join');
+    $oForm->configure(['onsubmit' => 'return false']);
+    $oForm->addElement(new PFBC\Element\Textbox('Your first name', 'first_name', ['required' => 1, 'placeholder' => 'First name']));
+    $oForm->addElement(new PFBC\Element\Email('Your email', 'email', ['required' => 1, 'placeholder' => 'you@example.com'], false));
+    $oForm->addElement(new PFBC\Element\Password('Your password', 'password', ['description' => 'Use a unique password for this account.']));
+    $oForm->addElement(new PFBC\Element\Range('Age', 'age', ['value' => 30, 'min' => 18, 'max' => 99]));
+    $oForm->addElement(new PFBC\Element\Range('Distance', 'distance', ['value' => 10, 'min' => 1, 'max' => 100]));
+    $oForm->addElement(new PFBC\Element\Select('Country', 'country', ['AU' => 'Australia', 'BE' => 'Belgium']));
+    $oForm->addElement(new PFBC\Element\Select('Interests', 'interests', ['music' => 'Music', 'travel' => 'Travel', 'food' => 'Food'], ['multiple' => 1]));
+    $oForm->addElement(new PFBC\Element\Radio('Visibility', 'visibility', ['public' => 'Public profile', 'private' => 'Members only'], ['inline' => 1]));
+    $oForm->addElement(new PFBC\Element\Textarea('About you', 'description', ['maxlength' => 100]));
+    $oForm->addElement(new PFBC\Element\File('Profile photo', 'photo', ['accept' => 'image/*']));
+    $oForm->addElement(new PFBC\Element\Checkbox('', 'agree', [1 => 'I agree to the community guidelines.'], ['value' => 1]));
+    $oForm->addElement(new PFBC\Element\Button('Join now', 'submit', ['icon' => 'person']));
+    PFBC\Form::clearErrors('preview_join');
+    PFBC\Form::setError('preview_join', 'Please check your email address and try again.');
+    $oForm->render();
+    ?>
+    <h2>Ajax recovery</h2>
+    <?php
+    foreach (['validation', 'failure', 'plain'] as $sReply) {
+        $oAjax = new PFBC\Form('preview_' . $sReply);
+        $oAjax->configure([
+            'ajax' => true,
+            'action' => '?reply=' . ($sReply === 'plain' ? 'failure' : $sReply),
+            'prevent' => $sReply === 'plain' ? ['jQueryUIButtons'] : []
+        ]);
+        $oAjax->addElement(new PFBC\Element\Button('Test ' . $sReply, 'submit', $sReply === 'plain' ? ['class' => 'btn btn-danger'] : []));
+        $oAjax->render();
+    }
+    ?>
+    <h2>Browser regression checks</h2>
+    <button type="button" class="btn btn-default" id="run_checks">Run interaction checks</button>
+    <output id="preview_result" aria-live="polite"></output>
+</main>
+<script src="/static/js/bootstrap.js"></script>
+<script src="/static/js/str.js"></script>
+<script src="/static/js/password_toggle.js"></script>
+<script src="/static/js/jquery/jquery-ui.js"></script>
+<script src="/static/js/form.js"></script>
+<script src="pfbc-preview.js"></script>
+</body>
+</html>

--- a/static/js/form.js
+++ b/static/js/form.js
@@ -6,19 +6,29 @@
 
 const sButtonPattern = 'button[type=submit]';
 
-function enable_button() {
-    $(sButtonPattern).attr('disabled', false);
-    $(sButtonPattern).css({background: '#E6E6E6'});
+function enable_button(oForm) {
+    set_submit_disabled(oForm, false);
 }
 
-function disable_button() {
-    $(sButtonPattern).attr('disabled', 'disabled');
-    $(sButtonPattern).css({background: '#FFF'});
+function disable_button(oForm) {
+    set_submit_disabled(oForm, true);
+}
+
+function set_submit_disabled(oForm, bDisabled) {
+    const $oButtons = oForm ? $(oForm).find(sButtonPattern) : $(sButtonPattern);
+    $oButtons.each(function () {
+        const $oButton = $(this);
+        if ($oButton.data('ui-button')) {
+            $oButton.button('option', 'disabled', bDisabled);
+        } else {
+            $oButton.prop('disabled', bDisabled);
+        }
+    });
 }
 
 const sInputAgree = 'input[name="agree[]"]';
-$(sInputAgree).on('click', function () {
-    $(sInputAgree + ':checked').val() == 1 ? enable_button() : disable_button();
+$(sInputAgree).on('change', function () {
+    this.checked && this.value === '1' ? enable_button(this.form) : disable_button(this.form);
 });
 
 $('input[name=all_action]').on('click', function () {

--- a/static/js/password_toggle.js
+++ b/static/js/password_toggle.js
@@ -46,6 +46,7 @@
                     .toggleClass('pwd_toggle_active', bReveal);
             });
 
+            $oInput.wrap('<span class="pwd_field"></span>');
             $oInput.after($oButton);
         });
     });

--- a/templates/themes/base/css/design_system.css
+++ b/templates/themes/base/css/design_system.css
@@ -25,6 +25,8 @@
     --ph7-border: #e4e4ec;
     --ph7-text: #1c1c26;
     --ph7-text-muted: #6b6b7a;
+    --ph7-error: #a12622;
+    --ph7-error-bg: #fff2f1;
 
     /* Shape & elevation */
     --ph7-radius-sm: 8px;
@@ -53,6 +55,8 @@
         --ph7-border: #32323f;
         --ph7-text: #ececf2;
         --ph7-text-muted: #a2a2b2;
+        --ph7-error: #ffb4ab;
+        --ph7-error-bg: #362023;
         --ph7-shadow-sm: 0 1px 3px rgba(0, 0, 0, .4);
         --ph7-shadow: 0 6px 24px rgba(0, 0, 0, .5);
     }
@@ -158,6 +162,76 @@ input:focus, select:focus, textarea:focus {
     border-color: var(--ph7-primary);
     box-shadow: 0 0 0 3px var(--ph7-primary-soft);
     outline: none;
+}
+
+/* PFBC emits its own classes, without Bootstrap's .form-control. */
+input.pfbc-textbox:not([type=color]):not([type=range]),
+select.pfbc-select, textarea.pfbc-textarea {
+    min-height: 44px;
+    max-width: 100%;
+    font-size: 16px;
+    border-color: var(--ph7-border);
+    border-radius: var(--ph7-radius-sm);
+}
+
+input.pfbc-textbox::placeholder, textarea.pfbc-textarea::placeholder {
+    color: var(--ph7-text-muted);
+    opacity: 1;
+}
+
+input.pfbc-textbox:disabled, input.pfbc-textbox[readonly],
+select.pfbc-select:disabled, textarea.pfbc-textarea:disabled,
+textarea.pfbc-textarea[readonly] {
+    background-color: var(--ph7-surface);
+    color: var(--ph7-text-muted);
+}
+
+form input[type=file] {
+    max-width: 100%;
+}
+
+.pfbc-checkbox label, .pfbc-radio label {
+    min-height: 44px;
+    margin: 0;
+    padding: 12px 0;
+    font-weight: 400;
+    line-height: 20px;
+}
+
+.pfbc-checkbox input[type=checkbox], .pfbc-radio input[type=radio] {
+    width: 18px;
+    height: 18px;
+    margin: 13px 8px 0 0;
+    accent-color: var(--ph7-primary);
+}
+
+form button.ui-button[type=submit]:not(.btn) {
+    min-height: 44px;
+    margin: 0;
+    padding: .65em 1.1em;
+    border: 1px solid var(--ph7-primary);
+    background: var(--ph7-primary);
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    text-shadow: none;
+}
+
+form button.ui-button[type=submit]:not(.btn):hover,
+form button.ui-button[type=submit]:not(.btn):focus-visible {
+    background: var(--ph7-primary-dark);
+    border-color: var(--ph7-primary-dark);
+}
+
+form button.ui-button[type=submit]:not(.btn) .ui-icon {
+    filter: brightness(0) invert(1);
+}
+
+.pfbc-error.ui-state-error {
+    border: 1px solid var(--ph7-error);
+    background: var(--ph7-error-bg);
+    color: var(--ph7-error);
+    overflow-wrap: anywhere;
 }
 
 /** NATIVE COLOR INPUT (replaces the legacy jQuery colorpicker) **/
@@ -353,12 +427,32 @@ input[type=color]::-moz-color-swatch {
 }
 
 /** PASSWORD VISIBILITY TOGGLE (see static/js/password_toggle.js) **/
+.pwd_field {
+    display: flex;
+    position: relative;
+    max-width: 100%;
+    align-items: center;
+}
+
+.pwd_field > input[type] {
+    min-width: 0;
+    flex: 1 1 auto;
+    /* Keep text clear of the button, including on focus. */
+    padding-right: 52px;
+}
+
 .pwd_toggle {
-    margin-left: .4em;
-    padding: .25em .55em;
-    border: 1px solid var(--ph7-border);
-    border-radius: var(--ph7-radius-sm);
-    background-color: var(--ph7-surface);
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 44px;
+    margin: 0;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 0 var(--ph7-radius-sm) var(--ph7-radius-sm) 0;
+    background-color: transparent;
+    color: var(--ph7-text);
     font-size: 1em;
     line-height: 1;
     cursor: pointer;

--- a/templates/themes/base/css/form.css
+++ b/templates/themes/base/css/form.css
@@ -51,9 +51,9 @@ input:not([type=image]):not([type=range]), textarea, select {
     box-sizing: border-box;
     font-size: 14px;
     border: 1px solid #ccc;
-    color: #3F3F3F;
-    text-shadow: 0 1px 0 rgba(200, 200, 200, .6);
-    box-shadow: 1px 1px 4px #aaa inset;
+    color: var(--ph7-text, #3F3F3F);
+    text-shadow: none;
+    box-shadow: none;
     border-radius: 5px;
     transition: border linear 0.3s, box-shadow linear 0.3s;
     -webkit-transition: border linear 0.3s, box-shadow linear 0.3s;
@@ -62,20 +62,13 @@ input:not([type=image]):not([type=range]), textarea, select {
     -ms-transition: border linear 0.3s, box-shadow linear 0.3s;
     -khtml-transition: border linear 0.3s, box-shadow linear 0.3s;
 
-    transition: padding .25s;
-    -moz-transition: padding .25s;
-    -webkit-transition: padding .25s;
-    -o-transition: padding .25s;
-    -ms-transition: padding .25s;
-    -khtml-transition: padding .25s;
     white-space: nowrap;
 }
 
 input:focus:not([type=image]):not([type=range]):not(.form_link), textarea:focus, select:focus {
     outline: 0;
-    border-color: rgba(82, 168, 236, .8);
-    box-shadow: 1px 1px 4px #aaa inset, 0 0 8px rgba(82, 168, 236, .6);
-    padding-right: 10px;
+    border-color: var(--ph7-primary, rgba(82, 168, 236, .8));
+    box-shadow: 0 0 0 3px var(--ph7-primary-soft, rgba(82, 168, 236, .2));
 }
 
 input, textarea {

--- a/templates/themes/premium/css/form.css
+++ b/templates/themes/premium/css/form.css
@@ -51,10 +51,10 @@ input:not([type=image]):not([type=range]), textarea, select {
     box-sizing: border-box;
     font-size: 14px;
     border: 1px solid #ccc;
-    color: #3F3F3F;
-    text-shadow: 0 1px 0 rgba(200, 200, 200, .6);
-    box-shadow: 1px 1px 4px #aaa inset;
-    border-radius: 5px !important;
+    color: var(--ph7-text, #3F3F3F);
+    text-shadow: none;
+    box-shadow: none;
+    border-radius: 5px;
     transition: border linear 0.3s, box-shadow linear 0.3s;
     -webkit-transition: border linear 0.3s, box-shadow linear 0.3s;
     -moz-transition: border linear 0.3s, box-shadow linear 0.3s;
@@ -62,20 +62,13 @@ input:not([type=image]):not([type=range]), textarea, select {
     -ms-transition: border linear 0.3s, box-shadow linear 0.3s;
     -khtml-transition: border linear 0.3s, box-shadow linear 0.3s;
 
-    transition: padding .25s;
-    -moz-transition: padding .25s;
-    -webkit-transition: padding .25s;
-    -o-transition: padding .25s;
-    -ms-transition: padding .25s;
-    -khtml-transition: padding .25s;
     white-space: nowrap;
 }
 
 input:focus:not([type=image]):not([type=range]):not(.form_link), textarea:focus, select:focus {
     outline: 0;
-    border-color: rgba(82, 168, 236, .8);
-    box-shadow: 1px 1px 4px #aaa inset, 0 0 8px rgba(82, 168, 236, .6);
-    padding-right: 10px;
+    border-color: var(--ph7-primary, rgba(82, 168, 236, .8));
+    box-shadow: 0 0 0 3px var(--ph7-primary-soft, rgba(82, 168, 236, .2));
 }
 
 input, textarea {


### PR DESCRIPTION
Improve PFBC readability and mobile spacing with the existing theme styles. Fix cross-form agreement controls, Ajax retry, pasted-text counters and signup age sliders.

Verified with 32 browser checks across base/premium, light/dark and 320/1280px layouts; PHPStan; the 891-test suite; and the final 19-test PFBC suite. Includes a local-only regression preview. No dependency or database changes.

This verifies the shared form components, not every installed-site workflow.

Best, [Pierre-Henry](https://github.com/pH-7)
