### PR TITLE
Prepare v19.2.0 maintenance release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,14 @@ Theme/CSS contributions: `_tools/theme-preview.html` renders the base theme's CS
 For real PFBC forms, run `php -S 127.0.0.1:8642 -t .` and open
 `http://127.0.0.1:8642/_tools/pfbc-preview.php`. Check base and premium themes at
 desktop and mobile widths, then select **Run interaction checks** to verify
-agreement handling, password visibility, age sliders, character counts, and Ajax retry.
+agreement handling, password visibility, age sliders, tag chips, character counts, and Ajax retry.
 This preview only runs on PHP's local development server and uses no application data.
+
+Use `PFBC\Element\Tag` for comma-separated tag lists. It adds removable chips
+with Enter or commas, keeps pending text on submission, and falls back to a
+textbox without JavaScript. Supply the usual `Str` validator for the complete
+list; blog and note forms use `PH7\Form::MAX_TAG_FIELD_LENGTH` (191 characters,
+including commas). Tag fields intentionally opt out of character counters.
 
 Use `_tools/autocomplete-preview.html` on the same server to check recipient and
 city suggestions. Its interaction checks use fixed mock responses; they do not

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -15,3 +15,12 @@ notice must remain in copies or substantial portions of the Software.
 Third-party libraries and assets remain subject to their own copyright notices
 and licenses. Preserve those notices and review the applicable dependency or
 asset license before redistribution.
+
+## Geolocation data
+
+This product includes GeoLite2 data created by [MaxMind](https://www.maxmind.com/).
+The bundled legacy database (3 December 2019) is distributed under the
+[Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/),
+not the project's MIT License. Its data has not been modified. New downloads
+must retain their accompanying notices and comply with their applicable terms.
+Public attribution is also provided on the site's Legal Notice page.

--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ only the required writable paths, configure the web server, and then open
 directory before opening the browser installer.
 
 ```console
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip.sha256
-sha256sum -c pH7Builder-v19.1.0.zip.sha256
-unzip pH7Builder-v19.1.0.zip
-cd pH7Builder-v19.1.0
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.2.0/pH7Builder-v19.2.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.2.0/pH7Builder-v19.2.0.zip.sha256
+sha256sum -c pH7Builder-v19.2.0.zip.sha256
+unzip pH7Builder-v19.2.0.zip
+cd pH7Builder-v19.2.0
 ```
 
 Composer can install the same tagged release from Packagist:
 
 ```console
-composer create-project ph7software/ph7builder:19.1.0 pH7Builder-v19.1.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.2.0 pH7Builder-v19.2.0 --no-dev --prefer-dist
 ```
 
 pH7Builder is also listed on

--- a/_install/library/Controller.class.php
+++ b/_install/library/Controller.class.php
@@ -30,7 +30,7 @@ abstract class Controller implements Controllable
     public const SOFTWARE_COPYRIGHT = 'Copyright © 2012-%s Pierre-Henry Soria and pH7Builder contributors.';
 
     public const SOFTWARE_VERSION_NAME = 'REVOLUTIONARY™';
-    public const SOFTWARE_VERSION = '19.1.0';
+    public const SOFTWARE_VERSION = '19.2.0';
 
     public const SOFTWARE_BUILD = '1';
 

--- a/_protected/app/includes/classes/Form.php
+++ b/_protected/app/includes/classes/Form.php
@@ -20,6 +20,8 @@ class Form extends Framework\Layout\Form\Form
 
     public const MIN_STRING_FIELD_LENGTH = 2;
     public const MAX_STRING_FIELD_LENGTH = 200;
+    // Blog and note tags are stored in VARCHAR(191) columns.
+    public const MAX_TAG_FIELD_LENGTH = 191;
 
     /**
      * To get Value Data from the database.

--- a/_protected/app/system/modules/blog/forms/AdminBlogForm.php
+++ b/_protected/app/system/modules/blog/forms/AdminBlogForm.php
@@ -14,6 +14,7 @@ use PFBC\Element\File;
 use PFBC\Element\Hidden;
 use PFBC\Element\HTMLExternal;
 use PFBC\Element\Radio;
+use PFBC\Element\Tag;
 use PFBC\Element\Textarea;
 use PFBC\Element\Textbox;
 use PFBC\Element\Token;
@@ -108,12 +109,11 @@ class AdminBlogForm
         );
         $oForm->addElement(new File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
         $oForm->addElement(
-            new Textbox(
+            new Tag(
                 t('Tags:'),
                 'tags',
                 [
-                    'description' => t('Separate keywords by commas and without spaces between the commas.'),
-                    'validation' => new Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
+                    'validation' => new Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_TAG_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/blog/forms/EditAdminBlogForm.php
+++ b/_protected/app/system/modules/blog/forms/EditAdminBlogForm.php
@@ -14,6 +14,7 @@ use PFBC\Element\File;
 use PFBC\Element\Hidden;
 use PFBC\Element\HTMLExternal;
 use PFBC\Element\Radio;
+use PFBC\Element\Tag;
 use PFBC\Element\Textarea;
 use PFBC\Element\Textbox;
 use PH7\Datatype\Type;
@@ -175,15 +176,14 @@ class EditAdminBlogForm
             }
 
             $oForm->addElement(
-                new Textbox(
+                new Tag(
                     t('Tags:'),
                     'tags',
                     [
                         'value' => $oPost->tags,
-                        'description' => t('Separate keywords by commas and without spaces between the commas.'),
                         'validation' => new \PFBC\Validation\Str(
                             Form::MIN_STRING_FIELD_LENGTH,
-                            Form::MAX_STRING_FIELD_LENGTH
+                            Form::MAX_TAG_FIELD_LENGTH
                         )
                     ]
                 )

--- a/_protected/app/system/modules/blog/forms/processing/EditAdminBlogFormProcess.php
+++ b/_protected/app/system/modules/blog/forms/processing/EditAdminBlogFormProcess.php
@@ -98,7 +98,7 @@ class EditAdminBlogFormProcess extends Form
         }
 
         // Updated the modification Date
-        $oBlogModel->updatePost('updatedDate', $this->dateTime->get()->dateTime('Y-m-d H:i:s'), $sPostId);
+        $oBlogModel->updatePost('updatedDate', $this->dateTime->get()->dateTime('Y-m-d H:i:s'), $iBlogId);
         unset($oBlog, $oBlogModel);
 
         Blog::clearCache();

--- a/_protected/app/system/modules/note/forms/EditNoteForm.php
+++ b/_protected/app/system/modules/note/forms/EditNoteForm.php
@@ -14,6 +14,7 @@ use PFBC\Element\File;
 use PFBC\Element\Hidden;
 use PFBC\Element\HTMLExternal;
 use PFBC\Element\Radio;
+use PFBC\Element\Tag;
 use PFBC\Element\Textarea;
 use PFBC\Element\Textbox;
 use PH7\Datatype\Type;
@@ -179,15 +180,14 @@ class EditNoteForm
             }
 
             $oForm->addElement(
-                new Textbox(
+                new Tag(
                     t('Tags:'),
                     'tags',
                     [
                         'value' => $oPost->tags,
-                        'description' => t('Separate keywords by commas and without spaces between the commas.'),
                         'validation' => new \PFBC\Validation\Str(
                             Form::MIN_STRING_FIELD_LENGTH,
-                            Form::MAX_STRING_FIELD_LENGTH
+                            Form::MAX_TAG_FIELD_LENGTH
                         )
                     ]
                 )

--- a/_protected/app/system/modules/note/forms/NoteForm.php
+++ b/_protected/app/system/modules/note/forms/NoteForm.php
@@ -17,6 +17,7 @@ use PFBC\Element\File;
 use PFBC\Element\Hidden;
 use PFBC\Element\HTMLExternal;
 use PFBC\Element\Radio;
+use PFBC\Element\Tag;
 use PFBC\Element\Textarea;
 use PFBC\Element\Textbox;
 use PFBC\Element\Token;
@@ -119,12 +120,11 @@ class NoteForm
         );
         $oForm->addElement(new File(t('Thumbnail:'), 'thumb', ['accept' => 'image/*']));
         $oForm->addElement(
-            new Textbox(
+            new Tag(
                 t('Tags:'),
                 'tags',
                 [
-                    'description' => t('Separate keywords by commas and without spaces between the commas.'),
-                    'validation' => new Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_STRING_FIELD_LENGTH)
+                    'validation' => new Str(Form::MIN_STRING_FIELD_LENGTH, Form::MAX_TAG_FIELD_LENGTH)
                 ]
             )
         );

--- a/_protected/app/system/modules/page/views/base/tpl/main/legalnotice.tpl
+++ b/_protected/app/system/modules/page/views/base/tpl/main/legalnotice.tpl
@@ -18,6 +18,11 @@ The user is solely responsible for their use.</p>
 No material from this website or its sub-domains and other services may not be copied, reproduced, modified, republished, uploaded, distorted, transmitted or distributed in any manner whatsoever.</p>
 <p>&nbsp;</p>
 
+<p><strong>Geolocation data</strong></p>
+<p>This product includes GeoLite2 data created by <a href="https://www.maxmind.com/">MaxMind</a>.
+The bundled legacy database is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0</a>.</p>
+<p>&nbsp;</p>
+
 <p><strong>Publisher and Managing Editor</strong></p>
 <p>NAME OF YOUR PUBLISHER, MANAGING EDITOR HERE<br />
 Contact: <a href="mailto:{admin_email}" rel="nofollow">{admin_email}</a>.</p>

--- a/_protected/framework/Geo/Ip/update-geo-database-version.txt
+++ b/_protected/framework/Geo/Ip/update-geo-database-version.txt
@@ -1,3 +1,17 @@
-GeoLite2 City database is updated on the first Tuesday of each month by MaxMind.
-Use `_tools/pH7.sh` -> `update geoip db` to download the latest database.
-You must export a valid `MAXMIND_LICENSE_KEY` before running the helper.
+The bundled legacy GeoLite2-City database was built on 3 December 2019.
+Updating the PHP reader does not update this location data.
+
+Get current GeoLite data through a free MaxMind account:
+https://www.maxmind.com/en/geolite-free-ip-geolocation-data
+
+Use MaxMind's GeoIP Update tool with a private GeoIP.conf containing your
+AccountID, LicenseKey and EditionIDs GeoLite2-City. From the project root, run:
+geoipupdate -f /absolute/private/path/GeoIP.conf -d ./_protected/framework/Geo/Ip
+
+Keep the configuration outside the web root, restrict it to its owner, and
+never commit it or share its licence key. Follow MaxMind's update guidance:
+https://dev.maxmind.com/geoip/updating-databases/
+
+Before redistributing a newly downloaded database, review its accompanying
+licence and notices, including attribution and ongoing-update requirements:
+https://www.maxmind.com/en/geolite/eula

--- a/_protected/framework/Layout/Form/Engine/PFBC/Element/Tag.php
+++ b/_protected/framework/Layout/Form/Engine/PFBC/Element/Tag.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @author Pierre-Henry Soria <hello@ph7builder.com>
+ * @license MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+namespace PFBC\Element;
+
+/**
+ * Comma-separated text without JavaScript, removable tags when enhanced.
+ */
+class Tag extends Textbox
+{
+    public function render()
+    {
+        $this->attributes['data-no-counter'] = 'true';
+        $this->attributes += [
+            'placeholder' => t('Add a tag'),
+            'data-tag-help' => t('Type a tag and press Enter, or use commas.'),
+            'data-tag-remove' => t('Remove tag: %0%'),
+            'data-tag-limit' => t('Too many characters. Shorten or remove a tag.'),
+            'data-tag-required' => t('Please add a tag.')
+        ];
+        $sHelpId = $this->getID() . '_tag_help';
+        $aDescriptionIds = explode(' ', $this->attributes['aria-describedby'] ?? '');
+        $aDescriptionIds[] = $sHelpId;
+        $this->attributes['aria-describedby'] = trim(implode(' ', array_unique($aDescriptionIds)));
+
+        parent::render();
+        echo '<small class="pfbc-tags-help" id="', $this->filter($sHelpId), '">',
+        $this->filter(t('Separate tags with commas.')), '</small>';
+    }
+
+    public function getCSSFiles(): array
+    {
+        return [$this->form->getResourcesPath() . '/css/tag.css'];
+    }
+
+    public function getJSFiles(): array
+    {
+        return [$this->form->getResourcesPath() . '/js/tag.js'];
+    }
+
+    public function jQueryDocumentReady()
+    {
+        $sInputId = json_encode($this->getID(), JSON_HEX_TAG);
+        echo 'if (window.pH7TagField) { pH7TagField.init(document.getElementById(', $sInputId, ')); }';
+    }
+}

--- a/_protected/framework/Layout/Html/Design.class.php
+++ b/_protected/framework/Layout/Html/Design.class.php
@@ -369,7 +369,11 @@ class Design
                 $bSoftwareName = true;
             }
 
