### PR TITLE
Prepare pH7Builder v19.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip.sha256
-sha256sum -c pH7Builder-v19.0.0.zip.sha256
-unzip pH7Builder-v19.0.0.zip
-cd pH7Builder-v19.0.0
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip.sha256
+sha256sum -c pH7Builder-v19.0.1.zip.sha256
+unzip pH7Builder-v19.0.1.zip
+cd pH7Builder-v19.0.1
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:19.0.0 pH7Builder-v19.0.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.1 pH7Builder-v19.0.1 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '19.0.0';
+    public const SOFTWARE_VERSION = '19.0.1';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/framework/Compress/Compress.class.php
+++ b/_protected/framework/Compress/Compress.class.php
@@ -129,8 +129,8 @@ class Compress
             $sCssMinified = $this->executeYuiCompressor($oFileType);
             unlink($this->sTmpFilePath);
         } else {
-            // Backup any values within single or double quotes
-            preg_match_all('/(\'[^\']*?\'|"[^"]*?")/ims', $sContent, $aHit, PREG_PATTERN_ORDER);
+            // Skip comments so their quotes cannot capture and discard intervening CSS rules.
+            preg_match_all('~/\*.*?\*/(*SKIP)(*F)|(\'[^\']*?\'|"[^"]*?")~s', $sContent, $aHit, PREG_PATTERN_ORDER);
 
             for ($i = 0, $iCountHit = count($aHit[1]); $i < $iCountHit; $i++) {
                 $sContent = str_replace($aHit[1][$i], '##########' . $i . '##########', $sContent);

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '19.0.0';
+    public const KERNEL_VERSION = '19.0.1';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-08-28';
+    public const KERNEL_RELEASE_DATE = '2026-09-05';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_tests/Unit/Framework/Compress/CompressCssTest.php
+++ b/_tests/Unit/Framework/Compress/CompressCssTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria and pH7Builder contributors.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Compress;
+
+use PH7\Framework\Compress\Compress;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class CompressCssTest extends TestCase
+{
+    #[DataProvider('quotedCommentProvider')]
+    public function testQuotesInsideCommentsDoNotConsumeCssRules(string $sFirstComment, string $sLastComment): void
+    {
+        $sCss = $sFirstComment . "\n.pfbc-textbox { min-height: 44px; font-size: 16px; }\n" . $sLastComment;
+        $sMinified = $this->compressCss($sCss);
+
+        $this->assertStringContainsString('.pfbc-textbox{min-height:44px;font-size:16px}', $sMinified);
+        $this->assertStringNotContainsString('/*', $sMinified);
+    }
+
+    public static function quotedCommentProvider(): iterable
+    {
+        yield 'apostrophes' => ["/* Bootstrap's controls */", "/* form.css's selectors */"];
+        yield 'double quotes' => ['/* An unmatched " in a comment */', '/* Another " comment */'];
+        yield 'quoted values in comments' => ['/* "Quoted" and \'quoted\' comments */', '/* End */'];
+    }
+
+    public function testCompressionPreservesQuotedValues(): void
+    {
+        $sMinified = $this->compressCss('.label::after { content: "Your name"; }');
+
+        $this->assertStringContainsString('content:"Your name"', $sMinified);
+    }
+
+    public function testProductionDesignSystemRetainsPfbcRules(): void
+    {
+        $sCss = file_get_contents(dirname(__DIR__, 4) . '/templates/themes/base/css/design_system.css');
+        $this->assertIsString($sCss);
+        $sMinified = $this->compressCss($sCss);
+
+        foreach (['input.pfbc-textbox', '.pfbc-checkbox', '.pfbc-radio', '.pfbc-error.ui-state-error', '.pwd_field'] as $sSelector) {
+            $this->assertStringContainsString($sSelector, $sMinified);
+        }
+        $this->assertStringContainsString('min-height:44px', $sMinified);
+        $this->assertStringContainsString('font-size:16px', $sMinified);
+    }
+
+    private function compressCss(string $sCss): string
+    {
+        // Exercise the default PHP path without configuring optional external compilers.
+        $oCompress = (new ReflectionClass(Compress::class))->newInstanceWithoutConstructor();
+
+        return $oCompress->parseCss($sCss);
+    }
+}

--- a/_tests/Unit/Root/ReleaseDeploymentTest.php
+++ b/_tests/Unit/Root/ReleaseDeploymentTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace PH7\Test\Unit\Root;
 
+use PH7\Framework\Core\Kernel;
+use PH7\Framework\Security\Version;
 use PHPUnit\Framework\TestCase;
 
 final class ReleaseDeploymentTest extends TestCase
@@ -51,6 +53,9 @@ final class ReleaseDeploymentTest extends TestCase
             preg_match("/SOFTWARE_VERSION = '([^']+)'/", $sInstaller, $aInstallerVersion)
         );
         $this->assertSame($aFrameworkVersion[1], $aInstallerVersion[1]);
+        $this->assertSame($aFrameworkVersion[1], Kernel::SOFTWARE_VERSION);
+        $this->assertSame(Version::KERNEL_VERSION_NAME, Kernel::SOFTWARE_VERSION_NAME);
+        $this->assertSame(Version::KERNEL_BUILD, Kernel::SOFTWARE_BUILD);
     }
 
     public function testStableReleaseGuidesAreSynchronized(): void
