### PR TITLE
Render PFBC age fields as native sliders

### DIFF
--- a/_protected/framework/Layout/Form/Engine/PFBC/Element/Range.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Element/Range.php
@@ -13,10 +13,8 @@ class Range extends Textbox
 {
     public function render()
     {
-        $this->attributes += [
-            'type' => 'range', // Range Type
-            'id' => 'rangeInput'
-        ];
+        $this->attributes['type'] = 'range';
+        $this->attributes += ['id' => 'rangeInput'];
         $this->validation[] = new Numeric();
         parent::render();
 

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/RangeTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/RangeTest.php
@@ -28,6 +28,9 @@ final class RangeTest extends TestCase
         $oForm->addElement($oDistance);
         $sHtml = $oForm->render(true);
 
+        $this->assertSame(2, substr_count($sHtml, 'type="range"'));
+        $this->assertStringNotContainsString('type="text"', $sHtml);
+        $this->assertStringContainsString('min="18" max="99"', $sHtml);
         foreach ([$oAge->getID(), $oDistance->getID()] as $sId) {
             $this->assertStringContainsString('id="' . $sId . '_output" for="' . $sId . '"', $sHtml);
             $this->assertStringContainsString('document.getElementById("' . $sId . '")', $sHtml);

--- a/_tools/pfbc-preview.js
+++ b/_tools/pfbc-preview.js
@@ -37,6 +37,8 @@
 
         const $oAge = $oJoin.find('input[name=age]');
         const $oDistance = $oJoin.find('input[name=distance]');
+        assert($oAge.attr('type') === 'range' && $oDistance.attr('type') === 'range', 'Render native sliders, not text boxes.');
+        assert($oAge.attr('min') === '18' && $oAge.attr('max') === '99', 'Preserve the configured age bounds.');
         assert(document.getElementById($oAge.attr('id') + '_output').value === '30', 'The age counter must show its initial value.');
         $oAge.val('42').trigger('input');
         assert(document.getElementById($oAge.attr('id') + '_output').value === '42', 'The age counter must follow the slider.');


### PR DESCRIPTION
The age field inherited `type="text"`, so it never displayed as a slider. Explicitly set `type="range"` and verify its age limits and keyboard-driven counter.

Passed the focused PHP test and 34 browser checks across base/premium, light/dark and mobile/desktop layouts.

Best, [Pierre-Henry](https://github.com/pH-7)