-            echo ($bSoftwareName ? '<span class="italic">' . t('Powered by') : ''), ' <strong>', ($bLink ? '<a class="underline" href="' . Kernel::SOFTWARE_WEBSITE . '" title="' . Kernel::SOFTWARE_DESCRIPTION . '">' : ''), ($bSoftwareName ? Kernel::SOFTWARE_NAME : ''), ($bVersion ? ' ' . Kernel::SOFTWARE_VERSION : ''), ($bLink ? '</a>' : ''), ($bSoftwareName ? '</strong></span>' : '');
+            echo ($bSoftwareName ? t('Powered by') . ' ' : ''),
+                ($bLink ? '<a href="' . Kernel::SOFTWARE_GIT_REPO_URL . '" title="' . Kernel::SOFTWARE_DESCRIPTION . '">' : ''),
+                ($bSoftwareName ? Kernel::SOFTWARE_NAME : ''),
+                ($bVersion ? ' v' . Kernel::SOFTWARE_VERSION : ''),
+                ($bLink ? '</a>' : '');
         }
 
         if ($bComment) {

--- a/_protected/framework/Security/Version.class.php
+++ b/_protected/framework/Security/Version.class.php
@@ -51,7 +51,7 @@ final class Version
      *
      * More details: https://ph7builder.com/new-versioning-system/
      */
-    public const KERNEL_VERSION = '19.1.0';
+    public const KERNEL_VERSION = '19.2.0';
     public const KERNEL_BUILD = '1';
     public const KERNEL_RELEASE_DATE = '2026-09-12';
 

--- a/_tests/Unit/App/System/Module/Blog/Forms/Processing/EditAdminBlogFormProcessTest.php
+++ b/_tests/Unit/App/System/Module/Blog/Forms/Processing/EditAdminBlogFormProcessTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\App\System\Module\Blog\Forms\Processing;
+
+use PHPUnit\Framework\TestCase;
+
+final class EditAdminBlogFormProcessTest extends TestCase
+{
+    public function testModificationDateUsesTheRowIdRatherThanTheUrlSlug(): void
+    {
+        $sProcess = file_get_contents(
+            __DIR__ . '/../../../../../../../../_protected/app/system/modules/blog/forms/processing/EditAdminBlogFormProcess.php'
+        );
+
+        self::assertIsString($sProcess);
+        self::assertMatchesRegularExpression(
+            '/->updatePost\(\s*\x27updatedDate\x27,\s*\$this->dateTime->get\(\)->dateTime\([^)]*\),\s*\$iBlogId\s*\)/',
+            $sProcess
+        );
+    }
+}

--- a/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TagTest.php
+++ b/_tests/Unit/Framework/Layout/Form/Engine/PFBC/Element/TagTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * @author Pierre-Henry Soria <hello@ph7builder.com>
+ * @license MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Framework\Layout\Form\Engine\PFBC\Element;
+
+require_once PH7_PATH_FRAMEWORK . 'Layout/Form/Engine/PFBC/Form.class.php';
+
+use PFBC\Element\Tag;
+use PFBC\Form;
+use PFBC\Validation\Str;
+use PH7\Form as AppForm;
+use PHPUnit\Framework\TestCase;
+
+final class TagTest extends TestCase
+{
+    public function testPlainTextboxFallbackPreservesSavedTagsAndValidation(): void
+    {
+        $oTag = new Tag('Tags', 'tags', [
+            'id' => 'article_tags',
+            'value' => 'coffee,weekend trips',
+            'required' => 1,
+            'validation' => new Str(2, AppForm::MAX_TAG_FIELD_LENGTH)
+        ]);
+        $sHtml = $this->render($oTag);
+
+        $this->assertStringContainsString('type="text"', $sHtml);
+        $this->assertStringContainsString('name="tags"', $sHtml);
+        $this->assertStringContainsString('value="coffee,weekend trips"', $sHtml);
+        $this->assertStringContainsString('maxlength="191"', $sHtml);
+        $this->assertStringContainsString('required="required"', $sHtml);
+        $this->assertStringContainsString('data-no-counter="true"', $sHtml);
+        $this->assertStringContainsString('Separate tags with commas.', $sHtml);
+        $this->assertTrue($oTag->isValid('coffee,weekend trips'));
+    }
+
+    public function testResourcesAreSharedButEachFieldInitializesIndependently(): void
+    {
+        $oForm = new Form('tag_test');
+        $oForm->addElement(new Tag('Tags', 'tags'));
+        $oForm->addElement(new Tag('More tags', 'more_tags'));
+        $sHtml = $oForm->render(true);
+
+        $this->assertSame(1, substr_count($sHtml, '/js/tag.js'));
+        $this->assertSame(1, substr_count($sHtml, '/css/tag.css'));
+        foreach ($oForm->getElements() as $oTag) {
+            $this->assertStringContainsString('document.getElementById("' . $oTag->getID() . '")', $sHtml);
+            $this->assertStringContainsString('id="' . $oTag->getID() . '_tag_help"', $sHtml);
+        }
+    }
+
+    public function testValuesAndHelpAttributesCannotCreateMarkup(): void
+    {
+        $sUnsafe = '"><img src=x onerror=alert(1)>';
+        $sHtml = $this->render(new Tag('Tags', 'tags', [
+            'id' => 'tags',
+            'value' => $sUnsafe,
+            'placeholder' => $sUnsafe,
+            'data-tag-remove' => $sUnsafe
+        ]));
+
+        $this->assertStringNotContainsString('<img', $sHtml);
+        $this->assertSame(3, substr_count($sHtml, htmlspecialchars($sUnsafe, ENT_QUOTES)));
+    }
+
+    public function testExistingDescriptionAndExplicitLimitArePreserved(): void
+    {
+        $oTag = new Tag('Tags', 'tags', [
+            'id' => 'tags',
+            'aria-describedby' => 'custom_help',
+            'maxlength' => 20,
+            'validation' => new Str(2, 191),
+            'readonly' => 'readonly'
+        ]);
+        $sHtml = $this->render($oTag);
+        $this->assertStringContainsString('aria-describedby="custom_help tags_tag_help"', $sHtml);
+        $this->assertStringContainsString('maxlength="20"', $sHtml);
+        $this->assertStringContainsString('readonly="readonly"', $sHtml);
+        $this->assertSame($sHtml, $this->render($oTag));
+    }
+
+    public function testSessionBackedValidationRejectsOverlongLists(): void
+    {
+        $oForm = new Form('tag_validation');
+        $oForm->addElement(new Tag('Tags', 'tags', ['validation' => new Str(2, AppForm::MAX_TAG_FIELD_LENGTH)]));
+        $oForm->render(true);
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $_POST = ['tags' => str_repeat('🌷', 191)];
+        $this->assertTrue(Form::isValid('tag_validation'));
+        $_POST = ['tags' => str_repeat('🌷', 192)];
+        $this->assertFalse(Form::isValid('tag_validation'));
+        $this->assertSame($_POST['tags'], Form::getSessionValues('tag_validation')['tags']);
+        $this->assertNotEmpty($_SESSION['pfbc']['tag_validation']['errors']['tags']);
+    }
+
+    public function testRequiredAndOptionalValidationAreNotLostOnSerialization(): void
+    {
+        $oOptional = unserialize(serialize(new Tag('Tags', 'tags', ['validation' => new Str(2, 191)])));
+        $this->assertTrue($oOptional->isValid(''));
+        $oRequired = unserialize(serialize(new Tag('Tags', 'tags', ['required' => 1, 'validation' => new Str(2, 191)])));
+        $this->assertFalse($oRequired->isValid(''));
+        $this->assertTrue($oRequired->isValid('travel,music'));
+    }
+
+    public function testBlogAndNoteFormsUseTheSchemaBoundedTagElement(): void
+    {
+        foreach (['blog/forms/AdminBlogForm.php', 'blog/forms/EditAdminBlogForm.php', 'note/forms/NoteForm.php', 'note/forms/EditNoteForm.php'] as $sPath) {
+            $sCode = file_get_contents(PH7_PATH_SYS_MOD . $sPath);
+            $this->assertMatchesRegularExpression('/new Tag\(\s*t\(\x27Tags:\x27\),\s*\x27tags\x27/', $sCode);
+            $this->assertStringContainsString('Form::MAX_TAG_FIELD_LENGTH', $sCode);
+        }
+        $sSchema = file_get_contents(dirname(PH7_PATH_PROTECTED) . '/_install/data/sql/MySQL/pH7_Core.sql');
+        $this->assertSame(2, substr_count($sSchema, 'tags varchar(' . AppForm::MAX_TAG_FIELD_LENGTH . ')'));
+    }
+
+    private function render(Tag $oTag): string
+    {
+        ob_start();
+        $oTag->render();
+
+        return ob_get_clean();
+    }
+}

--- a/_tests/Unit/Root/DependencyCompatibilityTest.php
+++ b/_tests/Unit/Root/DependencyCompatibilityTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use Aws\S3\S3Client;
+use Braintree\ClientToken;
+use Braintree\ClientTokenGateway;
+use Braintree\Gateway;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Utils;
+use GuzzleHttp\Psr7\Response;
+use PH7\Framework\Geo\Ip\Geo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Transport\NullTransport;
+use Symfony\Component\Mime\Email;
+use Twilio\Http\Client as SmsHttpClient;
+use Twilio\Http\Response as SmsResponse;
+use Twilio\Rest\Client as SmsClient;
+
+final class DependencyCompatibilityTest extends TestCase
+{
+    public function testHttpRequestsResolveThroughTheLockedPromiseStack(): void
+    {
+        $oHandler = new MockHandler([new Response(200, [], '{"ok":true}')]);
+        $oClient = new Client(['handler' => HandlerStack::create($oHandler)]);
+        $aResponses = Utils::all([$oClient->getAsync('https://example.com/check')])->wait();
+
+        self::assertSame(200, $aResponses[0]->getStatusCode());
+        self::assertSame(['ok' => true], json_decode((string)$aResponses[0]->getBody(), true));
+    }
+
+    public function testS3PresigningDoesNotNeedAProviderConnection(): void
+    {
+        $oClient = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => ['key' => 'test-key', 'secret' => 'test-secret']
+        ]);
+        $oCommand = $oClient->getCommand('GetObject', [
+            'Bucket' => 'release-test',
+            'Key' => 'photos/example.jpg'
+        ]);
+        $oUri = $oClient->createPresignedRequest($oCommand, '+20 minutes')->getUri();
+
+        self::assertSame('https', $oUri->getScheme());
+        self::assertSame('/photos/example.jpg', $oUri->getPath());
+        self::assertStringContainsString('X-Amz-Signature=', $oUri->getQuery());
+    }
+
+    public function testSmsRequestRetainsTheProviderContractWithoutSending(): void
+    {
+        $oHttp = $this->createMock(SmsHttpClient::class);
+        $oHttp->expects(self::once())->method('request')
+            ->with(
+                'POST',
+                self::stringContains('/2010-04-01/Accounts/'),
+                [],
+                self::callback(static function (array $aData): bool {
+                    return $aData['To'] === '+15005550006'
+                        && $aData['From'] === '+15005550001'
+                        && $aData['Body'] === 'Test message';
+                })
+            )
+            ->willReturn(new SmsResponse(201, '{"sid":"SM-test-message","status":"queued"}'));
+        $oClient = new SmsClient('AC' . str_repeat('0', 32), 'test-token', null, null, $oHttp);
+        $oMessage = $oClient->messages->create('+15005550006', [
+            'from' => '+15005550001',
+            'body' => 'Test message'
+        ]);
+
+        self::assertSame('SM-test-message', $oMessage->sid);
+    }
+
+    public function testBraintreeClientTokenRequestRetainsItsDefaultVersion(): void
+    {
+        $oGateway = new Gateway([
+            'environment' => 'sandbox',
+            'merchantId' => 'test-merchant',
+            'publicKey' => 'test-public',
+            'privateKey' => 'test-private'
+        ]);
+        $oTokens = $this->getMockBuilder(ClientTokenGateway::class)
+            ->setConstructorArgs([$oGateway])
+            ->onlyMethods(['_doGenerate'])
+            ->getMock();
+        $oTokens->expects(self::once())->method('_doGenerate')
+            ->with('/client_token', ['client_token' => ['version' => ClientToken::DEFAULT_VERSION]])
+            ->willReturn('test-client-token');
+
+        self::assertSame('test-client-token', $oTokens->generate());
+    }
+
+    public function testBundledGeoDatabaseWorksWithTheUpdatedReader(): void
+    {
+        self::assertMatchesRegularExpression('/\A[A-Z]{2}\z/', Geo::getCountryCode('8.8.8.8'));
+        self::assertNull(Geo::getCountryCode('127.0.0.1'));
+    }
+
+    public function testMimeMessageCanBeBuiltWithTheNullMailTransport(): void
+    {
+        $oEmail = (new Email())->from('owner@example.com')->to('member@example.com')
+            ->subject('Welcome to pH7Builder')->text('Your account is ready.');
+        $oMessage = (new NullTransport())->send($oEmail);
+
+        self::assertNotNull($oMessage);
+        self::assertStringContainsString('Your account is ready.', $oMessage->toString());
+    }
+}