@@ -66,6 +71,7 @@ final class ReleaseDeploymentTest extends TestCase
         );
 
         $sVersion = $aStableVersion[1];
+        $this->assertSame(Version::KERNEL_VERSION, $sVersion);
         $sReleaseUrl = "releases/download/v{$sVersion}/pH7Builder-v{$sVersion}.zip";
         $this->assertStringContainsString($sReleaseUrl, $sReadme);
         $this->assertStringContainsString($sReleaseUrl, $this->readFile('docs/QUICK_START.md'));

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.0/pH7Builder-v19.0.0.zip.sha256
-sha256sum -c pH7Builder-v19.0.0.zip.sha256
-unzip pH7Builder-v19.0.0.zip
-cp -a pH7Builder-v19.0.0/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip.sha256
+sha256sum -c pH7Builder-v19.0.1.zip.sha256
+unzip pH7Builder-v19.0.1.zip
+cp -a pH7Builder-v19.0.1/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v19.0.0` and run:
+For a source checkout instead, clone tag `v19.0.1` and run:
 
 ```console
-git clone --branch v19.0.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.0.0
-cd pH7Builder-v19.0.0
+git clone --branch v19.0.1 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.0.1
+cd pH7Builder-v19.0.1
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:19.0.0 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.1 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive

