### PR TITLE
Keep nested admin menus usable on mobile

### DIFF
--- a/_tests/Unit/Root/ThemeAssetTest.php
+++ b/_tests/Unit/Root/ThemeAssetTest.php
@@ -37,6 +37,25 @@ final class ThemeAssetTest extends TestCase
         self::assertStringContainsString('dropdown-submenu open', $sPreview);
     }
 
+    public function testNestedDropdownTogglesDoNotReachBootstrapsDocumentHandler(): void
+    {
+        $sScript = file_get_contents(dirname(__DIR__, 3) . '/static/js/common.js');
+        self::assertIsString($sScript);
+        self::assertStringContainsString("$('.navbar').on('click', '.dropdown-submenu > .dropdown-toggle'", $sScript);
+        self::assertStringContainsString('oEvent.stopPropagation();', $sScript);
+        self::assertStringContainsString(".children('.dropdown-toggle').attr('aria-expanded', 'false')", $sScript);
+        self::assertStringContainsString("$(this).attr('aria-expanded', 'true')", $sScript);
+
+        foreach (['base', 'premium'] as $sTheme) {
+            $sTemplate = file_get_contents(dirname(__DIR__, 3) . '/templates/themes/' . $sTheme . '/tpl/top_menu.inc.tpl');
+            self::assertIsString($sTemplate);
+            self::assertStringContainsString(
+                'title="{lang \'Admin Blog\'}" class="dropdown-toggle" role="button" aria-expanded="false" data-toggle="dropdown"',
+                $sTemplate
+            );
+        }
+    }
+
     public function testEveryThemeProvidesSharedLayoutAssets(): void
     {
         $sThemesDirectory = dirname(__DIR__, 3) . '/templates/themes';

--- a/docs/RELEASE_NOTES_19.1.0.md
+++ b/docs/RELEASE_NOTES_19.1.0.md
@@ -10,7 +10,8 @@ validation and nested admin navigation following the reports in
   an unknown email. The login handler now accepts the integer error codes
   returned by the model and shows the intended validation message.
 - Restores nested admin menus, including Mod → Blog/Newsletter/Billing and
-  Tools → Info, by preventing parent dropdowns from clipping their submenus.
+  Tools → Info, by preventing parent dropdowns from clipping their submenus or
+  collapsing when a nested toggle is tapped on mobile.
 - Improves Apprise dialog button and tipTip tooltip contrast in light and dark
   themes, with larger dialog button targets.
 - Avoids a PHP 8.2 deprecation for profiles without a birth date while preserving

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -19,10 +19,11 @@ dependencies; source deployments must run `composer install --no-dev
 site; remove the deployed `_install` directory before reopening it.
 
 Clear application caches in Admin → Tools → Caches, purge any CDN asset cache,
-and refresh browser assets. Deploy PHP and CSS together. Test valid and invalid
+and refresh browser assets. Deploy PHP, CSS and JavaScript together. Test valid and invalid
 member logins, signup, Stay signed in, and the nested Mod and Tools → Info menus
 on desktop and mobile. Review custom overrides of login processing or shared
-theme CSS. Earlier installations must also follow the applicable guidance below.
+theme CSS, navigation templates and JavaScript. Earlier installations must also
+follow the applicable guidance below.
 
 ## 19.0.1 patch release
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -4,6 +4,26 @@
  * License:       MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
  */
 
+// Bootstrap 3 closes all dropdowns when a nested toggle reaches its document handler.
+$(function () {
+    $('.navbar').on('click', '.dropdown-submenu > .dropdown-toggle', function (oEvent) {
+        oEvent.preventDefault();
+        oEvent.stopPropagation();
+
+        var oSubmenu = $(this).parent();
+        var bWasOpen = oSubmenu.hasClass('open');
+
+        oSubmenu.parent().find('.dropdown-submenu.open')
+            .removeClass('open')
+            .children('.dropdown-toggle').attr('aria-expanded', 'false');
+
+        if (!bWasOpen) {
+            oSubmenu.addClass('open');
+            $(this).attr('aria-expanded', 'true');
+        }
+    });
+});
+
 /**
  * Open external links in a new tab.
  * Delegated from the document so links added later (e.g. by ajax) are covered too.

--- a/templates/themes/base/tpl/top_menu.inc.tpl
+++ b/templates/themes/base/tpl/top_menu.inc.tpl
@@ -351,7 +351,7 @@
             {/if}
 
             {if $is_blog_enabled}
-              <li class="menu-item dropdown dropdown-submenu"><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Blog'}"><i class="fa fa-comments-o"></i> {lang 'Blog'}</a>
+              <li class="menu-item dropdown dropdown-submenu"><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Blog'}" class="dropdown-toggle" role="button" aria-expanded="false" data-toggle="dropdown"><i class="fa fa-comments-o"></i> {lang 'Blog'}</a>
                 <ul class="dropdown-menu" role="menu">
                   <li><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Control - Blog'}">{lang 'Admin Blog'}</a></li>
                   <li><a href="{{ $design->url('blog','admin','add') }}" title="{lang 'Add a Blog Post'}">{lang 'Add a Post'}</a></li>

--- a/templates/themes/premium/tpl/top_menu.inc.tpl
+++ b/templates/themes/premium/tpl/top_menu.inc.tpl
@@ -270,7 +270,7 @@
             {/if}
 
             {if $is_blog_enabled}
-              <li class="menu-item dropdown dropdown-submenu"><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Blog'}"><i class="fa fa-comments-o"></i> {lang 'Blog'}</a>
+              <li class="menu-item dropdown dropdown-submenu"><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Blog'}" class="dropdown-toggle" role="button" aria-expanded="false" data-toggle="dropdown"><i class="fa fa-comments-o"></i> {lang 'Blog'}</a>
                 <ul class="dropdown-menu" role="menu">
                   <li><a href="{{ $design->url('blog','admin','index') }}" title="{lang 'Admin Control - Blog'}">{lang 'Admin Blog'}</a></li>
                   <li><a href="{{ $design->url('blog','admin','add') }}" title="{lang 'Add a Blog Post'}">{lang 'Add a Post'}</a></li>


### PR DESCRIPTION
Fixes a release-check finding: tapping a nested menu closed its parent on mobile. Keeps the handler scoped to navigation, preserves leaf links, and enables the Blog toggle in both themes.

Verified Blog, Billing, Tools → Info and third-level newsletter navigation in the installed site, including 320px and desktop layouts. Adds regression coverage for v19.1.0.

Refs #1251.