--- a/_tests/Unit/Root/FooterBrandingTest.php
+++ b/_tests/Unit/Root/FooterBrandingTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PH7\Framework\Core\Kernel;
+use PH7\Framework\Layout\Html\Design;
+use PH7\Framework\Layout\Tpl\Engine\PH7Tpl\Syntax\Curly;
+use PH7\Framework\Mvc\Model\DbConfig;
+use PHPUnit\Framework\TestCase;
+
+final class FooterBrandingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_alias(FooterSettingsStub::class, DbConfig::class);
+        FooterSettingsStub::setDisplayed(true);
+    }
+
+    public function testThemeFootersRenderOnlyTheVersionedProjectCredit(): void
+    {
+        foreach (['base', 'premium'] as $sTheme) {
+            $sTemplate = file_get_contents(dirname(__DIR__, 3) . '/templates/themes/' . $sTheme . '/tpl/layout.tpl');
+            self::assertIsString($sTemplate);
+            self::assertStringNotContainsString('We use GeoLite2', $sTemplate);
+            self::assertStringNotContainsString('maxmind.com', $sTemplate);
+            self::assertSame(1, preg_match('/<div class="ft_copy">.*?<p>(.*?)<\/p>/s', $sTemplate, $aMatches));
+            self::assertStringNotContainsString('{site_name}', $aMatches[1]);
+
+            $oSyntax = new Curly();
+            $oSyntax->setCode($aMatches[1]);
+            $oSyntax->parse();
+            $design = new Design();
+            ob_start();
+            try {
+                eval('?>' . $oSyntax->getParsedCode());
+                $sHtml = (string)ob_get_contents();
+            } finally {
+                ob_end_clean();
+            }
+
+            $oDocument = new \DOMDocument();
+            $oDocument->loadHTML('<div>' . $sHtml . '</div>');
+            self::assertSame('Powered by pH7Builder v' . Kernel::SOFTWARE_VERSION, trim($oDocument->textContent));
+            self::assertSame(1, $oDocument->getElementsByTagName('a')->length);
+            self::assertSame(Kernel::SOFTWARE_GIT_REPO_URL, $oDocument->getElementsByTagName('a')->item(0)->getAttribute('href'));
+            self::assertSame(0, $oDocument->getElementsByTagName('strong')->length);
+            self::assertStringNotContainsString('italic', $sHtml);
+        }
+    }
+
+    public function testBrandingVisibilitySettingIsPreserved(): void
+    {
+        FooterSettingsStub::setDisplayed(false);
+        $sHtml = $this->renderLink([true, true, true]);
+
+        self::assertSame('', trim(strip_tags($sHtml)));
+        self::assertStringNotContainsString('<a', $sHtml);
+        self::assertStringContainsString('created by ' . Kernel::SOFTWARE_AUTHOR, $sHtml);
+    }
+
+    public function testEmailContextDoesNotAddVisibleBranding(): void
+    {
+        self::assertSame('', $this->renderLink([true, true, true, false, true]));
+    }
+
+    public function testPlainTextCreditRemainsAvailable(): void
+    {
+        self::assertSame('Powered by pH7Builder v' . Kernel::SOFTWARE_VERSION, $this->renderLink([false, true, true, false]));
+    }
+
+    public function testVersionCanStillBeOmittedByOtherCallers(): void
+    {
+        self::assertSame('Powered by pH7Builder', strip_tags($this->renderLink([true, true, false, false])));
+    }
+
+    public function testMaxMindAttributionRemainsOutsideTheFooter(): void
+    {
+        foreach (['COPYRIGHT.md', '_protected/app/system/modules/page/views/base/tpl/main/legalnotice.tpl'] as $sFile) {
+            $sNotice = file_get_contents(dirname(__DIR__, 3) . '/' . $sFile);
+            self::assertIsString($sNotice);
+            self::assertStringContainsString('GeoLite2 data created by', $sNotice);
+            self::assertStringContainsString('https://www.maxmind.com/', $sNotice);
+            self::assertStringContainsString('https://creativecommons.org/licenses/by-sa/4.0/', $sNotice);
+        }
+    }
+
+    private function renderLink(array $aArguments): string
+    {
+        ob_start();
+        try {
+            (new Design())->link(...$aArguments);
+
+            return (string)ob_get_contents();
+        } finally {
+            ob_end_clean();
+        }
+    }
+}
+
+final class FooterSettingsStub
+{
+    private static bool $bDisplayed = true;
+
+    public static function setDisplayed(bool $bDisplayed): void
+    {
+        self::$bDisplayed = $bDisplayed;
+    }
+
+    public static function getSetting(string $sSetting): bool
+    {
+        return $sSetting === 'displayPoweredByLink' && self::$bDisplayed;
+    }
+}

