### PR TITLE
Preserve article IDs without category links

### DIFF
--- a/_protected/app/system/modules/blog/models/BlogModel.php
+++ b/_protected/app/system/modules/blog/models/BlogModel.php
@@ -77,7 +77,7 @@ class BlogModel extends BlogCoreModel
 
         if (!$oPost = $this->cache->get()) {
             $rStmt = Db::getInstance()->prepare(
-                'SELECT * FROM' . Db::prefix(DbTableName::BLOG) . 'AS b LEFT JOIN' .
+                'SELECT b.*, c.categoryId FROM' . Db::prefix(DbTableName::BLOG) . 'AS b LEFT JOIN' .
                 Db::prefix(DbTableName::BLOG_CATEGORY) . 'AS c ON b.blogId = c.blogId WHERE b.postId = :postId LIMIT 1'
             );
             $rStmt->bindValue(':postId', $sPostId, PDO::PARAM_STR);

--- a/_protected/app/system/modules/note/models/NoteModel.php
+++ b/_protected/app/system/modules/note/models/NoteModel.php
@@ -112,7 +112,7 @@ class NoteModel extends NoteCoreModel
 
             $sSqlApproved = $bIsApproved ? ' AND approved = :approved' : '';
 
-            $sSqlQuery = 'SELECT n.*, c.*, m.username, m.firstName, m.sex FROM' . Db::prefix(DbTableName::NOTE) .
+            $sSqlQuery = 'SELECT n.*, c.categoryId, m.username, m.firstName, m.sex FROM' . Db::prefix(DbTableName::NOTE) .
                 'AS n LEFT JOIN' . Db::prefix(DbTableName::NOTE_CATEGORY) . 'AS c ON n.noteId = c.noteId INNER JOIN' .
                 Db::prefix(DbTableName::MEMBER) . 'AS m ON n.profileId = m.profileId WHERE n.profileId = :profileId AND n.postId = :postId' .
                 $sSqlApproved . ' LIMIT 1';

--- a/_tests/Unit/Root/ArticleIdentityTest.php
+++ b/_tests/Unit/Root/ArticleIdentityTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @author           Pierre-Henry Soria <hello@ph7builder.com>
+ * @copyright        (c) 2026, Pierre-Henry Soria. All Rights Reserved.
+ * @license          MIT License; See LICENSE.md and COPYRIGHT.md in the root directory.
+ */
+
+declare(strict_types=1);
+
+namespace PH7\Test\Unit\Root;
+
+use PH7\BlogModel;
+use PH7\Framework\Config\Config;
+use PH7\Framework\Mvc\Model\Engine\Db;
+use PH7\NoteModel;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class ArticleIdentityTest extends TestCase
+{
+    private \PDO $oDatabase;
+
+    protected function setUp(): void
+    {
+        Config::getInstance()->values['cache']['enable.general.cache'] = false;
+        $this->oDatabase = new \PDO('sqlite::memory:');
+        $this->oDatabase->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->oDatabase->exec('CREATE TABLE ph7_blogs (blogId INTEGER, postId TEXT, title TEXT)');
+        $this->oDatabase->exec('CREATE TABLE ph7_blogs_categories (categoryId INTEGER, blogId INTEGER)');
+        $this->oDatabase->exec('CREATE TABLE ph7_notes (noteId INTEGER, profileId INTEGER, postId TEXT, approved INTEGER)');
+        $this->oDatabase->exec('CREATE TABLE ph7_notes_categories (categoryId INTEGER, noteId INTEGER, profileId INTEGER)');
+        $this->oDatabase->exec('CREATE TABLE ph7_members (profileId INTEGER, username TEXT, firstName TEXT, sex TEXT)');
+        $this->oDatabase->exec("INSERT INTO ph7_blogs VALUES (3, 'sample-blog', 'Sample blog')");
+        $this->oDatabase->exec("INSERT INTO ph7_notes VALUES (5, 17, 'sample-note', 1)");
+        $this->oDatabase->exec("INSERT INTO ph7_members VALUES (17, 'member', 'Member', 'male')");
+
+        (new \ReflectionProperty(Db::class, 'oInstance'))->setValue(null, (new \ReflectionClass(Db::class))->newInstanceWithoutConstructor());
+        (new \ReflectionProperty(Db::class, 'oDb'))->setValue(null, $this->oDatabase);
+        (new \ReflectionProperty(Db::class, 'sPrefix'))->setValue(null, 'ph7_');
+
+        require_once PH7_PATH_SYS_MOD . 'blog/models/BlogModel.php';
+        require_once PH7_PATH_SYS_MOD . 'note/models/NoteModel.php';
+    }
+
+    #[DataProvider('categoryProvider')]
+    public function testBlogIdentityDoesNotDependOnCategoryLinks(bool $bHasCategory): void
+    {
+        if ($bHasCategory) {
+            $this->oDatabase->exec('INSERT INTO ph7_blogs_categories VALUES (2, 3)');
+        }
+
+        $oPost = (new BlogModel())->readPost('sample-blog');
+
+        self::assertIsObject($oPost);
+        self::assertSame(3, $oPost->blogId);
+        self::assertSame('Sample blog', $oPost->title);
+        self::assertSame($bHasCategory ? 2 : null, $oPost->categoryId);
+    }
+
+    #[DataProvider('categoryProvider')]
+    public function testNoteIdentityAndOwnerDoNotDependOnCategoryLinks(bool $bHasCategory): void
+    {
+        if ($bHasCategory) {
+            $this->oDatabase->exec('INSERT INTO ph7_notes_categories VALUES (2, 5, 17)');
+        }
+
+        $oModel = new NoteModel();
+        $oPost = $oModel->readPost('sample-note', 17);
+
+        self::assertIsObject($oPost);
+        self::assertSame(5, $oPost->noteId);
+        self::assertSame(17, $oPost->profileId);
+        self::assertSame('member', $oPost->username);
+        self::assertSame($bHasCategory ? 2 : null, $oPost->categoryId);
+        self::assertFalse($oModel->readPost('sample-note', 99));
+        self::assertFalse($oModel->readPost('sample-note', 17, 0));
+    }
+
+    public static function categoryProvider(): array
+    {
+        return [
+            'with category' => [true],
+            'without category' => [false]
+        ];
+    }
+}

--- a/docs/RELEASE_NOTES_19.2.0.md
+++ b/docs/RELEASE_NOTES_19.2.0.md
@@ -17,6 +17,8 @@ used by pH7Builder. It includes all login and navigation fixes from 19.1.0.
   now matches the database's 191-character limit for the complete tag list.
 - Fixes an internal error when saving blog edits on strict MySQL installations:
   the modification timestamp now uses the numeric row ID, not the URL slug.
+- Keeps blog and note IDs intact when an article has no category links, avoiding
+  broken article pages and preserving the note owner's ID.
 - Simplifies the footer to a versioned pH7Builder link to GitHub, with MaxMind
   attribution retained on the Legal Notice page and in copyright notices.
 - Adds offline checks for HTTP promises, S3 signing, SMS request construction,


### PR DESCRIPTION
Keep blog/note IDs and note ownership from the article row when category links are missing. This prevents an existing article-page error caused by nullable joined IDs.

Four regression cases cover articles with/without categories, owner filtering and approval. Verified: 930 tests / 2,897 assertions, PHPStan, and the previously failing page on MySQL 8.4 strict mode.

No schema change. Clear caches when upgrading, as documented.

Best,
[Pierre-Henry](https://github.com/pH-7)
