### PR TITLE
Prepare v19.1.0 with verified login and navigation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip.sha256
-sha256sum -c pH7Builder-v19.0.1.zip.sha256
-unzip pH7Builder-v19.0.1.zip
-cd pH7Builder-v19.0.1
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip.sha256
+sha256sum -c pH7Builder-v19.1.0.zip.sha256
+unzip pH7Builder-v19.1.0.zip
+cd pH7Builder-v19.1.0
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:19.0.1 pH7Builder-v19.0.1 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.1.0 pH7Builder-v19.1.0 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '19.0.1';
+    public const SOFTWARE_VERSION = '19.1.0';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/app/system/core/classes/UserBirthDateCore.php
+++ b/_protected/app/system/core/classes/UserBirthDateCore.php
@@ -17,13 +17,13 @@ class UserBirthDateCore
     public const NUMBER_ARRAY_ELEMENTS = 3;
 
     /**
-     * @param string $sBirthDate YYYY-MM-DD format
+     * @param string|null $sBirthDate YYYY-MM-DD format, or null for an incomplete profile
      *
      * @return int
      */
     public static function getAgeFromBirthDate($sBirthDate)
     {
-        $aAge = explode(self::BIRTHDATE_DELIMITER, $sBirthDate);
+        $aAge = explode(self::BIRTHDATE_DELIMITER, $sBirthDate ?? '');
 
         if (self::isInvalidBirthDate($aAge)) {
             return self::DEFAULT_AGE;

--- a/_protected/app/system/core/models/UserCoreModel.php
+++ b/_protected/app/system/core/models/UserCoreModel.php
@@ -111,7 +111,7 @@ class UserCoreModel extends Model
      * @param string $sPassword
      * @param string $sTable
      *
-     * @return bool|string (boolean "true" or string "message")
+     * @return bool|int true on success, otherwise a CredentialStatusCore error code
      */
     public function login($sEmail, $sPassword, $sTable = DbTableName::MEMBER)
     {

--- a/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
+++ b/_protected/app/system/modules/user/forms/processing/LoginFormProcess.php
@@ -44,9 +44,9 @@ class LoginFormProcess extends Form implements LoginableForm
             return;
         }
 
-        $sLogin = $this->oUserModel->login($sEmail, $sPassword);
-        if ($sLogin === CredentialStatusCore::INCORRECT_EMAIL_IN_DB || $sLogin === CredentialStatusCore::INCORRECT_PASSWORD_IN_DB) {
-            $this->handleLoginFailure($sLogin, $sEmail, $oSecurityModel);
+        $mLoginStatus = $this->oUserModel->login($sEmail, $sPassword);
+        if ($mLoginStatus === CredentialStatusCore::INCORRECT_EMAIL_IN_DB || $mLoginStatus === CredentialStatusCore::INCORRECT_PASSWORD_IN_DB) {
+            $this->handleLoginFailure($mLoginStatus, $sEmail, $oSecurityModel);
             return;
         }
 
@@ -134,10 +134,10 @@ class LoginFormProcess extends Form implements LoginableForm
     /**
      * Handles login failure logic for incorrect email or password.
      */
-    private function handleLoginFailure(string $sLoginStatus, string $sEmail, SecurityModel $oSecurityModel): void
+    private function handleLoginFailure(int $iLoginStatus, string $sEmail, SecurityModel $oSecurityModel): void
     {
         $this->preventBruteForce(self::BRUTE_FORCE_SLEEP_DELAY);
-        if ($sLoginStatus === CredentialStatusCore::INCORRECT_EMAIL_IN_DB) {
+        if ($iLoginStatus === CredentialStatusCore::INCORRECT_EMAIL_IN_DB) {
             $this->enableCaptcha();
             \PFBC\Form::setError(
                 'form_login_user',
@@ -149,7 +149,7 @@ class LoginFormProcess extends Form implements LoginableForm
                 'No Password',
                 'Failed! Incorrect Username'
             );
-        } elseif ($sLoginStatus === CredentialStatusCore::INCORRECT_PASSWORD_IN_DB) {
+        } elseif ($iLoginStatus === CredentialStatusCore::INCORRECT_PASSWORD_IN_DB) {
             $oSecurityModel->addLoginLog(
                 $sEmail,
                 'Guest',

--- a/_protected/framework/File/File.class.php
+++ b/_protected/framework/File/File.class.php
@@ -317,7 +317,7 @@ class File
             }
         } else {
             if (!is_dir($mDir)) {
-                if (!@mkdir($mDir, $iMode, true)) {
+                if (!@mkdir($mDir, $iMode, true) && !is_dir($mDir)) {
                     $sExceptMessage = 'Cannot create "%s" directory.<br /> Please verify that the directory permission is in writing mode.';
                     throw new PermissionException(sprintf($sExceptMessage, $mDir));
                 }

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,9 +51,9 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '19.0.1';
+    public const KERNEL_VERSION = '19.1.0';
     public const KERNEL_BUILD = '1';
-    public const KERNEL_RELEASE_DATE = '2026-09-05';
+    public const KERNEL_RELEASE_DATE = '2026-09-12';
 
     /*** Framework Server ***/
     public const KERNEL_TECHNOLOGY_NAME = 'pH7Builder.com';

--- a/_tests/Unit/App/System/Core/Classes/UserBirthDateCoreTest.php
+++ b/_tests/Unit/App/System/Core/Classes/UserBirthDateCoreTest.php
@@ -12,12 +12,26 @@ namespace PH7\Test\Unit\App\System\Core\Classes;
 
 require_once PH7_PATH_SYS . 'core/classes/UserBirthDateCore.php';
 
+use ErrorException;
 use PH7\UserBirthDateCore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class UserBirthDateCoreTest extends TestCase
 {
+    public function testMissingBirthDateDoesNotRaiseDeprecation(): void
+    {
+        set_error_handler(static function (int $iSeverity, string $sMessage): void {
+            throw new ErrorException($sMessage, 0, $iSeverity);
+        }, E_DEPRECATED);
+
+        try {
+            $this->assertSame(UserBirthDateCore::DEFAULT_AGE, UserBirthDateCore::getAgeFromBirthDate(null));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     #[DataProvider('invalidBirthDateProvider')]
     public function testInvalidAgeFromBirthDate(string $sBirthDate): void
     {

--- a/_tests/Unit/App/System/Module/User/Forms/Processing/LoginFormProcessTest.php
+++ b/_tests/Unit/App/System/Module/User/Forms/Processing/LoginFormProcessTest.php
@@ -10,10 +10,29 @@ declare(strict_types=1);
 
 namespace PH7\Test\Unit\App\System\Module\User\Forms\Processing;
 
+use PH7\CredentialStatusCore;
+use PH7\LoginFormProcess;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 final class LoginFormProcessTest extends TestCase
 {
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testFailureHandlerAcceptsIntegerCredentialStatuses(): void
+    {
+        require_once PH7_PATH_SYS . 'core/classes/CredentialStatusCore.php';
+        require_once PH7_PATH_SYS_MOD . 'user/forms/processing/LoginFormProcess.php';
+
+        $oStatusParameter = (new ReflectionMethod(LoginFormProcess::class, 'handleLoginFailure'))->getParameters()[0];
+
+        foreach ([CredentialStatusCore::INCORRECT_EMAIL_IN_DB, CredentialStatusCore::INCORRECT_PASSWORD_IN_DB] as $iStatus) {
+            $this->assertSame(get_debug_type($iStatus), (string)$oStatusParameter->getType());
+        }
+    }
+
     public function testMissingGeoLocationDoesNotBlockLogin(): void
     {
         $sSource = file_get_contents(

--- a/_tests/Unit/Framework/File/FileTest.php
+++ b/_tests/Unit/Framework/File/FileTest.php
@@ -11,11 +11,54 @@ declare(strict_types=1);
 namespace PH7\Test\Unit\Framework\File;
 
 use PH7\Framework\File\File;
+use PH7\Framework\File\Permission\PermissionException;
 use PHPUnit\Framework\TestCase;
 use ZipArchive;
 
 final class FileTest extends TestCase
 {
+    public function testCreateDirAcceptsDirectoryCreatedByAnotherWorker(): void
+    {
+        $oStream = new class {
+            public $context;
+            private static bool $bDirectoryExists = false;
+
+            public function url_stat(string $sPath, int $iFlags): array|false
+            {
+                return self::$bDirectoryExists ? ['mode' => 0040755] : false;
+            }
+
+            public function mkdir(string $sPath, int $iMode, int $iOptions): bool
+            {
+                // A competing worker creates the directory before mkdir returns.
+                self::$bDirectoryExists = true;
+
+                return false;
+            }
+        };
+        $this->assertTrue(stream_wrapper_register('ph7directoryrace', $oStream::class));
+
+        try {
+            (new File)->createDir('ph7directoryrace://cache');
+            $this->assertTrue(is_dir('ph7directoryrace://cache'));
+        } finally {
+            stream_wrapper_unregister('ph7directoryrace');
+        }
+    }
+
+    public function testCreateDirStillRejectsAFileAtTheDestination(): void
+    {
+        $sTarget = tempnam(sys_get_temp_dir(), 'ph7-create-dir-');
+        $this->assertNotFalse($sTarget);
+
+        try {
+            $this->expectException(PermissionException::class);
+            (new File)->createDir($sTarget);
+        } finally {
+            unlink($sTarget);
+        }
+    }
+
     // getFileExtWithDot
 
     public function testGetFileExtWithDotReturnsLowercaseDotExtension(): void

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -25,6 +25,18 @@ final class ThemeAssetTest extends TestCase
         'menu_inverse.css'
     ];
 
+    public function testDropdownPanelsDoNotClipNestedNavigation(): void
+    {
+        $sCss = file_get_contents(dirname(__DIR__, 3) . '/templates/themes/base/css/design_system.css');
+        self::assertIsString($sCss);
+        self::assertSame(1, preg_match('/^\.dropdown-menu\s*\{([^}]+)\}/m', $sCss, $aMatches));
+        self::assertStringContainsString('overflow: visible;', $aMatches[1]);
+
+        $sPreview = file_get_contents(dirname(__DIR__, 3) . '/_tools/theme-preview.html');
+        self::assertIsString($sPreview);
+        self::assertStringContainsString('dropdown-submenu open', $sPreview);
+    }
+
     public function testEveryThemeProvidesSharedLayoutAssets(): void
     {
         $sThemesDirectory = dirname(__DIR__, 3) . '/templates/themes';

--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -55,6 +55,19 @@ final class ThemeAssetTest extends TestCase
         }
     }
 
+    public function testPluginSurfacesUseThemeAwareTextAndBackgrounds(): void
+    {
+        $sCss = file_get_contents(dirname(__DIR__, 3) . '/templates/themes/base/css/design_system.css');
+        self::assertIsString($sCss);
+
+        foreach (['div.apprise .apprise-buttons button', '#tiptip_content'] as $sSelector) {
+            self::assertSame(1, preg_match('/^' . preg_quote($sSelector, '/') . '\\s*\\{([^}]+)\\}/m', $sCss, $aMatches));
+            self::assertStringContainsString('background: var(--ph7-', $aMatches[1]);
+            self::assertStringContainsString('color: var(--ph7-', $aMatches[1]);
+            self::assertStringContainsString('text-shadow: none;', $aMatches[1]);
+        }
+    }
+
     public function testEveryLocalCssImportResolves(): void
     {
         $sThemesDirectory = dirname(__DIR__, 3) . '/templates/themes';

--- a/_tests/Unit/Root/ThemePreviewTest.php
+++ b/_tests/Unit/Root/ThemePreviewTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author         Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright      (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license        MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+final class ThemePreviewTest extends TestCase
+{
+    public function testPreviewUsesPluginMarkupAndAnchoredDropdowns(): void
+    {
+        $sPreview = file_get_contents(dirname(__DIR__, 3) . '/_tools/theme-preview.html');
+        self::assertIsString($sPreview);
+        $oDocument = new DOMDocument;
+        self::assertTrue($oDocument->loadHTML($sPreview, LIBXML_NOERROR | LIBXML_NOWARNING));
+        $oXPath = new DOMXPath($oDocument);
+
+        self::assertSame(1, $oXPath->query('//div[@class="apprise-inner"]/following-sibling::div[@class="apprise-buttons"]')->length);
+        self::assertSame(2, $oXPath->query('//div[@class="apprise-buttons"]/button[not(@class)]')->length);
+        self::assertSame(1, $oXPath->query('//div[@class="dropdown open"]/button[@aria-expanded="true"]/following-sibling::ul[@class="dropdown-menu"]')->length);
+        self::assertSame(0, $oXPath->query('//ul[@class="dropdown-menu" and contains(@style, "position:static")]')->length);
+    }
+}

--- a/_tools/theme-preview.html
+++ b/_tools/theme-preview.html
@@ -148,6 +148,13 @@ if (previewRevision) {
             <li><a href="#">My profile</a></li>
             <li><a href="#">Messages</a></li>
             <li><a href="#">Settings</a></li>
+            <li class="dropdown-submenu open">
+                <a href="#">Tools → Info</a>
+                <ul class="dropdown-menu" style="display:block;">
+                    <li><a href="#">Software information</a></li>
+                    <li><a href="#">PHP configuration</a></li>
+                </ul>
+            </li>
         </ul>
     </div>
 </div>

--- a/_tools/theme-preview.html
+++ b/_tools/theme-preview.html
@@ -20,6 +20,41 @@
 <link rel="stylesheet" href="/templates/themes/base/css/js/jquery/apprise.css">
 <link rel="stylesheet" href="/templates/themes/base/css/js/jquery/tipTip.css">
 <link rel="stylesheet" href="/templates/themes/base/css/design_system.css">
+<style>
+/* Preview-only positioning; production plugins control their own placement. */
+.preview-dialog {
+    margin-bottom: 24px;
+}
+div.apprise.preview-dialog {
+    display: block;
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    max-width: 400px;
+    max-height: none;
+}
+#tiptip_holder.preview-tooltip {
+    display: inline-block;
+    position: relative;
+    top: auto;
+    left: auto;
+    margin-bottom: 24px;
+}
+.preview-dropdown {
+    min-height: 300px;
+}
+.preview-dropdown .dropdown-toggle {
+    margin: 0;
+}
+@media (max-width: 480px) {
+    .preview-dropdown .dropdown-submenu > .dropdown-menu {
+        position: static;
+        float: none;
+        margin: 0 8px 8px;
+    }
+}
+</style>
 <script>
 const previewParameters = new URLSearchParams(window.location.search);
 const selectedTheme = previewParameters.get('theme') || 'base';
@@ -53,7 +88,7 @@ if (previewRevision) {
 <body style="padding: 24px 0;">
 <div class="container">
     <h1>Theme style guide</h1>
-    <p>Every component below uses stock Bootstrap 3 markup and the selected theme's production CSS chain.</p>
+    <p>Developer preview, not a live site page. These examples use the selected theme's production styles; overlays and menus are held open for inspection.</p>
     <p aria-label="Choose preview theme">
         Theme:
         <a class="btn btn-default btn-xs" href="?theme=base">Base</a>
@@ -125,37 +160,39 @@ if (previewRevision) {
         <a class="btn btn-primary" href="#">Be the first — join for free!</a>
     </div>
 
-    <h2>Apprise dialog & tipTip tooltip (forced visible)</h2>
-    <div style="position: relative; height: 220px;">
-        <div class="apprise" style="display:block; position:absolute; top:10px; left:10px; width:calc(100% - 20px); max-width:280px; box-sizing:border-box;">
-            <div class="apprise-inner">
-                <p>Are you sure you want to unmatch Alex?</p>
-                <div class="apprise-buttons">
-                    <button class="btn btn-primary">Yes, unmatch</button>
-                    <button class="btn btn-default">Cancel</button>
-                </div>
-            </div>
+    <h2>Dialog (preview)</h2>
+    <div class="apprise preview-dialog">
+        <div class="apprise-inner">
+            <div class="apprise-content">Are you sure you want to unmatch Alex?</div>
         </div>
-        <div id="tiptip_holder" class="tip_top" style="display:block; position:absolute; top:150px; right:10px; left:auto;">
-            <div id="tiptip_content">Online 5 minutes ago</div>
+        <div class="apprise-buttons">
+            <button type="button">Yes, unmatch</button>
+            <button type="button">Cancel</button>
         </div>
     </div>
 
+    <h2>Tooltip (preview)</h2>
+    <div id="tiptip_holder" class="tip_top preview-tooltip">
+        <div id="tiptip_content">Online 5 minutes ago</div>
+    </div>
+
     <h2>Dropdown (open)</h2>
-    <div class="dropdown open" style="margin-bottom: 120px;">
-        <button class="btn btn-default dropdown-toggle">Menu <span class="caret"></span></button>
-        <ul class="dropdown-menu" style="display:block; position:static;">
-            <li><a href="#">My profile</a></li>
-            <li><a href="#">Messages</a></li>
-            <li><a href="#">Settings</a></li>
-            <li class="dropdown-submenu open">
-                <a href="#">Tools → Info</a>
-                <ul class="dropdown-menu" style="display:block;">
-                    <li><a href="#">Software information</a></li>
-                    <li><a href="#">PHP configuration</a></li>
-                </ul>
-            </li>
-        </ul>
+    <div class="preview-dropdown">
+        <div class="dropdown open" style="display:inline-block;">
+            <button type="button" class="btn btn-default dropdown-toggle" aria-expanded="true">Menu <span class="caret"></span></button>
+            <ul class="dropdown-menu" style="display:block;">
+                <li><a href="#">My profile</a></li>
+                <li><a href="#">Messages</a></li>
+                <li><a href="#">Settings</a></li>
+                <li class="dropdown-submenu open">
+                    <a href="#">Tools → Info</a>
+                    <ul class="dropdown-menu" style="display:block;">
+                        <li><a href="#">Software information</a></li>
+                        <li><a href="#">PHP configuration</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
     </div>
 </div>
 </body>

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.0.1/pH7Builder-v19.0.1.zip.sha256
-sha256sum -c pH7Builder-v19.0.1.zip.sha256
-unzip pH7Builder-v19.0.1.zip
-cp -a pH7Builder-v19.0.1/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip.sha256
+sha256sum -c pH7Builder-v19.1.0.zip.sha256
+unzip pH7Builder-v19.1.0.zip
+cp -a pH7Builder-v19.1.0/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v19.0.1` and run:
+For a source checkout instead, clone tag `v19.1.0` and run:
 
 ```console
-git clone --branch v19.0.1 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.0.1
-cd pH7Builder-v19.0.1
+git clone --branch v19.1.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.1.0
+cd pH7Builder-v19.1.0
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:19.0.1 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.1.0 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive

--- a/docs/RELEASE_NOTES_19.1.0.md
+++ b/docs/RELEASE_NOTES_19.1.0.md
@@ -15,6 +15,8 @@ validation and nested admin navigation following the reports in
   themes, with larger dialog button targets.
 - Avoids a PHP 8.2 deprecation for profiles without a birth date while preserving
   the existing age fallback.
+- Handles concurrent cache-directory creation without logging a false
+  permissions error; genuine creation failures still raise an exception.
 - Aligns the contributor theme preview with production plugin markup and adds
   regression coverage for these fixes.
 

--- a/docs/RELEASE_NOTES_19.1.0.md
+++ b/docs/RELEASE_NOTES_19.1.0.md
@@ -1,0 +1,41 @@
+# pH7Builder 19.1.0 — Release Notes
+
+Released on 12 September 2026, this maintenance update restores reliable login
+validation and nested admin navigation following the reports in
+[issue #1251](https://github.com/pH7Software/pH7-Social-Dating-CMS/issues/1251).
+
+## Highlights
+
+- Fixes an internal server error when a member enters an incorrect password or
+  an unknown email. The login handler now accepts the integer error codes
+  returned by the model and shows the intended validation message.
+- Restores nested admin menus, including Mod → Blog/Newsletter/Billing and
+  Tools → Info, by preventing parent dropdowns from clipping their submenus.
+- Improves Apprise dialog button and tipTip tooltip contrast in light and dark
+  themes, with larger dialog button targets.
+- Avoids a PHP 8.2 deprecation for profiles without a birth date while preserving
+  the existing age fallback.
+- Aligns the contributor theme preview with production plugin markup and adds
+  regression coverage for these fixes.
+
+## Compatibility and upgrade
+
+No intentional breaking changes. PHP 8.2+ and MySQL 8.0+ remain required, and the
+SQL schema stays at `1.6.6`. No database migration is needed from 19.0.1.
+Dependency, Bootstrap, jQuery and jQuery UI versions are unchanged.
+
+Back up first and verify a staging copy. Preserve configuration, uploads, custom
+modules/themes, language packs and credentials. Deploy PHP and browser assets
+together, remove the installer on existing sites, and clear application, CDN
+and browser caches. Test valid and invalid logins, signup, Stay signed in and
+nested admin menus. Custom login or theme overrides may need the same fixes.
+Follow the [Upgrade Guide](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.1.0/docs/UPGRADING.md).
+
+The `pH7Builder-v19.1.0.zip` asset includes production dependencies. Verify it
+with the attached `.sha256` file, then follow the
+[Quick Start](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.1.0/docs/QUICK_START.md) and
+[Launch Checklist](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.1.0/docs/LAUNCH_CHECKLIST.md).
+SMTP delivery, SMS, GeoNames and payments still require checks with your own
+provider configuration before going live.
+
+[All changes since 19.0.1](https://github.com/pH7Software/pH7-Social-Dating-CMS/compare/v19.0.1...v19.1.0)

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,27 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 19.1.0 maintenance release
+
+pH7Builder 19.1.0 fixes member-login errors for invalid credentials, restores
+nested admin menus, and improves dialog and tooltip contrast. It also avoids a
+PHP deprecation when a profile has no birth date. PHP 8.2+ and MySQL 8.0+
+requirements are unchanged. The SQL schema remains `1.6.6`; no database
+migration is needed from 19.0.1.
+
+Back up and upgrade a staging copy first. Deploy the complete tagged 19.1.0
+package while preserving local configuration, uploads, custom modules/themes,
+language packs, and credentials. The release ZIP includes production
+dependencies; source deployments must run `composer install --no-dev
+--prefer-dist --optimize-autoloader`. Do not rerun the installer on an existing
+site; remove the deployed `_install` directory before reopening it.
+
+Clear application caches in Admin → Tools → Caches, purge any CDN asset cache,
+and refresh browser assets. Deploy PHP and CSS together. Test valid and invalid
+member logins, signup, Stay signed in, and the nested Mod and Tools → Info menus
+on desktop and mobile. Review custom overrides of login processing or shared
+theme CSS. Earlier installations must also follow the applicable guidance below.
+
 ## 19.0.1 patch release
 
 pH7Builder 19.0.1 fixes form rendering, Ajax retries, age sliders, and recipient

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:19.0.1 pH7Builder-v19.0.1 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.1.0 pH7Builder-v19.1.0 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder

--- a/templates/themes/base/css/design_system.css
+++ b/templates/themes/base/css/design_system.css
@@ -486,6 +486,27 @@ div.apprise {
     backdrop-filter: blur(2px);
 }
 
+div.apprise .apprise-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+    background: var(--ph7-surface);
+    border-color: var(--ph7-border);
+    box-shadow: none;
+}
+
+div.apprise .apprise-buttons button {
+    background: var(--ph7-bg);
+    color: var(--ph7-text);
+    border-color: var(--ph7-border);
+    border-radius: var(--ph7-radius-sm);
+    min-height: 44px;
+    margin: 0;
+    text-shadow: none;
+    box-shadow: none;
+}
+
 div.apprise .apprise-input input {
     border-radius: var(--ph7-radius-sm);
     border: 1px solid var(--ph7-border);
@@ -495,8 +516,9 @@ div.apprise .apprise-input input {
 }
 
 #tiptip_content {
-    background-color: var(--ph7-text);
+    background: var(--ph7-text);
     color: var(--ph7-bg);
+    text-shadow: none;
     border-radius: var(--ph7-radius-sm);
     font-family: var(--ph7-font);
     box-shadow: var(--ph7-shadow-sm);

--- a/templates/themes/base/css/design_system.css
+++ b/templates/themes/base/css/design_system.css
@@ -341,7 +341,8 @@ input[type=color]::-moz-color-swatch {
     border: 1px solid var(--ph7-border);
     box-shadow: var(--ph7-shadow);
     background-color: var(--ph7-bg);
-    overflow: hidden;
+    /* Nested navigation panels extend beyond their parent dropdown. */
+    overflow: visible;
 }
 
 .dropdown-menu > li > a {


### PR DESCRIPTION
Fixes the reproduced login HTTP 500, clipped admin submenus and plugin contrast. Also handles missing birth dates without PHP deprecations.

Prepares v19.1.0 with matching runtime/installer versions and upgrade instructions. No schema or dependency changes.

The original login failure was reproduced in the v19.0.1 package and browser. Focused regression tests, PHPStan and both dependency audits pass. Full CI and packaged-install checks gate publication.

Refs #1251.