--- a/_tools/pfbc-preview.js
+++ b/_tools/pfbc-preview.js
@@ -2,6 +2,92 @@
 (function ($) {
     'use strict';
 
+    async function checkTags(assert) {
+        const oForm = document.getElementById('preview_tags');
+        oForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const oInput = oForm.querySelector('.pfbc-tags-input');
+        const oField = oInput.closest('.pfbc-tags');
+        const oRequired = oForm.querySelectorAll('.pfbc-tags-input')[1];
+        const getValue = () => new FormData(oForm).get('tags');
+        function type(sText, oTarget = oInput) {
+            oTarget.value = sText;
+            oTarget.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        function key(sKey, oTarget = oInput, bComposing = false) {
+            const oEvent = new KeyboardEvent('keydown', { key: sKey, bubbles: true, cancelable: true, isComposing: bComposing });
+            oTarget.dispatchEvent(oEvent);
+            return oEvent;
+        }
+        assert(oField.querySelectorAll('.pfbc-tag').length === 2, 'Saved tags must render as chips.');
+        assert(getValue() === 'Travel,Coffee', 'Saved tags must keep the comma-separated format.');
+        assert(!oForm.querySelector('.char_counter'), 'Tags must not show character counters.');
+        assert(oInput.labels[0].textContent === 'Article tags', 'The label must target the editable input.');
+        assert(!oRequired.checkValidity(), 'An empty required tag field must remain required.');
+        type('Music');
+        assert(getValue() === 'Travel,Coffee,Music', 'Pending text must be included even before Enter.');
+        assert(key('Enter').defaultPrevented, 'Enter must add tags without submitting the form.');
+        assert(oField.querySelectorAll('.pfbc-tag').length === 3 && oInput.value === '', 'Enter must create a real chip.');
+        assert(key('Enter').defaultPrevented, 'Empty Enter must not submit the form.');
+        type('Music');
+        key('Enter');
+        assert(oField.querySelectorAll('.pfbc-tag').length === 3, 'Exact duplicate tags must not be added.');
+        type(' weekend trips, art, ');
+        assert(getValue() === 'Travel,Coffee,Music,weekend trips,art', 'Pasted lists must trim separators but preserve spaces inside tags.');
+        const sUnsafe = '<img src=x onerror=alert(1)>';
+        type(sUnsafe);
+        key('Enter');
+        assert(!oField.querySelector('img') && oField.textContent.includes(sUnsafe), 'Tag labels must be literal text, never executable HTML.');
+        const oRemove = oField.querySelector('button');
+        assert(oRemove.type === 'button' && oRemove.getAttribute('aria-label') === 'Remove tag: Travel', 'Remove buttons need accessible names and must not submit.');
+        oRemove.click();
+        assert(!getValue().includes('Travel'), 'Removing a chip must update its submitted value.');
+        key('Backspace');
+        assert(document.activeElement === oField.querySelector('.pfbc-tag:last-child button'), 'Backspace must focus removal before deleting a tag.');
+        type('京都');
+        assert(!key('Enter', oInput, true).defaultPrevented && oInput.value === '京都', 'IME Enter must not prematurely commit a tag.');
+        key('Enter');
+        assert(getValue().endsWith(',京都'), 'Unicode tags must be preserved.');
+        type('a'.repeat(192));
+        key('Enter');
+        assert(!oInput.checkValidity() && oInput.value.length === 192, 'Overlong lists must show an error without losing input.');
+        oInput.focus();
+        assert(getComputedStyle(oInput).borderTopWidth === '0px' && oField.classList.contains('pfbc-tags-invalid'), 'Validation must highlight the whole tag field without a second inner border.');
+        assert(oField.nextElementSibling.textContent.includes('Shorten or remove a tag'), 'Overlong lists need an actionable message, not a counter.');
+        type('Shorter');
+        assert(oInput.checkValidity(), 'Shortening an overlong list must clear the error.');
+        oInput.dispatchEvent(new FocusEvent('blur'));
+        assert(oInput.value === '' && getValue().endsWith(',Shorter'), 'Leaving the field must commit the pending tag.');
+        type('🌷'.repeat(20), oRequired);
+        key('Enter', oRequired);
+        assert(oRequired.checkValidity() && !oRequired.required, 'Committed tags must satisfy required without requiring another tag.');
+        type('x', oRequired);
+        assert(!oRequired.checkValidity(), 'The limit must include existing tags and comma separators.');
+        type('', oRequired);
+        assert(oRequired.checkValidity(), 'Clearing excess pending text must restore validity.');
+        assert(new FormData(oForm).get('readonly_tags') === 'Saved tag', 'Read-only tags must still submit.');
+        assert(!new FormData(oForm).has('disabled_tags'), 'Disabled tags must not submit.');
+        assert(oForm.querySelectorAll('.pfbc-tag-remove:disabled').length === 2, 'Disabled/read-only tags must not be removable.');
+        oInput.disabled = true;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert(!new FormData(oForm).has('tags'), 'Disabling an enhanced field must disable its submitted value.');
+        oInput.disabled = false;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        pH7TagField.init(oInput);
+        assert(oField.querySelectorAll('input[type=hidden]').length === 1, 'Re-initialization must not duplicate the submitted value.');
+        oForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert(getValue() === 'Travel,Coffee' && oInput.value === '', 'Reset must restore saved tags without a duplicate draft.');
+        assert(oField.querySelectorAll('.pfbc-tag').length === 2, 'Reset must restore the initial chips.');
+        assert(!oRequired.checkValidity(), 'Reset must restore the required constraint.');
+        type('a'.repeat(170));
+        key('Enter');
+        assert(oField.querySelectorAll('.pfbc-tag').length === 3, 'Long valid tags must not be truncated.');
+        assert(oField.scrollWidth <= oField.clientWidth, 'Long tags must wrap inside the field, including on mobile.');
+        oForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     $('#run_checks').on('click', async function () {
         $(this).prop('disabled', true);
         const aFailures = [];
@@ -12,6 +98,8 @@
                 aFailures.push(sMessage);
             }
         }
+
+        await checkTags(assert);
 
         const $oJoin = $('#preview_join');
         const $oLoginButton = $('#preview_login button[type=submit]');
@@ -51,7 +139,16 @@
 
         for (const sReply of ['validation', 'failure', 'plain']) {
             const $oAjax = $('#preview_' + sReply);
-            const $oButton = $oAjax.find('button');
+            const $oButton = $oAjax.find('button[type=submit]');
+            const oTagInput = $oAjax.find('.pfbc-tags-input')[0];
+            oTagInput.value = 'Pending';
+            oTagInput.dispatchEvent(new Event('input', { bubbles: true }));
+            assert($oAjax.serialize().includes('tags=Travel%2CPending'), sReply + ': Ajax must include both chips and pending tags.');
+            if (sReply === 'validation') {
+                $(document).one('ajaxSuccess', function (oEvent, oRequest, oSettings, oData) {
+                    assert(oData.posted_tags === 'Travel,Pending', 'The PHP endpoint must receive the complete comma-separated list.');
+                });
+            }
             const oCompleted = new Promise((resolve) => $(document).one('ajaxStop', resolve));
             $oAjax.trigger('submit');
             assert($oButton.prop('disabled'), sReply + ': prevent duplicate submission.');

--- a/_tools/pfbc-preview.php
+++ b/_tools/pfbc-preview.php
@@ -19,7 +19,10 @@ if (isset($_GET['reply'])) {
         http_response_code(503);
         echo '{}';
     } else {
-        echo json_encode(['errors' => ['Please check your email address.']]);
+        echo json_encode([
+            'errors' => ['Please check your email address.'],
+            'posted_tags' => is_string($_POST['tags'] ?? null) ? $_POST['tags'] : null
+        ]);
     }
     exit;
 }
@@ -30,6 +33,7 @@ define('PH7', true);
 define('PH7_DS', '/');
 define('PH7_SH', '/');
 define('PH7_JS', 'js/');
+define('PH7_ENCODING', 'utf-8');
 define('PH7_URL_STATIC', '/static/');
 define('PH7_PATH_PROTECTED', dirname(__DIR__) . '/_protected/');
 define('PH7_PATH_FRAMEWORK', PH7_PATH_PROTECTED . 'framework/');
@@ -78,6 +82,17 @@ $sScheme = ($_GET['scheme'] ?? '') === 'dark' ? 'dark' : 'light';
     <p>Actual PFBC output with the bundled Bootstrap, jQuery and jQuery UI. Submissions stay in this local fixture.</p>
     <p><a href="?theme=base">Base theme</a> · <a href="?theme=premium">Premium theme</a> · <a href="theme-preview.html">Theme style guide</a></p>
     <p><a href="?theme=<?= $sTheme ?>&amp;scheme=light">Light appearance</a> · <a href="?theme=<?= $sTheme ?>&amp;scheme=dark">Dark appearance</a></p>
+    <h2>Tags</h2>
+    <?php
+    $oTags = new PFBC\Form('preview_tags');
+    $oTags->configure(['onsubmit' => 'return false']);
+    $oTags->addElement(new PFBC\Element\Tag('Article tags', 'tags', ['value' => 'Travel,Coffee', 'validation' => new PFBC\Validation\Str(2, 191)]));
+    $oTags->addElement(new PFBC\Element\Tag('Required tags', 'required_tags', ['required' => 1, 'validation' => new PFBC\Validation\Str(2, 20)]));
+    $oTags->addElement(new PFBC\Element\Tag('Read-only tags', 'readonly_tags', ['value' => 'Saved tag', 'readonly' => 'readonly']));
+    $oTags->addElement(new PFBC\Element\Tag('Disabled tags', 'disabled_tags', ['value' => 'Unavailable', 'disabled' => 'disabled']));
+    $oTags->addElement(new PFBC\Element\Button('Reset tags', 'reset'));
+    $oTags->render();
+    ?>
     <h2>Login</h2>
     <?php
     $oLogin = new PFBC\Form('preview_login');
@@ -114,6 +129,7 @@ $sScheme = ($_GET['scheme'] ?? '') === 'dark' ? 'dark' : 'light';
             'action' => '?reply=' . ($sReply === 'plain' ? 'failure' : $sReply),
             'prevent' => $sReply === 'plain' ? ['jQueryUIButtons'] : []
         ]);
+        $oAjax->addElement(new PFBC\Element\Tag('Ajax tags', 'tags', ['value' => 'Travel', 'maxlength' => 191]));
         $oAjax->addElement(new PFBC\Element\Button('Test ' . $sReply, 'submit', $sReply === 'plain' ? ['class' => 'btn btn-danger'] : []));
         $oAjax->render();
     }

--- a/composer.lock
+++ b/composer.lock
@@ -108,16 +108,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.390.2",
+            "version": "3.395.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a09e95bf062e15b7343f9c1362fd45c7a0dec39b"
+                "reference": "c8f42d03b697a61b4910d162d753b13d2de297fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a09e95bf062e15b7343f9c1362fd45c7a0dec39b",
-                "reference": "a09e95bf062e15b7343f9c1362fd45c7a0dec39b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c8f42d03b697a61b4910d162d753b13d2de297fc",
+                "reference": "c8f42d03b697a61b4910d162d753b13d2de297fc",
                 "shasum": ""
             },
             "require": {
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.390.2"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.395.0"
             },