--- a/docs/RELEASE_NOTES_19.0.1.md
+++ b/docs/RELEASE_NOTES_19.0.1.md
@@ -1,0 +1,43 @@
+# pH7Builder 19.0.1 — Release Notes
+
+Released on 5 September 2026, this patch makes everyday forms clearer and fixes
+interactions with the bundled jQuery UI. It also includes the maintenance
+updates merged since 19.0.0.
+
+## Highlights
+
+- Improves base and premium form readability, touch targets, dark-mode colours,
+  error messages, and password-toggle layout.
+- Keeps agreement checkboxes from disabling buttons in unrelated forms.
+- Restores PFBC Ajax submission and lets users retry failed requests.
+- Renders age fields as native sliders with independent live counters, and
+  updates textarea character counts when text is pasted.
+- Restores recipient avatars and keyboard selection, fits suggestions to narrow
+  screens, and keeps results after the signed-in user's own profile is skipped.
+- Uses the selected city's state and postcode, respects the current country,
+  and clears autocomplete loading indicators after request failures.
+- Updates locked Symfony Console and Mailer patch versions, clarifies
+  shared-host SMTP setup and payment-provider limitations, and expands
+  regression coverage and isolated browser previews for contributors.
+
+## Compatibility and upgrade
+
+No intentional breaking changes. PHP 8.2+ and MySQL 8.0+ remain required, and
+the SQL schema stays at `1.6.6`. No database migration is needed from 19.0.0.
+Bootstrap, jQuery, and jQuery UI versions are unchanged in this patch.
+
+Back up first and test a staging copy. Preserve configuration, uploads, custom
+modules/themes, language packs, and credentials. Deploy PHP and browser assets
+together, install locked dependencies when deploying from source, remove the
+installer on existing sites, and clear application, CDN, and browser caches.
+Custom form overrides may need to incorporate the updated styles and markup.
+Follow the [Upgrade Guide](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.0.1/docs/UPGRADING.md).
+
+The `pH7Builder-v19.0.1.zip` asset includes production dependencies. Verify it
+with the attached `.sha256` file, then follow the
+[Quick Start](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.0.1/docs/QUICK_START.md) and
+[Launch Checklist](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.0.1/docs/LAUNCH_CHECKLIST.md).
+SMTP delivery, GeoNames availability, and payment processing must be tested
+with your own provider configuration before going live.
+
+[All changes since 19.0.0](https://github.com/pH7Software/pH7-Social-Dating-CMS/compare/v19.0.0...v19.0.1)

--- a/docs/RELEASE_NOTES_19.0.1.md
+++ b/docs/RELEASE_NOTES_19.0.1.md
@@ -8,6 +8,8 @@ updates merged since 19.0.0.
 
 - Improves base and premium form readability, touch targets, dark-mode colours,
   error messages, and password-toggle layout.
+- Preserves those form styles in production CSS bundles when comments contain
+  apostrophes or quotation marks.
 - Keeps agreement checkboxes from disabling buttons in unrelated forms.
 - Restores PFBC Ajax submission and lets users retry failed requests.
 - Renders age fields as native sliders with independent live counters, and

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,28 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 19.0.1 patch release
+
+pH7Builder 19.0.1 fixes form rendering, Ajax retries, age sliders, and recipient
+and city autocomplete. PHP 8.2+ and MySQL 8.0+ requirements are unchanged. The
+SQL schema remains `1.6.6`; no database migration is needed from 19.0.0.
+
+Back up and upgrade a staging copy first. Deploy the complete tagged 19.0.1
+package, preserving local configuration, uploads, custom modules and themes,
+language packs, and gateway credentials. The release ZIP includes production
+dependencies; source deployments must run `composer install --no-dev
+--prefer-dist --optimize-autoloader` to install the updated locked Symfony
+patches. Do not rerun the installer on an existing site; remove the deployed
+`_install` directory before reopening it.
+
+Clear application caches in Admin → Tools → Caches, purge any CDN asset cache,
+and refresh browser assets. Deploy the PHP, CSS, and JavaScript files together.
+Review custom themes that override the bundled form styles or password-toggle
+markup. Test signup, login, agreement checkboxes, age sliders, Ajax form retry,
+recipient suggestions, and city/state/postcode selection on desktop and mobile.
+External SMTP, GeoNames, and payment services still require deployment-specific
+checks. Sites older than 19.0.0 must also follow the applicable guidance below.
+
 ## 19.0.0 major release
 
 pH7Builder 19.0.0 is a code-only security, compatibility, and usability release

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:19.0.0 pH7Builder-v19.0.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.0.1 pH7Builder-v19.0.1 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder


### PR DESCRIPTION
Prepares v19.0.1 with matching runtime/installer versions, download links and upgrade notes. Also fixes a CSS compressor issue found during the fresh-install check: quotes in comments could hide the new form styles.

898 tests pass; PHPStan, dependency audits and the rebuilt ZIP checks pass. Fresh installation, installer cleanup, admin login and mobile form rendering are verified. No schema or runtime-requirement changes. Provider-specific email and payment tests remain deployment checks.

Best, [Pierre-Henry](https://github.com/pH-7)
