### PR TITLE
Fix autocomplete compatibility with current jQuery UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ desktop and mobile widths, then select **Run interaction checks** to verify
 agreement handling, password visibility, age sliders, character counts, and Ajax retry.
 This preview only runs on PHP's local development server and uses no application data.
 
+Use `_tools/autocomplete-preview.html` on the same server to check recipient and
+city suggestions. Its interaction checks use fixed mock responses; they do not
+contact members or GeoNames and do not verify the external provider's availability.
+
 ## Reporting bugs & proposing features
 
 - Bugs: use the [issue tracker](https://github.com/pH7Software/pH7-Social-Dating-CMS/issues) and the bug-report template.

--- a/_protected/app/system/core/assets/ajax/autocompleteUsernameCoreAjax.php
+++ b/_protected/app/system/core/assets/ajax/autocompleteUsernameCoreAjax.php
@@ -1,12 +1,13 @@
 <?php
+
 /**
  * @title          Autocomplete Username File
+ *
  * @desc           This file can suggest a list of user name with jQuery and Ajax.
  *
  * @author         Pierre-Henry Soria <hello@ph7builder.com>
  * @copyright      (c) 2012-2019, Pierre-Henry Soria. All Rights Reserved.
  * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
- * @package        PH7 / App / System / Core / Asset / Ajax
  */
 
 namespace PH7;
@@ -21,19 +22,22 @@ const AVATAR_SIZE = 32;
 
 // Only for members
 if (UserCore::auth()) {
-    $oHttpRequest = new HttpRequest;
+    $oHttpRequest = new HttpRequest();
 
     if ($oHttpRequest->postExists('username')) {
-        if ($oUsernameResult = (new UserCoreModel)->getUsernameList($oHttpRequest->post('username'))) {
+        if ($oUsernameResult = (new UserCoreModel())->getUsernameList($oHttpRequest->post('username'))) {
+            $iCurrentProfileId = (int)(new Session())->get('member_id');
             echo '<users><ul>';
             foreach ($oUsernameResult as $oList) {
                 // Don't include the current signed in user profile, won't make sense for the user to see their-self
-                if ($oList->profileId == (new Session)->get('member_id')) break;
+                if ((int)$oList->profileId === $iCurrentProfileId) {
+                    continue;
+                }
 
                 echo '<li>
                         <username>', escape($oList->username, true), '</username>
-                        <avatar>', (new Design)->getUserAvatar($oList->username, $oList->sex, AVATAR_SIZE), '</avatar>
-                      </ul>';
+                        <avatar>', (new Design())->getUserAvatar($oList->username, $oList->sex, AVATAR_SIZE), '</avatar>
+                      </li>';
             }
             echo '</ul></users>';
         }

--- a/_tests/Unit/App/System/Core/Assets/Ajax/AutocompleteUsernameResponseTest.php
+++ b/_tests/Unit/App/System/Core/Assets/Ajax/AutocompleteUsernameResponseTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ * @package          PH7 / Test / Unit / App / System / Core / Assets / Ajax
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Core\Assets\Ajax;
+
+use PHPUnit\Framework\TestCase;
+
+final class AutocompleteUsernameResponseTest extends TestCase
+{
+    public function testSkippingCurrentMemberPreservesLaterSuggestions(): void
+    {
+        class_alias(AutocompleteMemberStub::class, 'PH7\UserCore');
+        class_alias(AutocompleteModelStub::class, 'PH7\UserCoreModel');
+        class_alias(AutocompleteSessionStub::class, 'PH7\Framework\Session\Session');
+        class_alias(AutocompleteRequestStub::class, 'PH7\Framework\Mvc\Request\Http');
+        class_alias(AutocompleteAvatarStub::class, 'PH7\Framework\Layout\Html\Design');
+
+        ob_start();
+        require PH7_PATH_SYS . 'core/assets/ajax/autocompleteUsernameCoreAjax.php';
+        $sResponse = ob_get_clean();
+
+        $oXml = simplexml_load_string($sResponse);
+        $this->assertNotFalse($oXml);
+        $this->assertSame(2, $oXml->ul->li->count());
+        $this->assertSame('alex', (string)$oXml->ul->li[0]->username);
+        $this->assertSame('sam', (string)$oXml->ul->li[1]->username);
+        $this->assertSame('https://example.com/sam.svg', (string)$oXml->ul->li[1]->avatar);
+    }
+}
+
+final class AutocompleteMemberStub
+{
+    public static function auth(): bool
+    {
+        return true;
+    }
+}
+
+final class AutocompleteModelStub
+{
+    public function getUsernameList(string $sQuery): array
+    {
+        return [
+            (object)['profileId' => 1, 'username' => 'alex', 'sex' => 'male'],
+            (object)['profileId' => '2', 'username' => 'current', 'sex' => 'male'],
+            (object)['profileId' => 3, 'username' => 'sam', 'sex' => 'female']
+        ];
+    }
+}
+
+final class AutocompleteSessionStub
+{
+    public function get(string $sKey): int
+    {
+        return 2;
+    }
+}
+
+final class AutocompleteRequestStub
+{
+    public function postExists(string $sKey): bool
+    {
+        return true;
+    }
+
+    public function post(string $sKey): string
+    {
+        return 'a';
+    }
+}
+
+final class AutocompleteAvatarStub
+{
+    public function getUserAvatar(string $sUsername, string $sSex, int $iSize): void
+    {
+        echo 'https://example.com/' . $sUsername . '.svg';
+    }
+}

--- a/_tests/Unit/Root/GeoAutocompleteTest.php
+++ b/_tests/Unit/Root/GeoAutocompleteTest.php
@@ -23,7 +23,9 @@ final class GeoAutocompleteTest extends TestCase
 
         $this->assertIsString($sScript);
         $this->assertIsString($sDocumentation);
-        $this->assertStringContainsString('https://secure.geonames.org/searchJSON?', $sScript);
+        $this->assertStringContainsString("url: 'https://secure.geonames.org/searchJSON',", $sScript);
+        $this->assertStringContainsString('username: sGeonamesUsername', $sScript);
+        $this->assertStringContainsString('country: sCountry', $sScript);
         $this->assertStringContainsString("autocompleteCityInit('ph7cms')", $sScript);
         $this->assertStringNotContainsString('http://ws.geonames.org', $sScript);
         $this->assertStringNotContainsString('http://www.geonames.org', $sScript);

--- a/_tools/autocomplete-preview.html
+++ b/_tools/autocomplete-preview.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Autocomplete compatibility preview</title>
+    <link rel="stylesheet" href="/static/css/js/jquery/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="/static/css/bootstrap.css">
+    <link rel="stylesheet" href="/templates/themes/base/css/form.css">
+    <link rel="stylesheet" href="/templates/themes/base/css/design_system.css">
+    <script src="/static/js/jquery/jquery.js"></script>
+    <script src="/static/js/jquery/jquery-ui.js"></script>
+    <script src="autocomplete-preview.js"></script>
+    <script src="/static/js/autocompleteUsername.js"></script>
+    <script src="/static/js/geo/autocompleteCity.js"></script>
+</head>
+<body>
+<main class="container" style="padding:24px 15px; max-width:760px">
+    <h1>Autocomplete preview</h1>
+    <p>Real application scripts and jQuery UI, with fixed mock responses. No member lookup or GeoNames request is sent.</p>
+    <form onsubmit="return false">
+        <p><label for="recipient">Recipient</label><input class="form-control" id="recipient"></p>
+        <p><label for="str_country">Country</label><select class="form-control" id="str_country"><option value="AU">Australia</option><option value="BE">Belgium</option></select></p>
+        <p><label for="str_city">City</label><input class="form-control" id="str_city"></p>
+        <p><label for="str_state">State</label><input class="form-control" id="str_state"></p>
+        <p><label for="str_zip_code">Postcode</label><input class="form-control" id="str_zip_code"></p>
+    </form>
+    <button type="button" class="btn btn-primary" id="run_autocomplete_checks">Run autocomplete checks</button>
+    <output id="autocomplete_result" aria-live="polite"></output>
+</main>
+</body>
+</html>

--- a/_tools/autocomplete-preview.js
+++ b/_tools/autocomplete-preview.js
@@ -1,0 +1,90 @@
+/* Isolated browser fixture: mock responses exercise the real application scripts. */
+window.pH7Url = {base: '/preview/'};
+(function ($) {
+    'use strict';
+
+    let sReply = 'success';
+    const aRequests = [];
+    $.ajax = function (oOptions) {
+        aRequests.push(oOptions);
+        setTimeout(function () {
+            if (sReply === 'failure') {
+                if (oOptions.error) oOptions.error({}, 'error');
+                if (oOptions.complete) oOptions.complete({}, 'error');
+                return;
+            }
+            let mResponse;
+            if (oOptions.url.includes('autocompleteUsername')) {
+                const sAvatar = location.origin + '/templates/themes/base/img/icon/visitor_no_picture-32.svg';
+                mResponse = '<users><ul><li><username>alex</username><avatar>' + sAvatar + '</avatar></li>' +
+                    '<li><username>sam</username><avatar>' + sAvatar + '</avatar></li>' +
+                    '<li><username>&lt;b&gt;literal&lt;/b&gt;</username><avatar>javascript:void(0)</avatar></li></ul></users>';
+            } else if (oOptions.url.includes('geonames.org')) {
+                mResponse = sReply === 'malformed' ? {} : {geonames: [
+                    {name: 'Sydney', adminName1: 'New South Wales', postalcode: '2000', countryName: 'Australia'},
+                    {name: 'Melbourne', adminName1: 'Victoria', countryName: 'Australia'}
+                ]};
+            } else {
+                throw new Error('Unexpected request in isolated autocomplete preview.');
+            }
+            if (oOptions.success) oOptions.success(mResponse);
+            if (oOptions.complete) oOptions.complete({responseText: mResponse}, 'success');
+        }, 0);
+    };
+
+    $(function () {
+        $('#run_autocomplete_checks').on('click', async function () {
+            $(this).prop('disabled', true);
+            let iAssertions = 0;
+            const aFailures = [];
+            function assert(bCondition, sMessage) {
+                ++iAssertions;
+                if (!bCondition) aFailures.push(sMessage);
+            }
+            async function search($oField) {
+                const oResponse = new Promise((resolve) => $oField.one('autocompleteresponse', resolve));
+                $oField.trigger('focus').autocomplete('search', 's');
+                await Promise.race([oResponse, new Promise((resolve) => setTimeout(resolve, 1000))]);
+            }
+
+            const $oRecipient = $('#recipient');
+            sReply = 'success';
+            await search($oRecipient);
+            const $oUsers = $oRecipient.autocomplete('widget');
+            assert($oUsers.find('.ui-menu-item').length === 3, 'Render every suggested recipient.');
+            assert($oUsers.find('img').length === 2, 'Render avatars with current jQuery UI markup.');
+            assert($oUsers.find('b').length === 0, 'Treat usernames as text.');
+            assert($oUsers.find('img[src^="javascript:"]').length === 0, 'Ignore unsafe avatar URLs.');
+            const oBounds = $oUsers[0].getBoundingClientRect();
+            assert(oBounds.left >= 0 && oBounds.right <= innerWidth, 'Keep recipient suggestions inside the viewport.');
+            $oUsers.find('.ui-menu-item-wrapper').first().trigger('click');
+            assert($oRecipient.val() === 'alex', 'Selecting a recipient must fill the field.');
+            sReply = 'failure';
+            await search($oRecipient);
+            assert($oRecipient.autocomplete('instance').pending === 0, 'Clear recipient loading state after failure.');
+
+            const $oCity = $('#str_city');
+            $('#str_country').val('AU');
+            $('#str_state').val('Unchanged');
+            sReply = 'success';
+            await search($oCity);
+            assert(aRequests[aRequests.length - 1].data.country === 'AU', 'Read the country without requiring a mouse click.');
+            $oCity.trigger('mousemove');
+            assert($('#str_state').val() === 'Unchanged', 'Do not copy details from unselected cities.');
+            $oCity.autocomplete('widget').find('.ui-menu-item-wrapper').first().trigger('click');
+            assert($('#str_state').val() === 'New South Wales' && $('#str_zip_code').val() === '2000', 'Use the selected city details.');
+            await search($oCity);
+            $oCity.autocomplete('widget').find('.ui-menu-item-wrapper').last().trigger('click');
+            assert($('#str_state').val() === 'Victoria' && $('#str_zip_code').val() === '', 'Clear a previous postcode when the selected city has none.');
+            for (const sFailure of ['malformed', 'failure']) {
+                sReply = sFailure;
+                await search($oCity);
+                assert($oCity.autocomplete('instance').pending === 0, sFailure + ': clear city loading state.');
+            }
+            sReply = 'success';
+            assert(document.documentElement.scrollWidth <= innerWidth, 'Avoid horizontal page overflow.');
+            $('#autocomplete_result').text(aFailures.length ? aFailures.join(' ') : iAssertions + ' checks passed.');
+            $(this).prop('disabled', false);
+        });
+    });
+})(jQuery);

--- a/static/js/autocompleteUsername.js
+++ b/static/js/autocompleteUsername.js
@@ -5,37 +5,47 @@
  */
 
 $(document).ready(function () {
-    $('input#recipient').autocomplete({
-        source: function (request, callback) {
-            var dataString = {username: request.term};
+    var $oRecipient = $('input#recipient');
+    if (!$oRecipient.length) {
+        return;
+    }
+
+    var oAutocomplete = $oRecipient.autocomplete({
+        position: {collision: 'flipfit'},
+        source: function (oRequest, oResponse) {
             $.ajax({
                 type: 'POST',
                 url: pH7Url.base + 'asset/ajax/autocompleteUsername',
-                data: dataString,
-                //cache: false,
-                complete: function (oXhr, sResult) {
-                    if (sResult != 'success') return;
-                    var response = oXhr.responseText;
-                    var usernames = [];
-                    $(response).find('li username').each(function () {
-                        usernames.push($(this).text());
-                    });
-                    callback(usernames);
-
-                    var oUl = $('input#recipient').autocomplete('widget');
-                    $(response).find('li avatar').each(function (sIndex) {
-                        var img = $(this).text();
-                        $(oUl).find('li:eq(' + sIndex + ') a')
-                            .wrapInner('<span style="position:relative;top:-7px;left:10px"></span>')
-                            .prepend('<img src="' + img + '" class="avatar" alt="Avatar" />');
-
-                    });
+                data: {username: oRequest.term},
+                dataType: 'html',
+                success: function (sHtml) {
+                    var aUsers = $($.parseHTML(sHtml)).find('li').map(function () {
+                        var $oUser = $(this);
+                        return {
+                            label: $oUser.find('username').text(),
+                            value: $oUser.find('username').text(),
+                            avatar: $oUser.find('avatar').text()
+                        };
+                    }).get();
+                    oResponse(aUsers);
+                },
+                error: function () {
+                    oResponse([]);
                 }
             });
-        },
-        open: function () {
-            var oUl = $(this).autocomplete('widget');
-            oUl.css('width', '400px');
         }
-    })
+    }).autocomplete('instance');
+
+    oAutocomplete._renderItem = function ($oList, oItem) {
+        var $oContent = $('<div>').css({display: 'flex', gap: '8px', alignItems: 'center', overflowWrap: 'anywhere'});
+        if (/^https?:\/\//i.test(oItem.avatar)) {
+            $oContent.append($('<img>', {src: oItem.avatar, 'class': 'avatar', alt: '', width: 32, height: 32}));
+        }
+        $oContent.append($('<span>').text(oItem.label));
+        return $('<li>').append($oContent).appendTo($oList);
+    };
+
+    oAutocomplete._resizeMenu = function () {
+        this.menu.element.outerWidth(Math.min(Math.max(this.element.outerWidth(), 240), $(window).width() - 24));
+    };
 });

--- a/static/js/geo/autocompleteCity.js
+++ b/static/js/geo/autocompleteCity.js
@@ -14,20 +14,18 @@ $(document).ready(function () {
 });
 
 function autocompleteCityInit(sGeonamesUsername) {
-    // Set "country" API parameter
-    var sUrlSlug = '';
-    $('#str_city').click(function () {
-        sUrlSlug = '&country=' + $('#str_country').val();
-    });
-
     $('#str_city').autocomplete(
         {
             source: function (oRequest, oResponse) {
+                var sCountry = $('#str_country').val() || '';
                 $.ajax(
                     {
-                        url: 'https://secure.geonames.org/searchJSON?username=' + sGeonamesUsername + sUrlSlug,
+                        url: 'https://secure.geonames.org/searchJSON',
                         dataType: 'jsonp',
+                        timeout: 10000,
                         data: {
+                            username: sGeonamesUsername,
+                            country: sCountry,
                             featureClass: 'P',
                             style: 'full',
                             maxRows: 12,
@@ -35,25 +33,30 @@ function autocompleteCityInit(sGeonamesUsername) {
                         },
                         success: function (oData) {
                             // Check if "geonames" exists. When the API returns an error message, it won't return "geonames"
-                            if (!oData.geonames) {
-                                if (oData.status.message) {
+                            if (!oData || !Array.isArray(oData.geonames)) {
+                                if (oData && oData.status && oData.status.message) {
                                     console.error(oData.status.message); // Display the error message from the API into the browser's log
                                 }
+                                oResponse([]);
                             } else {
                                 oResponse($.map(oData.geonames, function (oItem) {
-                                    $('#str_city').mousemove(function () {
-                                        $('#str_state').val((oItem.adminName1 ? oItem.adminName1 : ''));
-                                        $('#str_zip_code').val(oItem.postalcode);
-                                    });
-
                                     return {
-                                        label: oItem.name + (oItem.adminName1 ? ', ' + oItem.adminName1 : '') + (sUrlSlug.trim() ? '' : ', ' + oItem.countryName),
-                                        value: oItem.name
-                                    }
+                                        label: oItem.name + (oItem.adminName1 ? ', ' + oItem.adminName1 : '') + (sCountry ? '' : ', ' + oItem.countryName),
+                                        value: oItem.name,
+                                        state: oItem.adminName1 || '',
+                                        postal_code: oItem.postalcode || ''
+                                    };
                                 }));
                             }
+                        },
+                        error: function () {
+                            oResponse([]);
                         }
-                    })
+                    });
+            },
+            select: function (oEvent, oUi) {
+                $('#str_state').val(oUi.item.state);
+                $('#str_zip_code').val(oUi.item.postal_code);
             }
-        })
+        });
 }


### PR DESCRIPTION
Fix recipient avatars for current jQuery UI, keep suggestions within mobile screens, and clear loading states after failed requests. City details now come from the selected suggestion, including keyboard navigation. Skipping your own profile no longer hides later recipients.

Verified with 14 mocked browser checks at 320/1280px, keyboard selection, a PHP response regression test and PHPStan. Includes an isolated preview; live GeoNames availability is not covered.

Best, [Pierre-Henry](https://github.com/pH-7)