-            "time": "2026-07-31T18:06:07+00:00"
+            "time": "2026-09-11T18:07:54+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -260,16 +260,16 @@
         },
         {
             "name": "braintree/braintree_php",
-            "version": "6.36.0",
+            "version": "6.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/braintree/braintree_php.git",
-                "reference": "8f816a138ca700217249b933cca77ec3695744bd"
+                "reference": "0f53ece38397c9fed05b94620634a5a23ef8ee48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/8f816a138ca700217249b933cca77ec3695744bd",
-                "reference": "8f816a138ca700217249b933cca77ec3695744bd",
+                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/0f53ece38397c9fed05b94620634a5a23ef8ee48",
+                "reference": "0f53ece38397c9fed05b94620634a5a23ef8ee48",
                 "shasum": ""
             },
             "require": {
@@ -303,22 +303,22 @@
             "description": "Braintree PHP Client Library",
             "support": {
                 "issues": "https://github.com/braintree/braintree_php/issues",
-                "source": "https://github.com/braintree/braintree_php/tree/6.36.0"
+                "source": "https://github.com/braintree/braintree_php/tree/6.37.0"
             },
-            "time": "2026-06-15T20:42:41+00:00"
+            "time": "2026-08-05T20:52:14+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.13",
+            "version": "1.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5"
+                "reference": "0c8abba0634f637bd78c4e451981da368d403463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/c008272789979f709f7fcb32c2ecf1d2db5e84e5",
-                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/0c8abba0634f637bd78c4e451981da368d403463",
+                "reference": "0c8abba0634f637bd78c4e451981da368d403463",
                 "shasum": ""
             },
             "require": {
@@ -365,7 +365,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.13"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.14"
             },
             "funding": [
                 {
@@ -377,7 +377,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-18T12:35:13+00:00"
+            "time": "2026-08-21T14:57:29+00:00"
         },
         {
             "name": "dasprid/enum",
@@ -757,22 +757,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.2",
+            "version": "7.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.13",
+                "guzzlehttp/promises": "^2.5.3",
+                "guzzlehttp/psr7": "^2.13.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -865,7 +865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.5"
             },
             "funding": [
                 {
@@ -881,20 +881,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-26T23:23:20+00:00"
+            "time": "2026-08-24T09:21:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/cde49999552d185d64715fe9c1f77a2aadd2f9f1",
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1",
                 "shasum": ""
             },
             "require": {
@@ -949,7 +949,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.3"
             },
             "funding": [
                 {
@@ -965,20 +965,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-24T09:11:28+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/95e7828100de18b4e269fb1703be530082d5166d",
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d",
                 "shasum": ""
             },
             "require": {
@@ -1068,7 +1068,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.1"
             },
             "funding": [
                 {
@@ -1084,33 +1084,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-16T22:23:49+00:00"
+            "time": "2026-08-24T09:13:11+00:00"
         },
         {
             "name": "maxmind-db/reader",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maxmind/MaxMind-DB-Reader-php.git",
-                "reference": "2194f58d0f024ce923e685cdf92af3daf9951908"
+                "reference": "f3c92f68b3bec42a9aa780368399e03dc6b91e89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/2194f58d0f024ce923e685cdf92af3daf9951908",
-                "reference": "2194f58d0f024ce923e685cdf92af3daf9951908",
+                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/f3c92f68b3bec42a9aa780368399e03dc6b91e89",
+                "reference": "f3c92f68b3bec42a9aa780368399e03dc6b91e89",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
             "conflict": {
-                "ext-maxminddb": "<1.11.1 || >=2.0.0"
+                "ext-maxminddb": "<1.14.0 || >=2.0.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.*",
                 "phpstan/phpstan": "*",
                 "phpunit/phpunit": ">=8.0.0,<10.0.0",
-                "squizlabs/php_codesniffer": "4.*"
+                "squizlabs/php_codesniffer": "4.*",
+                "symfony/polyfill-php80": "^1.33"
             },
             "suggest": {
                 "ext-bcmath": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
@@ -1132,7 +1133,7 @@
                 {
                     "name": "Gregory J. Oschwald",
                     "email": "goschwald@maxmind.com",
-                    "homepage": "https://www.maxmind.com/"
+                    "homepage": "https://www.maxmind.com/en/home"
                 }
             ],
             "description": "MaxMind DB Reader API",
@@ -1146,9 +1147,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
-                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.13.1"
+                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.14.0"
             },
-            "time": "2025-11-21T22:24:26+00:00"
+            "time": "2026-09-10T22:02:38+00:00"
         },
         {
             "name": "maxmind/web-service-common",
@@ -2326,16 +2327,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.15",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9"
+                "reference": "d269974ee93c61d03620ffee358355bfdb471d66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/336e7f3b9e95aba04f93ea9143920c2186abfbb9",
-                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d269974ee93c61d03620ffee358355bfdb471d66",
+                "reference": "d269974ee93c61d03620ffee358355bfdb471d66",
                 "shasum": ""
             },
             "require": {
@@ -2387,7 +2388,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.15"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -2407,7 +2408,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-21T15:13:06+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2491,16 +2492,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.15",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79"
+                "reference": "90d412aa5277c6819db39e7605aa46b1019e3232"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ff16a16bf87fdf264638b8f6995b3515975e3c79",
-                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/90d412aa5277c6819db39e7605aa46b1019e3232",
+                "reference": "90d412aa5277c6819db39e7605aa46b1019e3232",
                 "shasum": ""
             },
             "require": {
@@ -2537,7 +2538,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.15"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -2557,7 +2558,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T07:36:05+00:00"
+            "time": "2026-08-23T10:03:40+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -2645,16 +2646,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.15",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "0c1daf58bc931628df0bea26840d1fc8b9a3d34b"
+                "reference": "bf328d82105831db3e409195db0540ff57f27c80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/0c1daf58bc931628df0bea26840d1fc8b9a3d34b",
-                "reference": "0c1daf58bc931628df0bea26840d1fc8b9a3d34b",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/bf328d82105831db3e409195db0540ff57f27c80",
+                "reference": "bf328d82105831db3e409195db0540ff57f27c80",
                 "shasum": ""
             },
             "require": {
@@ -2678,7 +2679,7 @@
                 "symfony/process": "^6.4|^7.0|^8.0",
                 "symfony/property-access": "^6.4|^7.0|^8.0",
                 "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+                "symfony/serializer": "^6.4.44|^7.4.17|^8.1.5"
             },
             "type": "library",
             "autoload": {
@@ -2710,7 +2711,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.15"
+                "source": "https://github.com/symfony/mime/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -2730,7 +2731,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-29T07:59:49+00:00"
+            "time": "2026-08-22T09:04:42+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2899,16 +2900,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.38.1",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/51b5ff5ba85452b31ec6f55490b08148612339d9",
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +2963,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -2982,20 +2983,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T15:22:23+00:00"
+            "time": "2026-08-24T10:51:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.38.0",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/aa20edea75bd9c48cfecc8360922e5a6e5c44502",
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502",
                 "shasum": ""
             },
             "require": {
@@ -3047,7 +3048,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -3067,7 +3068,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T13:48:31+00:00"
+            "time": "2026-08-07T06:33:24+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3240,16 +3241,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.1",
+            "version": "v3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
                 "shasum": ""
             },
             "require": {
@@ -3303,7 +3304,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.3"
             },
             "funding": [
                 {
@@ -3323,7 +3324,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T09:55:08+00:00"
+            "time": "2026-07-27T15:39:01+00:00"
         },
         {
             "name": "symfony/string",
@@ -3473,25 +3474,25 @@
         },
         {
             "name": "twilio/sdk",
-            "version": "8.11.6",
+            "version": "8.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twilio/twilio-php",
-                "reference": "57754efb0998086007ec9a63874fd85def5afb7f"
+                "reference": "1446cb97fc7cf0daef94389c2bad465e3b7df64b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/57754efb0998086007ec9a63874fd85def5afb7f",
-                "reference": "57754efb0998086007ec9a63874fd85def5afb7f",
+                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/1446cb97fc7cf0daef94389c2bad465e3b7df64b",
+                "reference": "1446cb97fc7cf0daef94389c2bad465e3b7df64b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "guzzlehttp/guzzle": "^6.3 || ^7.0",
-                "phpunit/phpunit": ">=7.0 < 10"
+                "friendsofphp/php-cs-fixer": "3.94.2",
+                "guzzlehttp/guzzle": "7.15.3",
+                "phpunit/phpunit": "9.6.34"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "An HTTP client to execute the API requests"
@@ -3519,7 +3520,7 @@
                 "sms",
                 "twilio"
             ],
-            "time": "2026-05-07T16:40:31+00:00"
+            "time": "2026-09-09T12:37:32+00:00"
         }
     ],
     "packages-dev": [
@@ -4151,16 +4152,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.18",
+            "version": "v3.95.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683"
+                "reference": "2cdfc1f3daf173d83a1ebb6177949b58c95de6ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a8b4e4216faabf67f4e96110ee99a48c96e4e683",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/2cdfc1f3daf173d83a1ebb6177949b58c95de6ff",
+                "reference": "2cdfc1f3daf173d83a1ebb6177949b58c95de6ff",
                 "shasum": ""
             },
             "require": {
@@ -4196,7 +4197,6 @@
                 "infection/infection": "^0.32.7",
                 "justinrainbow/json-schema": "^6.10.0",
                 "keradus/cli-executor": "^2.3",
-                "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
@@ -4244,7 +4244,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.18"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.25"
             },
             "funding": [
                 {
@@ -4252,24 +4252,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-30T15:46:02+00:00"
+            "time": "2026-09-08T11:11:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -4304,15 +4304,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4562,11 +4562,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.7",
+            "version": "2.2.13",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
-                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "reference": "9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
                 "shasum": ""
             },
             "require": {
@@ -4622,7 +4622,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-29T17:39:32+00:00"
+            "time": "2026-09-03T20:38:19+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6715,16 +6715,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.14",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
+                "reference": "5ce28827081f6d1f0c32eaf3882750f19cb5bbe6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
-                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5ce28827081f6d1f0c32eaf3882750f19cb5bbe6",
+                "reference": "5ce28827081f6d1f0c32eaf3882750f19cb5bbe6",
                 "shasum": ""
             },
             "require": {
@@ -6759,7 +6759,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.14"
+                "source": "https://github.com/symfony/finder/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -6779,7 +6779,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T08:31:18+00:00"
+            "time": "2026-08-21T12:09:28+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7014,16 +7014,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.13",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f5804be144caceb570f6747519999636b664f24c"
+                "reference": "058d17fc284cce14efb2385783b55014a461b176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
-                "reference": "f5804be144caceb570f6747519999636b664f24c",
+                "url": "https://api.github.com/repos/symfony/process/zipball/058d17fc284cce14efb2385783b55014a461b176",
+                "reference": "058d17fc284cce14efb2385783b55014a461b176",
                 "shasum": ""
             },
             "require": {
@@ -7055,7 +7055,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.13"
+                "source": "https://github.com/symfony/process/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -7075,7 +7075,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T16:05:06+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,21 +43,21 @@ the archive and its checksum from the same GitHub release:
 sudo mkdir -p /var/www/ph7builder
 sudo chown deploy:www-data /var/www/ph7builder
 cd /tmp
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip
-curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.1.0/pH7Builder-v19.1.0.zip.sha256
-sha256sum -c pH7Builder-v19.1.0.zip.sha256
-unzip pH7Builder-v19.1.0.zip
-cp -a pH7Builder-v19.1.0/. /var/www/ph7builder/
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.2.0/pH7Builder-v19.2.0.zip
+curl -LO https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/download/v19.2.0/pH7Builder-v19.2.0.zip.sha256
+sha256sum -c pH7Builder-v19.2.0.zip.sha256
+unzip pH7Builder-v19.2.0.zip
+cp -a pH7Builder-v19.2.0/. /var/www/ph7builder/
 ```
 
 Run these commands as the `deploy` account, or replace that example account
 with your normal non-root deployment user.
 
-For a source checkout instead, clone tag `v19.1.0` and run:
+For a source checkout instead, clone tag `v19.2.0` and run:
 
 ```console
-git clone --branch v19.1.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.1.0
-cd pH7Builder-v19.1.0
+git clone --branch v19.2.0 --depth 1 https://github.com/pH7Software/pH7-Social-Dating-CMS.git pH7Builder-v19.2.0
+cd pH7Builder-v19.2.0
 composer install --no-dev --prefer-dist --optimize-autoloader
 ```
 
@@ -66,7 +66,7 @@ tagged Packagist release. Run this from the parent of the intended deployment
 directory:
 
 ```console
-composer create-project ph7software/ph7builder:19.1.0 ph7builder --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.2.0 ph7builder --no-dev --prefer-dist
 ```
 
 Softaculous and SourceForge also list pH7Builder, but their available archive

--- a/docs/RELEASE_NOTES_19.2.0.md
+++ b/docs/RELEASE_NOTES_19.2.0.md
@@ -15,6 +15,8 @@ used by pH7Builder. It includes all login and navigation fixes from 19.1.0.
 - Adds removable tag chips to blog and note forms: press Enter or use commas,
   without character counters. Existing saved tags stay compatible; validation
   now matches the database's 191-character limit for the complete tag list.
+- Fixes an internal error when saving blog edits on strict MySQL installations:
+  the modification timestamp now uses the numeric row ID, not the URL slug.
 - Simplifies the footer to a versioned pH7Builder link to GitHub, with MaxMind
   attribution retained on the Legal Notice page and in copyright notices.
 - Adds offline checks for HTTP promises, S3 signing, SMS request construction,

--- a/docs/RELEASE_NOTES_19.2.0.md
+++ b/docs/RELEASE_NOTES_19.2.0.md
@@ -12,6 +12,8 @@ used by pH7Builder. It includes all login and navigation fixes from 19.1.0.
   resource limits. These are dependency hardening changes, not a claim that
   a vulnerability was found in pH7Builder's own application code.
 - Refreshes PHPStan, PHP CS Fixer and supporting development dependencies.
+- Simplifies the footer to a versioned pH7Builder link to GitHub, with MaxMind
+  attribution retained on the Legal Notice page and in copyright notices.
 - Adds offline checks for HTTP promises, S3 signing, SMS request construction,
   Braintree client tokens, the bundled GeoIP database and MIME email generation.
 

--- a/docs/RELEASE_NOTES_19.2.0.md
+++ b/docs/RELEASE_NOTES_19.2.0.md
@@ -1,0 +1,73 @@
+# pH7Builder 19.2.0 — Release Notes
+
+Released on 12 September 2026, this minor maintenance release refreshes 19
+locked PHP dependencies and adds offline compatibility coverage for the SDKs
+used by pH7Builder. It includes all login and navigation fixes from 19.1.0.
+
+## Highlights
+
+- Updates AWS, Braintree and Twilio SDKs within their existing major versions.
+- Updates Guzzle, certificate bundles, GeoIP decoding and Symfony components.
+- Includes upstream Braintree request-path validation fixes and MaxMind decoder
+  resource limits. These are dependency hardening changes, not a claim that
+  a vulnerability was found in pH7Builder's own application code.
+- Refreshes PHPStan, PHP CS Fixer and supporting development dependencies.
+- Adds offline checks for HTTP promises, S3 signing, SMS request construction,
+  Braintree client tokens, the bundled GeoIP database and MIME email generation.
+
+## Dependency versions
+
+| Package | From | To |
+| --- | --- | --- |
+| aws/aws-sdk-php | 3.390.2 | 3.395.0 |
+| braintree/braintree_php | 6.36.0 | 6.37.0 |
+| composer/ca-bundle | 1.5.13 | 1.5.14 |
+| friendsofphp/php-cs-fixer | 3.95.18 | 3.95.25 |
+| guzzlehttp/guzzle | 7.15.2 | 7.15.5 |
+| guzzlehttp/promises | 2.5.1 | 2.5.3 |
+| guzzlehttp/psr7 | 2.13.0 | 2.13.1 |
+| maxmind-db/reader | 1.13.1 | 1.14.0 |
+| myclabs/deep-copy | 1.13.4 | 1.14.0 |
+| phpstan/phpstan | 2.2.7 | 2.2.13 |
+| symfony/event-dispatcher | 7.4.15 | 7.4.17 |
+| symfony/filesystem | 7.4.15 | 7.4.18 |
+| symfony/finder | 7.4.14 | 7.4.17 |
+| symfony/mime | 7.4.15 | 7.4.18 |
+| symfony/polyfill-intl-idn | 1.38.1 | 1.42.0 |
+| symfony/polyfill-intl-normalizer | 1.38.0 | 1.42.0 |
+| symfony/process | 7.4.13 | 7.4.18 |
+| symfony/service-contracts | 3.7.1 | 3.7.3 |
+| twilio/sdk | 8.11.6 | 8.12.1 |
+
+## Compatibility and upgrade
+
+PHP 8.2+, MySQL 8.0+ and schema `1.6.6` are unchanged. No database migration is
+needed from 19.1.0. Bootstrap, jQuery, jQuery UI and Smarty versions are unchanged.
+
+**Optional extension requirement:** hosts with compiled `ext-maxminddb` must use
+`>=1.14.0 <2.0.0`. The updated reader conflicts with older extension versions;
+pure-PHP installations do not need the extension. Custom Twilio integrations
+must review the retired WhatsApp Senders v1 endpoints and preview API changes.
+The bundled SMS integration continues to use the 2010 Messages API.
+See [MaxMind's release notes](https://github.com/maxmind/MaxMind-DB-Reader-php/releases/tag/v1.14.0),
+[Twilio's release notes](https://github.com/twilio/twilio-php/releases/tag/8.12.1) and
+[Braintree's changelog](https://github.com/braintree/braintree_php/blob/6.37.0/CHANGELOG.md).
+
+Back up first and follow the [Upgrade Guide](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.2.0/docs/UPGRADING.md).
+Deploy the complete package, preserve configuration and user data, remove the
+installer on existing sites, and clear caches. Source deployments must install
+dependencies from the committed lock file. Offline tests do not verify provider
+credentials, SMS/email delivery, storage access or successful live payments;
+check your configured services in staging before going live.
+
+The GeoIP reader update does not refresh location data. The bundled legacy
+GeoLite2-City snapshot is still dated 3 December 2019; obtain current data with
+your own free MaxMind account and follow the
+[database update instructions](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.2.0/_protected/framework/Geo/Ip/update-geo-database-version.txt).
+
+The `pH7Builder-v19.2.0.zip` asset includes production dependencies. Verify its
+attached SHA-256 checksum, then use the
+[Quick Start](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.2.0/docs/QUICK_START.md) and
+[Launch Checklist](https://github.com/pH7Software/pH7-Social-Dating-CMS/blob/v19.2.0/docs/LAUNCH_CHECKLIST.md).
+
+[All changes since 19.1.0](https://github.com/pH7Software/pH7-Social-Dating-CMS/compare/v19.1.0...v19.2.0)

--- a/docs/RELEASE_NOTES_19.2.0.md
+++ b/docs/RELEASE_NOTES_19.2.0.md
@@ -12,6 +12,9 @@ used by pH7Builder. It includes all login and navigation fixes from 19.1.0.
   resource limits. These are dependency hardening changes, not a claim that
   a vulnerability was found in pH7Builder's own application code.
 - Refreshes PHPStan, PHP CS Fixer and supporting development dependencies.
+- Adds removable tag chips to blog and note forms: press Enter or use commas,
+  without character counters. Existing saved tags stay compatible; validation
+  now matches the database's 191-character limit for the complete tag list.
 - Simplifies the footer to a versioned pH7Builder link to GitHub, with MaxMind
   attribution retained on the Legal Notice page and in copyright notices.
 - Adds offline checks for HTTP promises, S3 signing, SMS request construction,

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -3,6 +3,38 @@
 Automatic in-place upgrades are currently unavailable. Upgrade a staging copy
 manually, verify it, and only then repeat the reviewed procedure in production.
 
+## 19.2.0 dependency-maintenance release
+
+pH7Builder 19.2.0 updates the locked PHP dependencies and adds offline SDK
+compatibility checks. PHP 8.2+, MySQL 8.0+ and schema `1.6.6` are unchanged.
+No database migration is needed from 19.1.0. Bootstrap, jQuery, jQuery UI and
+the installer dependency are unchanged.
+
+Before upgrading, check `php --ri maxminddb` using the PHP installation that
+serves your site. If the optional compiled `ext-maxminddb` extension is present,
+upgrade it to `>=1.14.0 <2.0.0`; older versions conflict with the updated reader.
+The bundled pure-PHP reader does not require installing this extension.
+
+The reader update does not refresh the bundled 2019 GeoLite2 location data.
+Use a free MaxMind account to obtain current data and arrange regular updates;
+see the [GeoIP database instructions](../_protected/framework/Geo/Ip/update-geo-database-version.txt).
+Preserve your newer local database when replacing application files.
+
+Back up and test a staging copy. Deploy the complete 19.2.0 package while
+preserving local configuration, uploads, custom modules/themes, language packs
+and credentials. Source deployments must run `composer install --no-dev
+--prefer-dist --optimize-autoloader` from the new lock file. Do not run
+`composer update` on the live site or reuse an older vendor directory. Do not
+rerun the installer on an existing site; remove `_install` before reopening it.
+
+Clear application and browser/CDN caches. Check signup, login, admin navigation,
+email delivery, SMS, storage and a sandbox payment for the providers you use.
+Custom Twilio integrations should review its upstream changes, including the
+retired WhatsApp Senders v1 endpoints and changes to preview APIs; the bundled
+SMS provider uses the 2010 Messages API, not those endpoints. See the
+[19.2.0 release notes](RELEASE_NOTES_19.2.0.md) for dependency versions and sources.
+Earlier installations must also follow the applicable guidance below.
+
 ## 19.1.0 maintenance release
 
 pH7Builder 19.1.0 fixes member-login errors for invalid credentials, restores

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -20,6 +20,11 @@ Use a free MaxMind account to obtain current data and arrange regular updates;
 see the [GeoIP database instructions](../_protected/framework/Geo/Ip/update-geo-database-version.txt).
 Preserve your newer local database when replacing application files.
 
+The base and premium footers now show a plain, versioned pH7Builder link to
+GitHub instead of the site name and GeoLite2 line. The existing branding
+visibility setting still applies. MaxMind attribution is on the Legal Notice
+page and in `COPYRIGHT.md`; retain it when merging customised legal pages.
+
 Back up and test a staging copy. Deploy the complete 19.2.0 package while
 preserving local configuration, uploads, custom modules/themes, language packs
 and credentials. Source deployments must run `composer install --no-dev

--- a/installation-instructions-(start-here).txt
+++ b/installation-instructions-(start-here).txt
@@ -16,7 +16,7 @@ Release guides:
 https://github.com/pH7Software/pH7-Social-Dating-CMS/tree/18.x/docs
 
 Composer installation of this release:
-composer create-project ph7software/ph7builder:19.1.0 pH7Builder-v19.1.0 --no-dev --prefer-dist
+composer create-project ph7software/ph7builder:19.2.0 pH7Builder-v19.2.0 --no-dev --prefer-dist
 
 Other distribution listings:
 Softaculous: https://www.softaculous.com/apps/socialnetworking/pH7Builder

--- a/static/PFBC/css/tag.css
+++ b/static/PFBC/css/tag.css
@@ -1,0 +1,120 @@
+/* PFBC tag input. Shared by every theme; uses the theme's existing colour tokens. */
+.pfbc-tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    max-width: 100%;
+    min-height: 48px;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    border: 1px solid var(--ph7-border, #e4e4ec);
+    border-radius: var(--ph7-radius-sm, 8px);
+    background: var(--ph7-bg, #fff);
+    color: var(--ph7-text, #1c1c26);
+}
+
+.pfbc-tags:focus-within {
+    border-color: var(--ph7-primary, #d6336c);
+    box-shadow: 0 0 0 3px var(--ph7-primary-soft, #fde8ef);
+}
+
+.pfbc-tags.pfbc-tags-invalid {
+    border-color: var(--ph7-error, #a12622);
+}
+
+.pfbc-tags.pfbc-tags-invalid:focus-within {
+    box-shadow: 0 0 0 3px var(--ph7-error-bg, #fff2f1);
+}
+
+.pfbc-tags-list {
+    display: contents;
+}
+
+.pfbc-tag {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    padding-left: 12px;
+    border-radius: var(--ph7-radius-pill, 999px);
+    background: var(--ph7-primary-soft, #fde8ef);
+    color: var(--ph7-text, #1c1c26);
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.pfbc-tag-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+/* Override the legacy form/input rules without changing ordinary PFBC textboxes. */
+form .pfbc-tags input.pfbc-tags-input[type=text],
+form .pfbc-tags input.pfbc-tags-input[type=text]:focus {
+    flex: 1 1 140px;
+    width: 140px !important;
+    min-width: 0;
+    min-height: 36px;
+    height: auto;
+    margin: 0;
+    padding: 4px 0;
+    border: 0 !important;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    outline: none;
+    color: inherit;
+    font-size: 16px;
+}
+
+form .pfbc-tag-remove {
+    flex: 0 0 36px;
+    min-width: 36px;
+    min-height: 36px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+form .pfbc-tag-remove:hover:not(:disabled),
+form .pfbc-tag-remove:focus-visible {
+    background: var(--ph7-border, #e4e4ec);
+    outline: 2px solid var(--ph7-primary, #d6336c);
+    outline-offset: -2px;
+}
+
+.pfbc-tags-help, .pfbc-tags-error {
+    display: block;
+    margin-top: 6px;
+    font-size: 13px;
+    font-style: normal;
+    color: var(--ph7-text-muted, #6b6b7a);
+}
+
+.pfbc-tags-error {
+    color: var(--ph7-error, #a12622);
+}
+
+.pfbc-tags-error:empty, .pfbc-tags-help:empty {
+    display: none;
+}
+
+.pfbc-tags-inactive {
+    background: var(--ph7-surface, #f7f7fa);
+    color: var(--ph7-text-muted, #6b6b7a);
+}
+
+.pfbc-tags-inactive .pfbc-tag {
+    padding: 8px 12px;
+}
+
+.pfbc-tags-inactive .pfbc-tag-remove {
+    display: none;
+}

--- a/static/PFBC/js/tag.js
+++ b/static/PFBC/js/tag.js
@@ -1,0 +1,204 @@
+/*
+ * Progressive enhancement for PFBC's comma-separated Tag element.
+ * Author: Pierre-Henry Soria <hello@ph7builder.com>
+ * License: MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+(function () {
+    'use strict';
+
+    // PFBC can include this asset once for each form on the page.
+    if (window.pH7TagField) {
+        return;
+    }
+
+    function splitTags(sValue) {
+        return sValue.split(',').map(function (sTag) {
+            return sTag.trim();
+        }).filter(function (sTag) {
+            return sTag !== '';
+        });
+    }
+
+    function init(oInput) {
+        if (!oInput || oInput.dataset.tagBound) {
+            return;
+        }
+        oInput.dataset.tagBound = 'true';
+
+        var oForm = oInput.form;
+        var bRequired = oInput.required;
+        var sPlaceholder = oInput.placeholder;
+        var iMax = oInput.maxLength;
+        var bComposing = false;
+        var aTags = splitTags(oInput.value);
+        var oField = document.createElement('div');
+        var oList = document.createElement('span');
+        var oValue = document.createElement('input');
+        var oError = document.createElement('small');
+        var oHelp = document.getElementById(oInput.id + '_tag_help');
+
+        oField.className = 'pfbc-tags';
+        oList.className = 'pfbc-tags-list';
+        oList.setAttribute('role', 'list');
+        oValue.type = 'hidden';
+        oValue.name = oInput.name;
+        if (oInput.hasAttribute('form')) {
+            oValue.setAttribute('form', oInput.getAttribute('form'));
+        }
+        oError.id = oInput.id + '_tag_error';
+        oError.className = 'pfbc-tags-error';
+        oError.setAttribute('aria-live', 'polite');
+        oInput.setAttribute('aria-describedby', (oInput.getAttribute('aria-describedby') || '') + ' ' + oError.id);
+        oInput.removeAttribute('name');
+        // The limit applies to the whole submitted list, not just the next tag.
+        oInput.removeAttribute('maxlength');
+        oInput.classList.add('pfbc-tags-input');
+        oInput.value = '';
+        oInput.parentNode.insertBefore(oField, oInput);
+        oField.append(oList, oInput, oValue);
+        oField.after(oError);
+
+        function pendingTags() {
+            var aValues = aTags.slice();
+            splitTags(oInput.value).forEach(function (sTag) {
+                if (aValues.indexOf(sTag) === -1) {
+                    aValues.push(sTag);
+                }
+            });
+            return aValues;
+        }
+
+        function syncValue() {
+            // Keep pending text too: both native submit and PFBC Ajax serialize this input.
+            oValue.value = pendingTags().join(',');
+            oValue.disabled = oInput.disabled;
+            oInput.required = bRequired && aTags.length === 0;
+            var sError = '';
+            if (!oInput.disabled && !oInput.readOnly) {
+                if (iMax >= 0 && Array.from(oValue.value).length > iMax) {
+                    sError = oInput.dataset.tagLimit;
+                } else if (bRequired && !oValue.value) {
+                    sError = oInput.dataset.tagRequired;
+                }
+            }
+            oInput.setCustomValidity(sError);
+            // Leave empty required fields quiet until the user attempts to submit.
+            oError.textContent = oValue.value ? sError : '';
+            oInput.setAttribute('aria-invalid', oError.textContent ? 'true' : 'false');
+            oField.classList.toggle('pfbc-tags-invalid', Boolean(oError.textContent));
+            return sError === '';
+        }
+
+        function renderTags() {
+            oList.textContent = '';
+            aTags.forEach(function (sTag, iIndex) {
+                var oTag = document.createElement('span');
+                var oLabel = document.createElement('span');
+                var oRemove = document.createElement('button');
+                oTag.className = 'pfbc-tag';
+                oTag.setAttribute('role', 'listitem');
+                oLabel.className = 'pfbc-tag-label';
+                oLabel.textContent = sTag;
+                oRemove.type = 'button';
+                oRemove.className = 'pfbc-tag-remove';
+                oRemove.textContent = '×';
+                oRemove.setAttribute('aria-label', oInput.dataset.tagRemove.replace('%0%', sTag));
+                oRemove.disabled = oInput.disabled || oInput.readOnly;
+                oRemove.addEventListener('click', function () {
+                    if (oInput.disabled || oInput.readOnly) {
+                        return;
+                    }
+                    aTags.splice(iIndex, 1);
+                    renderTags();
+                    syncValue();
+                    oInput.focus();
+                });
+                oTag.append(oLabel, oRemove);
+                oList.append(oTag);
+            });
+            var bInactive = oInput.disabled || oInput.readOnly;
+            oField.classList.toggle('pfbc-tags-inactive', bInactive);
+            oInput.placeholder = bInactive ? '' : sPlaceholder;
+            if (oHelp) {
+                oHelp.textContent = bInactive ? '' : oInput.dataset.tagHelp;
+            }
+        }
+
+        function commitTags() {
+            if (bComposing || oInput.disabled || oInput.readOnly || !syncValue()) {
+                return;
+            }
+            if (!oInput.value.trim()) {
+                return;
+            }
+            aTags = pendingTags();
+            oInput.value = '';
+            renderTags();
+            syncValue();
+        }
+
+        oInput.addEventListener('keydown', function (oEvent) {
+            if (bComposing || oEvent.isComposing || oEvent.keyCode === 229) {
+                return;
+            }
+            if (oEvent.key === 'Enter') {
+                oEvent.preventDefault();
+                commitTags();
+            } else if (oEvent.key === 'Backspace' && !oInput.value && oList.lastElementChild) {
+                // Focus the remove button first; never silently delete a tag.
+                oEvent.preventDefault();
+                oList.lastElementChild.querySelector('button').focus();
+            }
+        });
+        oInput.addEventListener('input', function () {
+            syncValue();
+            if (!bComposing && oInput.value.includes(',')) {
+                commitTags();
+            }
+        });
+        oInput.addEventListener('change', syncValue);
+        oInput.addEventListener('invalid', function () {
+            oError.textContent = oInput.validationMessage;
+            oInput.setAttribute('aria-invalid', 'true');
+            oField.classList.add('pfbc-tags-invalid');
+        });
+        oInput.addEventListener('compositionstart', function () { bComposing = true; });
+        oInput.addEventListener('compositionend', function () {
+            bComposing = false;
+            syncValue();
+        });
+        oInput.addEventListener('blur', function (oEvent) {
+            // Keep the clicked remove button in the DOM until its click is handled.
+            if (!oField.contains(oEvent.relatedTarget)) {
+                commitTags();
+            }
+        });
+        oField.addEventListener('click', function (oEvent) {
+            if (oEvent.target === oField) {
+                oInput.focus();
+            }
+        });
+        new MutationObserver(function () {
+            renderTags();
+            syncValue();
+        }).observe(oInput, { attributes: true, attributeFilter: ['disabled', 'readonly'] });
+        if (oForm) {
+            oForm.addEventListener('reset', function (oEvent) {
+                // The reset event precedes restoration of the input's default value.
+                setTimeout(function () {
+                    if (!oEvent.defaultPrevented) {
+                        aTags = splitTags(oInput.defaultValue);
+                        oInput.value = '';
+                        bComposing = false;
+                        renderTags();
+                        syncValue();
+                    }
+                }, 0);
+            });
+        }
+        renderTags();
+        syncValue();
+    }
+
+    window.pH7TagField = { init: init };
+})();

--- a/templates/themes/base/tpl/layout.tpl
+++ b/templates/themes/base/tpl/layout.tpl
@@ -170,7 +170,7 @@
           {{ $design->littleSocialMediaWidgets() }}
 
           <p>
-            &copy; <ph:date value="Y" /> <strong>{site_name}</strong>  {{ $design->link() }}
+            {{ $design->link(true, true, true) }}
           </p>
         </div>
         {{ $design->langList() }}
@@ -188,12 +188,6 @@
     </footer>
 
     <div class="clear"></div>
-    <div class="right vs_marg">
-      {* Required for the GeoLite2 free version. Not needed if you purchase their full paid version *}
-      <small class="small">
-        {lang}We use GeoLite2 from <a href="https://www.maxmind.com" rel="nofollow" class="gray">MaxMind</a>{/lang}
-      </small>
-    </div>
     <!-- End Footer -->
 
     <!-- Begin Footer JavaScript -->

--- a/templates/themes/premium/tpl/layout.tpl
+++ b/templates/themes/premium/tpl/layout.tpl
@@ -170,7 +170,7 @@
           {{ $design->littleSocialMediaWidgets() }}
 
           <p>
-            &copy; <ph:date value="Y" /> <strong>{site_name}</strong>  {{ $design->link() }}
+            {{ $design->link(true, true, true) }}
           </p>
         </div>
         {{ $design->langList() }}
@@ -188,12 +188,6 @@
     </footer>
 
     <div class="clear"></div>
-    <div class="right vs_marg">
-      {* Required for the GeoLite2 free version. Not needed if you purchase their full paid version *}
-      <small class="small">
-        {lang}We use GeoLite2 from <a href="https://www.maxmind.com" rel="nofollow" class="gray">MaxMind</a>{/lang}
-      </small>
-    </div>
     <!-- End Footer -->
 
     <!-- Begin Footer JavaScript -->


### PR DESCRIPTION
Prepare v19.2.0 for 18.x: refresh 19 locked dependencies, add PFBC tag chips, simplify footer branding, and align runtime/installer versions and upgrade guides.

The final browser check caught a strict-MySQL blog-edit error. Fixed the timestamp update to use the numeric blog ID, with regression coverage and a successful save/reload check.

Verified: 926 tests / 2,875 assertions, PHPStan, 22 passing CI checks, clean root/installer dependency audits, and 73 PFBC interaction checks. A fresh production ZIP completed MySQL 8.4 strict-mode installation, cleanup, signup, member/admin login, remember-me and CSRF checks. Mobile tag rendering and real article tag persistence also passed.

PHP 8.2+, schema 1.6.6 and bundled Bootstrap/jQuery versions remain unchanged. Review the documented optional MaxMind extension requirement and custom Twilio integration changes before upgrading.

GeoLite2 data remains the documented December 2019 snapshot; updating its reader does not refresh the data. A current DB-IP download was evaluated separately, but is not bundled because it changes postal-code coverage and attribution requirements. Provider delivery/payments remain deployment checks.

Published in [v19.2.0](https://github.com/pH7Software/pH7-Social-Dating-CMS/releases/tag/v19.2.0), including #1255. The final ZIP passed fresh-install checks; its public download matches the tested archive and SHA-256 checksum.

Best,
[Pierre-Henry](https://github.com/pH-7)
